### PR TITLE
Remove verbose from early stopping

### DIFF
--- a/scvi/train/_trainer.py
+++ b/scvi/train/_trainer.py
@@ -113,7 +113,6 @@ class Trainer(pl.Trainer):
         )
         if early_stopping:
             early_stopping_callback = LoudEarlyStopping(
-                verbose=True,
                 monitor=early_stopping_monitor,
                 min_delta=early_stopping_min_delta,
                 patience=early_stopping_patience,


### PR DESCRIPTION
In #1208, the flag `verbose=True` was accidentally changed to True, which causes output like so:

![image](https://user-images.githubusercontent.com/14086852/136856359-20e92103-dc27-4113-9d2c-f6c7d29e89b3.png)

This should be a hotfix on v14 to prevent unnecessary output for users.

Tested on colab and print is no longer output.