### PR TITLE
scvi-tools NB parameterization for numpyro

### DIFF
--- a/docs/api/developer.rst
+++ b/docs/api/developer.rst
@@ -69,6 +69,7 @@ Parameterizable probability distributions.
    distributions.NegativeBinomial
    distributions.NegativeBinomialMixture
    distributions.ZeroInflatedNegativeBinomial
+   distributions.JaxNegativeBinomialMeanDisp
 
 
 Model (Base)

--- a/docs/release_notes/v0.15.1.rst
+++ b/docs/release_notes/v0.15.1.rst
@@ -5,6 +5,7 @@ New in 0.15.1 (2022-MM-DD)
 Changes
 ~~~~~~~
 - Remove ``labels_key`` from :class:`~scvi.model.MULTIVI` as it is not used in the model (`#1393`_).
+- Use scvi-tools mean/inv_disp parameterization of negative binomial for :class:`~scvi.model.JaxSCVI` likelihood (`#1386`_).
 
 Contributors
 ~~~~~~~~~~~~
@@ -17,4 +18,5 @@ Contributors
 .. _`@watiss`: https://github.com/watiss
 
 .. _`#1393`: https://github.com/YosefLab/scvi-tools/pull/1393
+.. _`#1386`: https://github.com/YosefLab/scvi-tools/pull/1386
 

--- a/scvi/distributions/__init__.py
+++ b/scvi/distributions/__init__.py
@@ -1,4 +1,5 @@
 from ._negative_binomial import (
+    JaxNegativeBinomialMeanDisp,
     NegativeBinomial,
     NegativeBinomialMixture,
     ZeroInflatedNegativeBinomial,
@@ -8,4 +9,5 @@ __all__ = [
     "NegativeBinomial",
     "NegativeBinomialMixture",
     "ZeroInflatedNegativeBinomial",
+    "JaxNegativeBinomialMeanDisp",
 ]

--- a/scvi/distributions/_negative_binomial.py
+++ b/scvi/distributions/_negative_binomial.py
@@ -1,8 +1,13 @@
 import warnings
 from typing import Optional, Tuple, Union
 
+import jax
+import jax.numpy as jnp
+import numpyro.distributions as dist
 import torch
 import torch.nn.functional as F
+from numpyro.distributions import constraints as numpyro_constraints
+from numpyro.distributions.util import promote_shapes, validate_sample
 from torch.distributions import Distribution, Gamma, Poisson, constraints
 from torch.distributions.utils import (
     broadcast_all,
@@ -64,7 +69,14 @@ def log_zinb_positive(
     return res
 
 
-def log_nb_positive(x: torch.Tensor, mu: torch.Tensor, theta: torch.Tensor, eps=1e-8):
+def log_nb_positive(
+    x: Union[torch.Tensor, jnp.ndarray],
+    mu: Union[torch.Tensor, jnp.ndarray],
+    theta: Union[torch.Tensor, jnp.ndarray],
+    eps: float = 1e-8,
+    log_fn: callable = torch.log,
+    lgamma_fn: callable = torch.lgamma,
+):
     """
     Log likelihood (scalar) of a minibatch according to a nb model.
 
@@ -78,25 +90,16 @@ def log_nb_positive(x: torch.Tensor, mu: torch.Tensor, theta: torch.Tensor, eps=
         inverse dispersion parameter (has to be positive support) (shape: minibatch x vars)
     eps
         numerical stability constant
-
-    Notes
-    -----
-    We parametrize the bernoulli using the logits, hence the softplus functions appearing.
-
     """
-    if theta.ndimension() == 1:
-        theta = theta.view(
-            1, theta.size(0)
-        )  # In this case, we reshape theta for broadcasting
-
-    log_theta_mu_eps = torch.log(theta + mu + eps)
-
+    log = log_fn
+    lgamma = lgamma_fn
+    log_theta_mu_eps = log(theta + mu + eps)
     res = (
-        theta * (torch.log(theta + eps) - log_theta_mu_eps)
-        + x * (torch.log(mu + eps) - log_theta_mu_eps)
-        + torch.lgamma(x + theta)
-        - torch.lgamma(theta)
-        - torch.lgamma(x + 1)
+        theta * (log(theta + eps) - log_theta_mu_eps)
+        + x * (log(mu + eps) - log_theta_mu_eps)
+        + lgamma(x + theta)
+        - lgamma(theta)
+        - lgamma(x + 1)
     )
 
     return res
@@ -540,4 +543,44 @@ class NegativeBinomialMixture(Distribution):
             self.theta2,
             self.mixture_logits,
             eps=1e-08,
+        )
+
+
+class JaxNegativeBinomialMeanDisp(dist.NegativeBinomial2):
+    """Negative binomial parameterized by mean and inverse dispersion."""
+
+    arg_constraints = {
+        "mean": numpyro_constraints.positive,
+        "inverse_dispersion": numpyro_constraints.positive,
+    }
+    support = numpyro_constraints.nonnegative_integer
+
+    def __init__(
+        self,
+        mean: jnp.ndarray,
+        inverse_dispersion: jnp.ndarray,
+        validate_args: Optional[bool] = None,
+        eps: float = 1e-8,
+    ):
+        self._inverse_dispersion, self._mean = promote_shapes(inverse_dispersion, mean)
+        self._eps = eps
+        super().__init__(mean, inverse_dispersion, validate_args=validate_args)
+
+    @property
+    def mean(self):
+        return self._mean
+
+    @validate_sample
+    def log_prob(self, value):
+        # theta is inverse_dispersion
+        theta = self._inverse_dispersion
+        mu = self._mean
+        eps = self._eps
+        return log_nb_positive(
+            value,
+            mu,
+            theta,
+            eps=eps,
+            log_fn=jnp.log,
+            lgamma_fn=jax.scipy.special.gammaln,
         )

--- a/scvi/module/_jaxvae.py
+++ b/scvi/module/_jaxvae.py
@@ -28,10 +28,9 @@ class JaxNegativeBinomialMeanDisp(dist.NegativeBinomial2):
         validate_args: Optional[bool] = None,
         eps: float = 1e-8,
     ):
-        rate = inverse_dispersion / mean
         self._inverse_dispersion, self._mean = promote_shapes(inverse_dispersion, mean)
         self._eps = eps
-        super().__init__(inverse_dispersion, rate, validate_args=validate_args)
+        super().__init__(mean, inverse_dispersion, validate_args=validate_args)
 
     @property
     def mean(self):

--- a/scvi/module/_jaxvae.py
+++ b/scvi/module/_jaxvae.py
@@ -6,55 +6,9 @@ import numpy as np
 import numpyro.distributions as dist
 from flax import linen as nn
 from flax.linen.initializers import variance_scaling
-from numpyro.distributions import constraints
-from numpyro.distributions.util import promote_shapes, validate_sample
 
 from scvi import REGISTRY_KEYS
-
-
-class JaxNegativeBinomialMeanDisp(dist.NegativeBinomial2):
-    """Negative binomial parameterized by mean and inverse dispersion."""
-
-    arg_constraints = {
-        "mean": constraints.positive,
-        "inverse_dispersion": constraints.positive,
-    }
-    support = constraints.nonnegative_integer
-
-    def __init__(
-        self,
-        mean: jnp.ndarray,
-        inverse_dispersion: jnp.ndarray,
-        validate_args: Optional[bool] = None,
-        eps: float = 1e-8,
-    ):
-        self._inverse_dispersion, self._mean = promote_shapes(inverse_dispersion, mean)
-        self._eps = eps
-        super().__init__(mean, inverse_dispersion, validate_args=validate_args)
-
-    @property
-    def mean(self):
-        return self._mean
-
-    @validate_sample
-    def log_prob(self, value):
-        # theta is inverse_dispersion
-        theta = self._inverse_dispersion
-        mu = self._mean
-        eps = self._eps
-        lgamma = jax.scipy.special.gammaln
-
-        log_theta_mu_eps = jnp.log(theta + mu + eps)
-
-        res = (
-            theta * (jnp.log(theta + eps) - log_theta_mu_eps)
-            + value * (jnp.log(mu + eps) - log_theta_mu_eps)
-            + lgamma(value + theta)
-            - lgamma(theta)
-            - lgamma(value + 1)
-        )
-
-        return res
+from scvi.distributions import JaxNegativeBinomialMeanDisp as NegativeBinomial
 
 
 class Dense(nn.Dense):
@@ -135,7 +89,7 @@ class FlaxDecoder(nn.Module):
 class VAEOutput(NamedTuple):
     rec_loss: jnp.ndarray
     kl: jnp.ndarray
-    px: JaxNegativeBinomialMeanDisp
+    px: NegativeBinomial
     qz: dist.Normal
 
 
@@ -181,7 +135,7 @@ class JaxVAE(nn.Module):
 
         if self.gene_likelihood == "nb":
             disp_ = jnp.exp(disp)
-            px = JaxNegativeBinomialMeanDisp(mean=mu, inverse_dispersion=disp_)
+            px = NegativeBinomial(mean=mu, inverse_dispersion=disp_)
         else:
             px = dist.Poisson(mu)
 


### PR DESCRIPTION
- Adds `scvi.distributions.JaxNegativeBinomialMeanDisp`

Here I mirror the log prob of our pytorch NB dist.

This restores the performance on scIB metrics for JaxSCVI:

PyTorch Metrics:

<img width="415" alt="Screen Shot 2022-03-01 at 8 43 52 AM" src="https://user-images.githubusercontent.com/10859440/156211174-294dd68b-d9cd-42be-89bc-d47ad669c0df.png">

Jax Metrics:

<img width="603" alt="Screen Shot 2022-03-01 at 8 44 25 AM" src="https://user-images.githubusercontent.com/10859440/156211265-13e8ea18-22e3-4e24-bb97-f3116f60e334.png">


Without this dist, integration metrics were worse.

The remaining differences are either stochasticity or the way our Dense layer is initialized.

