### PR TITLE
autoclass template, document shared attrs in `BaseModel`

### DIFF
--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -1,3 +1,6 @@
+.. role:: hidden
+    :class: hidden-section
+
 {{ fullname | escape | underline}}
 
 .. currentmodule:: {{ module }}
@@ -34,6 +37,8 @@
    {% if attributes %}
 
    {% for item in attributes %}
+   :hidden: {{ item }}
+   ~~~~~~~~~~~~~~~~~~~~
    .. autoattribute:: {{ item }}
    {%- endfor %}
 
@@ -45,6 +50,8 @@
 
    {% for item in methods %}
    {%- if item != '__init__' %}
+   :hidden: {{ item }}
+   ~~~~~~~~~~~~~~~~~~~~
    .. automethod:: {{ item }}
    {%- endif -%}
    {%- endfor %}

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -35,8 +35,9 @@
 
    {% for item in attributes %}
 {{ item }}
-~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+   .. currentmodule:: {{ module }}
    .. autoattribute:: ~{{ fullname }}.{{ item }}
    {%- endfor %}
 
@@ -49,8 +50,9 @@
    {% for item in methods %}
    {%- if item != '__init__' %}
 {{ item }}
-~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+   .. currentmodule:: {{ module }}
    .. automethod:: ~{{ fullname }}.{{ item }}
    {%- endif -%}
    {%- endfor %}

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -37,7 +37,7 @@
    {% if attributes %}
 
    {% for item in attributes %}
-   :hidden: {{ item }}
+   {{ item }}
    ~~~~~~~~~~~~~~~~~~~~
    .. autoattribute:: {{ item }}
    {%- endfor %}
@@ -50,7 +50,7 @@
 
    {% for item in methods %}
    {%- if item != '__init__' %}
-   :hidden: {{ item }}
+   {{ item }}
    ~~~~~~~~~~~~~~~~~~~~
    .. automethod:: {{ item }}
    {%- endif -%}

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -8,10 +8,10 @@
 
    {% block attributes %}
    {% if attributes %}
-   .. rubric:: Attributes
+   Attributes
+   ^^^^^^^^^^
 
    .. autosummary::
-      :toctree: .
    {% for item in attributes %}
       ~{{ fullname }}.{{ item }}
    {%- endfor %}
@@ -20,10 +20,10 @@
 
    {% block methods %}
    {% if methods %}
-   .. rubric:: Methods
+   Methods
+   ^^^^^^^
 
    .. autosummary::
-      :toctree: .
    {% for item in methods %}
       {%- if item != '__init__' %}
         ~{{ fullname }}.{{ item }}

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -44,7 +44,6 @@
    {% if methods %}
 
    {% for item in methods %}
-   .. automethod:: {{ item }}
       {%- if item != '__init__' %}
         .. automethod:: {{ item }}
       {%- endif -%}

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -37,7 +37,7 @@
 {{ item }}
 ~~~~~~~~~~
 
-   .. autoattribute:: {{ item }}
+   .. autoattribute:: ~{{ fullname }}.{{ item }}
    {%- endfor %}
 
    {% endif %}
@@ -51,7 +51,7 @@
 {{ item }}
 ~~~~~~~~~~
 
-   .. automethod:: {{ item }}
+   .. automethod:: ~{{ fullname }}.{{ item }}
    {%- endif -%}
    {%- endfor %}
 

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -8,8 +8,8 @@
 
 {% block attributes %}
 {% if attributes %}
-Attributes
-~~~~~~~~~~
+Attributes table
+~~~~~~~~~~~~~~~~~~
 
 .. autosummary::
 {% for item in attributes %}
@@ -20,8 +20,8 @@ Attributes
 
 {% block methods %}
 {% if methods %}
-Methods
-~~~~~~~~
+Methods table
+~~~~~~~~~~~~~
 
 .. autosummary::
 {% for item in methods %}
@@ -34,10 +34,12 @@ Methods
 
 {% block attributes_documentation %}
 {% if attributes %}
+Attributes
+~~~~~~~~~~~
 
 {% for item in attributes %}
 {{ item }}
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoattribute:: {{ [objname, item] | join(".") }}
 {%- endfor %}
@@ -47,11 +49,13 @@ Methods
 
 {% block methods_documentation %}
 {% if methods %}
+Methods
+~~~~~~~
 
 {% for item in methods %}
 {%- if item != '__init__' %}
 {{ item }}
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automethod:: {{ [objname, item] | join(".") }}
 {%- endif -%}

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -44,9 +44,9 @@
    {% if methods %}
 
    {% for item in methods %}
-      {%- if item != '__init__' %}
-        .. automethod:: {{ item }}
-      {%- endif -%}
+   {%- if item != '__init__' %}
+   .. automethod:: {{ item }}
+   {%- endif -%}
    {%- endfor %}
 
    {% endif %}

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -34,6 +34,9 @@
    {% if attributes %}
 
    {% for item in attributes %}
+{{ item }}
+~~~~~~~~~~
+
    .. autoattribute:: {{ item }}
    {%- endfor %}
 
@@ -45,6 +48,9 @@
 
    {% for item in methods %}
    {%- if item != '__init__' %}
+{{ item }}
+~~~~~~~~~~
+
    .. automethod:: {{ item }}
    {%- endif -%}
    {%- endfor %}

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -35,10 +35,9 @@
 
    {% for item in attributes %}
 {{ item }}
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~
 
-   .. currentmodule:: {{ module }}
-   .. autoattribute:: ~{{ fullname }}.{{ item }}
+   .. autoattribute:: {{ [objname, item] | join(".") }}
    {%- endfor %}
 
    {% endif %}
@@ -50,10 +49,9 @@
    {% for item in methods %}
    {%- if item != '__init__' %}
 {{ item }}
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~
 
-   .. currentmodule:: {{ module }}
-   .. automethod:: ~{{ fullname }}.{{ item }}
+   .. automethod:: {{ [objname, item] | join(".") }}
    {%- endif -%}
    {%- endfor %}
 

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -37,8 +37,8 @@
    {% if attributes %}
 
    {% for item in attributes %}
-   {{ item }}
-   ~~~~~~~~~~~~~~~~~~~~
+   {{ item | escape | underline}}
+
    .. autoattribute:: {{ item }}
    {%- endfor %}
 
@@ -50,8 +50,8 @@
 
    {% for item in methods %}
    {%- if item != '__init__' %}
-   {{ item }}
-   ~~~~~~~~~~~~~~~~~~~~
+   {{ item | escape | underline}}
+
    .. automethod:: {{ item }}
    {%- endif -%}
    {%- endfor %}

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -6,54 +6,56 @@
 
 .. autoclass:: {{ objname }}
 
-   {% block attributes %}
-   {% if attributes %}
-   .. rubric:: Attributes
-
-   .. autosummary::
-   {% for item in attributes %}
-      ~{{ fullname }}.{{ item }}
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
-
-   {% block methods %}
-   {% if methods %}
-   .. rubric:: Methods
-
-   .. autosummary::
-   {% for item in methods %}
-      {%- if item != '__init__' %}
-        ~{{ fullname }}.{{ item }}
-      {%- endif -%}
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
-
-   {% block attributes_documentation %}
-   {% if attributes %}
-
-   {% for item in attributes %}
-{{ item }}
+{% block attributes %}
+{% if attributes %}
+Attributes
 ~~~~~~~~~~
 
-   .. autoattribute:: {{ [objname, item] | join(".") }}
-   {%- endfor %}
+.. autosummary::
+{% for item in attributes %}
+    ~{{ fullname }}.{{ item }}
+{%- endfor %}
+{% endif %}
+{% endblock %}
 
-   {% endif %}
-   {% endblock %}
+{% block methods %}
+{% if methods %}
+Methods
+~~~~~~~~
 
-   {% block methods_documentation %}
-   {% if methods %}
+.. autosummary::
+{% for item in methods %}
+    {%- if item != '__init__' %}
+    ~{{ fullname }}.{{ item }}
+    {%- endif -%}
+{%- endfor %}
+{% endif %}
+{% endblock %}
 
-   {% for item in methods %}
-   {%- if item != '__init__' %}
+{% block attributes_documentation %}
+{% if attributes %}
+
+{% for item in attributes %}
 {{ item }}
-~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   .. automethod:: {{ [objname, item] | join(".") }}
-   {%- endif -%}
-   {%- endfor %}
+.. autoattribute:: {{ [objname, item] | join(".") }}
+{%- endfor %}
 
-   {% endif %}
-   {% endblock %}
+{% endif %}
+{% endblock %}
+
+{% block methods_documentation %}
+{% if methods %}
+
+{% for item in methods %}
+{%- if item != '__init__' %}
+{{ item }}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automethod:: {{ [objname, item] | join(".") }}
+{%- endif -%}
+{%- endfor %}
+
+{% endif %}
+{% endblock %}

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -8,8 +8,7 @@
 
    {% block attributes %}
    {% if attributes %}
-   Attributes
-   ^^^^^^^^^^
+   .. rubric:: Attributes
 
    .. autosummary::
    {% for item in attributes %}
@@ -20,8 +19,7 @@
 
    {% block methods %}
    {% if methods %}
-   Methods
-   ^^^^^^^
+   .. rubric:: Methods
 
    .. autosummary::
    {% for item in methods %}
@@ -29,5 +27,28 @@
         ~{{ fullname }}.{{ item }}
       {%- endif -%}
    {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes_documentation %}
+   {% if attributes %}
+
+   {% for item in attributes %}
+   .. autoattribute:: {{ item }}
+   {%- endfor %}
+
+   {% endif %}
+   {% endblock %}
+
+   {% block methods_documentation %}
+   {% if methods %}
+
+   {% for item in methods %}
+   .. automethod:: {{ item }}
+      {%- if item != '__init__' %}
+        .. automethod:: {{ item }}
+      {%- endif -%}
+   {%- endfor %}
+
    {% endif %}
    {% endblock %}

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -1,6 +1,3 @@
-.. role:: hidden
-    :class: hidden-section
-
 {{ fullname | escape | underline}}
 
 .. currentmodule:: {{ module }}
@@ -37,8 +34,6 @@
    {% if attributes %}
 
    {% for item in attributes %}
-   {{ item | escape | underline}}
-
    .. autoattribute:: {{ item }}
    {%- endfor %}
 
@@ -50,8 +45,6 @@
 
    {% for item in methods %}
    {%- if item != '__init__' %}
-   {{ item | escape | underline}}
-
    .. automethod:: {{ item }}
    {%- endif -%}
    {%- endfor %}

--- a/docs/_templates/class_no_inherited.rst
+++ b/docs/_templates/class_no_inherited.rst
@@ -9,10 +9,10 @@
 
    {% block attributes %}
    {% if attributes %}
-   .. rubric:: Attributes
+   Attributes
+   ^^^^^^^^^^
 
    .. autosummary::
-      :toctree: .
     {% for item in attributes %}
         {%- if item not in inherited_members%}
             ~{{ fullname }}.{{ item }}
@@ -24,10 +24,10 @@
 
    {% block methods %}
    {% if methods %}
-   .. rubric:: Methods
+   Methods
+   ^^^^^^^
 
    .. autosummary::
-      :toctree: .
    {% for item in methods %}
       {%- if item != '__init__' and item not in inherited_members%}
         ~{{ fullname }}.{{ item }}

--- a/docs/_templates/class_no_inherited.rst
+++ b/docs/_templates/class_no_inherited.rst
@@ -49,7 +49,6 @@
    {% if methods %}
 
    {% for item in methods %}
-   .. automethod:: {{ item }}
       {%- if item != '__init__' and item not in inherited_members%}
         .. automethod:: {{ item }}
       {%- endif -%}

--- a/docs/_templates/class_no_inherited.rst
+++ b/docs/_templates/class_no_inherited.rst
@@ -9,8 +9,7 @@
 
    {% block attributes %}
    {% if attributes %}
-   Attributes
-   ^^^^^^^^^^
+   .. rubric:: Attributes
 
    .. autosummary::
     {% for item in attributes %}
@@ -24,8 +23,7 @@
 
    {% block methods %}
    {% if methods %}
-   Methods
-   ^^^^^^^
+   .. rubric:: Methods
 
    .. autosummary::
    {% for item in methods %}
@@ -34,5 +32,28 @@
       {%- endif -%}
 
    {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes_documentation %}
+   {% if attributes %}
+
+   {% for item in attributes %}
+   .. autoattribute:: {{ item }}
+   {%- endfor %}
+
+   {% endif %}
+   {% endblock %}
+
+   {% block methods_documentation %}
+   {% if methods %}
+
+   {% for item in methods %}
+   .. automethod:: {{ item }}
+      {%- if item != '__init__' and item not in inherited_members%}
+        .. automethod:: {{ item }}
+      {%- endif -%}
+   {%- endfor %}
+
    {% endif %}
    {% endblock %}

--- a/docs/_templates/class_no_inherited.rst
+++ b/docs/_templates/class_no_inherited.rst
@@ -1,3 +1,6 @@
+.. role:: hidden
+    :class: hidden-section
+
 {{ fullname | escape | underline}}
 
 .. currentmodule:: {{ module }}
@@ -39,6 +42,8 @@
    {% if attributes %}
 
    {% for item in attributes %}
+   :hidden: {{ item }}
+   ~~~~~~~~~~~~~~~~~~~~
    .. autoattribute:: {{ item }}
    {%- endfor %}
 
@@ -50,6 +55,8 @@
 
    {% for item in methods %}
    {%- if item != '__init__' and item not in inherited_members%}
+   :hidden: {{ item }}
+   ~~~~~~~~~~~~~~~~~~~~
    .. automethod:: {{ item }}
    {%- endif -%}
    {%- endfor %}

--- a/docs/_templates/class_no_inherited.rst
+++ b/docs/_templates/class_no_inherited.rst
@@ -9,8 +9,8 @@
 
 {% block attributes %}
 {% if attributes %}
-Attributes
-~~~~~~~~~~
+Attributes table
+~~~~~~~~~~~~~~~~
 
 .. autosummary::
 {% for item in attributes %}
@@ -24,8 +24,8 @@ Attributes
 
 {% block methods %}
 {% if methods %}
-Methods
-~~~~~~~~
+Methods table
+~~~~~~~~~~~~~~
 
 .. autosummary::
 {% for item in methods %}
@@ -39,10 +39,12 @@ Methods
 
 {% block attributes_documentation %}
 {% if attributes %}
+Attributes
+~~~~~~~~~~
 
 {% for item in attributes %}
 {{ item }}
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoattribute:: {{ [objname, item] | join(".") }}
 {%- endfor %}
@@ -52,12 +54,13 @@ Methods
 
 {% block methods_documentation %}
 {% if methods %}
+Methods
+~~~~~~~
 
 {% for item in methods %}
 {%- if item != '__init__' and item not in inherited_members%}
 {{ item }}
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automethod:: {{ [objname, item] | join(".") }}
 {%- endif -%}
 {%- endfor %}

--- a/docs/_templates/class_no_inherited.rst
+++ b/docs/_templates/class_no_inherited.rst
@@ -7,58 +7,60 @@
 .. autoclass:: {{ objname }}
    :show-inheritance:
 
-   {% block attributes %}
-   {% if attributes %}
-   .. rubric:: Attributes
+{% block attributes %}
+{% if attributes %}
+Attributes
+~~~~~~~~~~
 
-   .. autosummary::
-    {% for item in attributes %}
-        {%- if item not in inherited_members%}
-            ~{{ fullname }}.{{ item }}
-        {%- endif -%}
-    {%- endfor %}
-    {% endif %}
-    {% endblock %}
-
-
-   {% block methods %}
-   {% if methods %}
-   .. rubric:: Methods
-
-   .. autosummary::
-   {% for item in methods %}
-      {%- if item != '__init__' and item not in inherited_members%}
+.. autosummary::
+{% for item in attributes %}
+    {%- if item not in inherited_members%}
         ~{{ fullname }}.{{ item }}
-      {%- endif -%}
+    {%- endif -%}
+{%- endfor %}
+{% endif %}
+{% endblock %}
 
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
 
-   {% block attributes_documentation %}
-   {% if attributes %}
+{% block methods %}
+{% if methods %}
+Methods
+~~~~~~~~
 
-   {% for item in attributes %}
+.. autosummary::
+{% for item in methods %}
+    {%- if item != '__init__' and item not in inherited_members%}
+    ~{{ fullname }}.{{ item }}
+    {%- endif -%}
+
+{%- endfor %}
+{% endif %}
+{% endblock %}
+
+{% block attributes_documentation %}
+{% if attributes %}
+
+{% for item in attributes %}
 {{ item }}
-~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   .. autoattribute:: {{ [objname, item] | join(".") }}
-   {%- endfor %}
+.. autoattribute:: {{ [objname, item] | join(".") }}
+{%- endfor %}
 
-   {% endif %}
-   {% endblock %}
+{% endif %}
+{% endblock %}
 
-   {% block methods_documentation %}
-   {% if methods %}
+{% block methods_documentation %}
+{% if methods %}
 
-   {% for item in methods %}
-   {%- if item != '__init__' and item not in inherited_members%}
+{% for item in methods %}
+{%- if item != '__init__' and item not in inherited_members%}
 {{ item }}
-~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   .. automethod:: {{ [objname, item] | join(".") }}
-   {%- endif -%}
-   {%- endfor %}
+.. automethod:: {{ [objname, item] | join(".") }}
+{%- endif -%}
+{%- endfor %}
 
-   {% endif %}
-   {% endblock %}
+{% endif %}
+{% endblock %}

--- a/docs/_templates/class_no_inherited.rst
+++ b/docs/_templates/class_no_inherited.rst
@@ -39,7 +39,10 @@
    {% if attributes %}
 
    {% for item in attributes %}
-   .. autoattribute:: {{ item }}
+{{ item }}
+~~~~~~~~~~
+
+   .. autoattribute:: {{ [objname, item] | join(".") }}
    {%- endfor %}
 
    {% endif %}
@@ -50,7 +53,10 @@
 
    {% for item in methods %}
    {%- if item != '__init__' and item not in inherited_members%}
-   .. automethod:: {{ item }}
+{{ item }}
+~~~~~~~~~~
+
+   .. automethod:: {{ [objname, item] | join(".") }}
    {%- endif -%}
    {%- endfor %}
 

--- a/docs/_templates/class_no_inherited.rst
+++ b/docs/_templates/class_no_inherited.rst
@@ -49,9 +49,9 @@
    {% if methods %}
 
    {% for item in methods %}
-      {%- if item != '__init__' and item not in inherited_members%}
-        .. automethod:: {{ item }}
-      {%- endif -%}
+   {%- if item != '__init__' and item not in inherited_members%}
+   .. automethod:: {{ item }}
+   {%- endif -%}
    {%- endfor %}
 
    {% endif %}

--- a/docs/_templates/class_no_inherited.rst
+++ b/docs/_templates/class_no_inherited.rst
@@ -42,7 +42,7 @@
    {% if attributes %}
 
    {% for item in attributes %}
-   :hidden: {{ item }}
+   {{ item }}
    ~~~~~~~~~~~~~~~~~~~~
    .. autoattribute:: {{ item }}
    {%- endfor %}
@@ -55,7 +55,7 @@
 
    {% for item in methods %}
    {%- if item != '__init__' and item not in inherited_members%}
-   :hidden: {{ item }}
+   {{ item }}
    ~~~~~~~~~~~~~~~~~~~~
    .. automethod:: {{ item }}
    {%- endif -%}

--- a/docs/_templates/class_no_inherited.rst
+++ b/docs/_templates/class_no_inherited.rst
@@ -1,6 +1,3 @@
-.. role:: hidden
-    :class: hidden-section
-
 {{ fullname | escape | underline}}
 
 .. currentmodule:: {{ module }}
@@ -42,8 +39,6 @@
    {% if attributes %}
 
    {% for item in attributes %}
-   {{ item }}
-   ~~~~~~~~~~~~~~~~~~~~
    .. autoattribute:: {{ item }}
    {%- endfor %}
 
@@ -55,8 +50,6 @@
 
    {% for item in methods %}
    {%- if item != '__init__' and item not in inherited_members%}
-   {{ item }}
-   ~~~~~~~~~~~~~~~~~~~~
    .. automethod:: {{ item }}
    {%- endif -%}
    {%- endfor %}

--- a/docs/release_notes/v0.15.1.rst
+++ b/docs/release_notes/v0.15.1.rst
@@ -9,11 +9,12 @@ Changes
 - Use `setup` for Flax-based modules (`#1403`_).
 - Use multiple particles optionally in :class:`~scvi.model.JaxSCVI` (`#1385`_).
 - :class:`~scvi.external.SOLO` no longer warns about count data (`#1411`_).
-- Error gracefully when NaNs present in :class:`~scvi.data.fields.CategoricalJointObsmField` (`#1417`_).
+- Class docs are now one page on docs site (`#1415`_).
 
 Bug fixes
 ~~~~~~~~~~
 - Fix an issue with using gene lists and proteins lists as well as `transform_batch` for :class:`~scvi.model.TOTALVI` (`#1413`_).
+- Error gracefully when NaNs present in :class:`~scvi.data.fields.CategoricalJointObsmField` (`#1417`_).
 
 Contributors
 ~~~~~~~~~~~~
@@ -32,3 +33,4 @@ Contributors
 .. _`#1411`: https://github.com/YosefLab/scvi-tools/pull/1411
 .. _`#1413`: https://github.com/YosefLab/scvi-tools/pull/1413
 .. _`#1417`: https://github.com/YosefLab/scvi-tools/pull/1417
+.. _`#1415`: https://github.com/YosefLab/scvi-tools/pull/1417

--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -119,7 +119,8 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
         self.module.to(my_device)
 
     @property
-    def device(self):
+    def device(self) -> str:
+        """The current device that the module's params are on."""
         return self.module.device
 
     @staticmethod
@@ -391,19 +392,23 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
                 raise RuntimeError(message)
 
     @property
-    def is_trained(self):
+    def is_trained(self) -> bool:
+        """Whether the model has been trained."""
         return self.is_trained_
 
     @property
-    def test_indices(self):
+    def test_indices(self) -> np.ndarray:
+        """Observations that are in test set."""
         return self.test_indices_
 
     @property
-    def train_indices(self):
+    def train_indices(self) -> np.ndarray:
+        """Observations that are in train set."""
         return self.train_indices_
 
     @property
-    def validation_indices(self):
+    def validation_indices(self) -> np.ndarray:
+        """Observations that are in validation set."""
         return self.validation_indices_
 
     @train_indices.setter


### PR DESCRIPTION
Doc build takes 360 seconds vs 900 from before. Classes take one page now (methods on right side content bar)

Example here: https://scvi--1415.org.readthedocs.build/en/1415/api/reference/scvi.model.TOTALVI.html#scvi.model.TOTALVI