### PR TITLE
Fix warning for old model version when using scArches

### DIFF
--- a/scvi/model/base/_archesmixin.py
+++ b/scvi/model/base/_archesmixin.py
@@ -119,7 +119,7 @@ class ArchesMixin:
         adata_manager = model.get_anndata_manager(adata, required=True)
 
         version_split = adata_manager.registry[_constants._SCVI_VERSION_KEY].split(".")
-        if version_split[1] < "8" and version_split[0] == "0":
+        if int(version_split[1]) < 8 and int(version_split[0]) == 0:
             warnings.warn(
                 "Query integration should be performed using models trained with version >= 0.8"
             )


### PR DESCRIPTION
Loading a model trained with 0.15.0 currently triggers `"Query integration should be performed using models trained with version >= 0.8"`.