### PR TITLE
`setup_mudata` using dynamic class generation

### DIFF
--- a/docs/api/developer.md
+++ b/docs/api/developer.md
@@ -33,6 +33,15 @@ for operating over a collection of AnnDataFields and an AnnData object.
    data.fields.ObsmField
    data.fields.ProteinObsmField
    data.fields.LabelsWithUnlabeledObsField
+   data.fields.BaseMuDataWrapperClass
+   data.fields.MuDataWrapper
+   data.fields.MuDataLayerField
+   data.fields.MuDataProteinLayerField
+   data.fields.MuDataNumericalObsField
+   data.fields.MuDataCategoricalObsField
+   data.fields.MuDataObsmField
+   data.fields.MuDataNumericalJointObsField
+   data.fields.MuDataCategoricalJointObsField
 
 ```
 

--- a/docs/release_notes/v0.17.0.md
+++ b/docs/release_notes/v0.17.0.md
@@ -1,0 +1,19 @@
+# New in 0.17.0 (2022-MM-DD)
+
+## Changes
+
+- Experimental MuData support for {class}`~scvi.model.TOTALVI` via the method {meth}`~scvi.model.TOTALVI.setup_mudata` [#1474].
+
+## Breaking changes
+
+## Bug Fixes
+
+## Contributors
+
+- [@jjhong922]
+- [@adamgayoso]
+
+[#1474]: https://github.com/YosefLab/scvi-tools/pull/1474
+
+[@jjhong922]: https://github.com/jjhong922
+[@adamgayoso]: https://github.com/adamgayoso

--- a/docs/release_notes/v0.17.0.md
+++ b/docs/release_notes/v0.17.0.md
@@ -2,7 +2,7 @@
 
 ## Changes
 
-- Experimental MuData support for {class}`~scvi.model.TOTALVI` via the method {meth}`~scvi.model.TOTALVI.setup_mudata` [#1474].
+- Experimental MuData support for {class}`~scvi.model.TOTALVI` via the method {meth}`~scvi.model.TOTALVI.setup_mudata`. For several of the existing `AnnDataField` classes, there is now a MuData counterpart with an additional `mod_key` argument used to indicate the modality where the data lives (e.g. {class}`~scvi.data.fields.LayerField` to {class}`~scvi.data.fields.MuDataLayerField`). These modified classes are simply wrapped versions of the original `AnnDataField` code via  the new {method}`scvi.data.fields.MuDataWrapper` method [#1474].
 
 ## Breaking changes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ jax = ">=0.3"
 jupyter = {version = ">=1.0", optional = true}
 leidenalg = {version = "*", optional = true}
 loompy = {version = ">=3.0.6", optional = true}
-mudata = { git = "https://github.com/scverse/mudata.git", rev = "de11245" }
+mudata = { git = "https://github.com/scverse/mudata.git", rev = "c3bf23c" }
 myst-parser = {version = "*", optional = true}
 nbconvert = {version = ">=5.4.0", optional = true}
 nbformat = {version = ">=4.4.0", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ jax = ">=0.3"
 jupyter = {version = ">=1.0", optional = true}
 leidenalg = {version = "*", optional = true}
 loompy = {version = ">=3.0.6", optional = true}
+mudata = { git = "https://github.com/scverse/mudata.git", rev = "de11245" }
 myst-parser = {version = "*", optional = true}
 nbconvert = {version = ">=5.4.0", optional = true}
 nbformat = {version = ">=4.4.0", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ jax = ">=0.3"
 jupyter = {version = ">=1.0", optional = true}
 leidenalg = {version = "*", optional = true}
 loompy = {version = ">=3.0.6", optional = true}
-mudata = { git = "https://github.com/scverse/mudata.git", rev = "c3bf23c" }
+mudata = ">=0.1.2" 
 myst-parser = {version = "*", optional = true}
 nbconvert = {version = ">=5.4.0", optional = true}
 nbformat = {version = ">=4.4.0", optional = true}

--- a/scvi/_types.py
+++ b/scvi/_types.py
@@ -1,14 +1,11 @@
-from typing import Dict, Type, Union
+from typing import Dict, Union
 
 import anndata
 import jax.numpy as jnp
 import mudata
 import torch
 
-from scvi.data.fields import BaseAnnDataField
-
 Number = Union[int, float]
 AnnOrMuData = Union[anndata.AnnData, mudata.MuData]
-AnnDataField = Type[BaseAnnDataField]
 Tensor = Union[torch.Tensor, jnp.ndarray]
 LossRecord = Union[Dict[str, Tensor], Tensor]

--- a/scvi/_types.py
+++ b/scvi/_types.py
@@ -1,11 +1,14 @@
 from typing import Dict, Type, Union
 
+import anndata
 import jax.numpy as jnp
+import mudata
 import torch
 
 from scvi.data.fields import BaseAnnDataField
 
 Number = Union[int, float]
+AnnOrMuData = Union[anndata.AnnData, mudata.MuData]
 AnnDataField = Type[BaseAnnDataField]
 Tensor = Union[torch.Tensor, jnp.ndarray]
 LossRecord = Union[Dict[str, Tensor], Tensor]

--- a/scvi/data/_compat.py
+++ b/scvi/data/_compat.py
@@ -123,7 +123,6 @@ def registry_from_setup_dict(
         field_summary_stats = field_registry[_constants._SUMMARY_STATS_KEY]
 
         if attr_name in (_constants._ADATA_ATTRS.X, _constants._ADATA_ATTRS.LAYERS):
-            field_state_registry[LayerField.N_CELLS_KEY] = summary_stats["n_cells"]
             field_state_registry[LayerField.N_VARS_KEY] = summary_stats["n_vars"]
             field_summary_stats.update(field_state_registry)
         elif attr_name == _constants._ADATA_ATTRS.OBS:

--- a/scvi/data/_constants.py
+++ b/scvi/data/_constants.py
@@ -23,6 +23,7 @@ _SUMMARY_STATS_KEY = "summary_stats"
 # ----------------------------
 # Keys used in the data registry.
 
+_DR_MOD_KEY = "mod_key"
 _DR_ATTR_NAME = "attr_name"
 _DR_ATTR_KEY = "attr_key"
 

--- a/scvi/data/_constants.py
+++ b/scvi/data/_constants.py
@@ -13,6 +13,7 @@ _MANAGER_UUID_KEY = "_scvi_manager_uuid"
 
 _SCVI_VERSION_KEY = "scvi_version"
 _MODEL_NAME_KEY = "model_name"
+_SETUP_METHOD_NAME = "setup_method_name"
 _SETUP_ARGS_KEY = "setup_args"
 _FIELD_REGISTRIES_KEY = "field_registries"
 _DATA_REGISTRY_KEY = "data_registry"

--- a/scvi/data/_manager.py
+++ b/scvi/data/_manager.py
@@ -335,7 +335,7 @@ class AnnDataManager:
         )
 
         for registry_key, data_loc in self.data_registry.items():
-            mod_key = data_loc.mod_key
+            mod_key = getattr(data_loc, _constants._DR_MOD_KEY, None)
             attr_name = data_loc.attr_name
             attr_key = data_loc.attr_key
             scvi_data_str = "adata"

--- a/scvi/data/_manager.py
+++ b/scvi/data/_manager.py
@@ -9,13 +9,19 @@ from uuid import uuid4
 import numpy as np
 import pandas as pd
 import rich
+from mudata import MuData
 
 import scvi
 from scvi._types import AnnOrMuData
 from scvi.utils import attrdict
 
 from . import _constants
-from ._utils import _assign_adata_uuid, _check_if_view, get_anndata_attribute
+from ._utils import (
+    _assign_adata_uuid,
+    _check_if_view,
+    _check_mudata_fully_paired,
+    get_anndata_attribute,
+)
 from .fields import AnnDataField
 
 
@@ -75,6 +81,9 @@ class AnnDataManager:
     def _validate_anndata_object(adata: AnnOrMuData):
         """For a given AnnData object, runs general scvi-tools compatibility checks."""
         _check_if_view(adata, copy_if_view=False)
+
+        if isinstance(adata, MuData):
+            _check_mudata_fully_paired(adata)
 
     def _get_setup_method_args(self) -> dict:
         """

--- a/scvi/data/_manager.py
+++ b/scvi/data/_manager.py
@@ -9,14 +9,13 @@ from uuid import uuid4
 import numpy as np
 import pandas as pd
 import rich
-from anndata import AnnData
 
 import scvi
 from scvi._types import AnnOrMuData
 from scvi.utils import attrdict
 
 from . import _constants
-from ._utils import _assign_adata_uuid, get_anndata_attribute
+from ._utils import _assign_adata_uuid, _check_if_view, get_anndata_attribute
 from .fields import AnnDataField
 
 
@@ -73,10 +72,9 @@ class AnnDataManager:
             )
 
     @staticmethod
-    def _validate_anndata_object(adata: AnnData):
+    def _validate_anndata_object(adata: AnnOrMuData):
         """For a given AnnData object, runs general scvi-tools compatibility checks."""
-        if adata.is_view:
-            raise ValueError("Please run `adata = adata.copy()`")
+        _check_if_view(adata, copy_if_view=False)
 
     def _get_setup_method_args(self) -> dict:
         """

--- a/scvi/data/_manager.py
+++ b/scvi/data/_manager.py
@@ -271,7 +271,7 @@ class AnnDataManager:
         """
         data_loc = self.data_registry[registry_key]
         mod_key, attr_name, attr_key = (
-            data_loc[_constants._DR_MOD_KEY],
+            getattr(data_loc, _constants._DR_MOD_KEY, None),
             data_loc[_constants._DR_ATTR_NAME],
             data_loc[_constants._DR_ATTR_KEY],
         )

--- a/scvi/data/_utils.py
+++ b/scvi/data/_utils.py
@@ -252,3 +252,17 @@ def _check_if_view(adata: AnnOrMuData, copy_if_view: bool = False):
         for mod_key in adata.mod.keys():
             mod_adata = adata.mod[mod_key]
             _check_if_view(mod_adata, copy_if_view)
+
+
+def _check_mudata_fully_paired(mdata: MuData):
+    if isinstance(mdata, AnnData):
+        raise AssertionError(
+            "Cannot call ``_check_mudata_fully_paired`` with AnnData object."
+        )
+    for mod_key in mdata.mod:
+        if not mdata.obsm[mod_key].all():
+            raise ValueError(
+                f"Detected unpaired observations in modality {mod_key}. "
+                "Please make sure that data is fully paired in all MuData inputs. "
+                "Either pad the unpaired modalities or take the intersection with muon.pp.intersect_obs()."
+            )

--- a/scvi/data/_utils.py
+++ b/scvi/data/_utils.py
@@ -13,15 +13,26 @@ import scipy.sparse as sp_sparse
 from anndata._core.sparse_dataset import SparseDataset
 from pandas.api.types import CategoricalDtype
 
+from scvi._types import AnnOrMuData
+
 from . import _constants
 
 logger = logging.getLogger(__name__)
 
 
 def get_anndata_attribute(
-    adata: anndata.AnnData, attr_name: str, attr_key: Optional[str]
+    adata: AnnOrMuData,
+    attr_name: str,
+    attr_key: Optional[str],
+    mod_key: Optional[str] = None,
 ) -> Union[np.ndarray, pd.DataFrame]:
-    """Returns the requested data from a given AnnData object."""
+    """Returns the requested data from a given AnnData/MuData object."""
+    if mod_key is not None:
+        if isinstance(adata, anndata.AnnData):
+            raise ValueError(f"Cannot access modality {mod_key} on an AnnData object.")
+        if mod_key not in adata.mod:
+            raise ValueError(f"{mod_key} is not a valid modality in adata.mod.")
+        adata = adata.mod[mod_key]
     adata_attr = getattr(adata, attr_name)
     if attr_key is None:
         field = adata_attr

--- a/scvi/data/fields/__init__.py
+++ b/scvi/data/fields/__init__.py
@@ -1,5 +1,6 @@
 from ._base_field import AnnDataField, BaseAnnDataField
 from ._layer_field import LayerField, MuDataLayerField
+from ._mudata import BaseMuDataWrapperClass, MuDataWrapper
 from ._obs_field import (
     CategoricalObsField,
     MuDataCategoricalObsField,
@@ -11,6 +12,8 @@ from ._scanvi import LabelsWithUnlabeledObsField
 
 __all__ = [
     "BaseAnnDataField",
+    "BaseMuDataWrapperClass",
+    "MuDataWrapper",
     "AnnDataField",
     "LayerField",
     "NumericalObsField",

--- a/scvi/data/fields/__init__.py
+++ b/scvi/data/fields/__init__.py
@@ -4,9 +4,17 @@ from ._mudata import BaseMuDataWrapperClass, MuDataWrapper
 from ._obs_field import (
     CategoricalObsField,
     MuDataCategoricalObsField,
+    MuDataNumericalObsField,
     NumericalObsField,
 )
-from ._obsm_field import CategoricalJointObsField, NumericalJointObsField, ObsmField
+from ._obsm_field import (
+    CategoricalJointObsField,
+    MuDataCategoricalJointObsField,
+    MuDataNumericalJointObsField,
+    MuDataObsmField,
+    NumericalJointObsField,
+    ObsmField,
+)
 from ._protein import MuDataProteinLayerField, ProteinObsmField
 from ._scanvi import LabelsWithUnlabeledObsField
 
@@ -16,14 +24,18 @@ __all__ = [
     "MuDataWrapper",
     "AnnDataField",
     "LayerField",
+    "MuDataLayerField",
+    "MuDataProteinLayerField",
     "NumericalObsField",
+    "MuDataNumericalObsField",
     "CategoricalObsField",
-    "NumericalJointObsField",
-    "CategoricalJointObsField",
+    "MuDataCategoricalObsField",
     "ObsmField",
+    "MuDataObsmField",
+    "NumericalJointObsField",
+    "MuDataNumericalJointObsField",
+    "CategoricalJointObsField",
+    "MuDataCategoricalJointObsField",
     "ProteinObsmField",
     "LabelsWithUnlabeledObsField",
-    "MuDataLayerField",
-    "MuDataCategoricalObsField",
-    "MuDataProteinLayerField",
 ]

--- a/scvi/data/fields/__init__.py
+++ b/scvi/data/fields/__init__.py
@@ -1,8 +1,12 @@
 from ._base_field import AnnDataField, BaseAnnDataField
 from ._layer_field import LayerField, MuDataLayerField
-from ._obs_field import CategoricalObsField, NumericalObsField
+from ._obs_field import (
+    CategoricalObsField,
+    MuDataCategoricalObsField,
+    NumericalObsField,
+)
 from ._obsm_field import CategoricalJointObsField, NumericalJointObsField, ObsmField
-from ._protein import ProteinObsmField
+from ._protein import ProteinObsmField, MuDataProteinLayerField
 from ._scanvi import LabelsWithUnlabeledObsField
 
 __all__ = [
@@ -17,4 +21,6 @@ __all__ = [
     "ProteinObsmField",
     "LabelsWithUnlabeledObsField",
     "MuDataLayerField",
+    "MuDataCategoricalObsField",
+    "MuDataProteinLayerField",
 ]

--- a/scvi/data/fields/__init__.py
+++ b/scvi/data/fields/__init__.py
@@ -6,7 +6,7 @@ from ._obs_field import (
     NumericalObsField,
 )
 from ._obsm_field import CategoricalJointObsField, NumericalJointObsField, ObsmField
-from ._protein import ProteinObsmField, MuDataProteinLayerField
+from ._protein import MuDataProteinLayerField, ProteinObsmField
 from ._scanvi import LabelsWithUnlabeledObsField
 
 __all__ = [

--- a/scvi/data/fields/__init__.py
+++ b/scvi/data/fields/__init__.py
@@ -1,5 +1,5 @@
-from ._base_field import BaseAnnDataField
-from ._layer_field import LayerField
+from ._base_field import AnnDataField, BaseAnnDataField
+from ._layer_field import LayerField, MuDataLayerField
 from ._obs_field import CategoricalObsField, NumericalObsField
 from ._obsm_field import CategoricalJointObsField, NumericalJointObsField, ObsmField
 from ._protein import ProteinObsmField
@@ -7,6 +7,7 @@ from ._scanvi import LabelsWithUnlabeledObsField
 
 __all__ = [
     "BaseAnnDataField",
+    "AnnDataField",
     "LayerField",
     "NumericalObsField",
     "CategoricalObsField",
@@ -15,4 +16,5 @@ __all__ = [
     "ObsmField",
     "ProteinObsmField",
     "LabelsWithUnlabeledObsField",
+    "MuDataLayerField",
 ]

--- a/scvi/data/fields/_base_field.py
+++ b/scvi/data/fields/_base_field.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional, Union
+from typing import Optional, Type, Union
 
 import numpy as np
 import pandas as pd
@@ -153,3 +153,7 @@ class BaseAnnDataField(ABC):
             _constants._DR_ATTR_NAME: self.attr_name,
             _constants._DR_ATTR_KEY: self.attr_key,
         }
+
+
+# Convenience type
+AnnDataField = Type[BaseAnnDataField]

--- a/scvi/data/fields/_base_field.py
+++ b/scvi/data/fields/_base_field.py
@@ -148,11 +148,13 @@ class BaseAnnDataField(ABC):
         if self.is_empty:
             return dict()
 
-        return {
-            _constants._DR_MOD_KEY: self.mod_key,
+        data_registry = {
             _constants._DR_ATTR_NAME: self.attr_name,
             _constants._DR_ATTR_KEY: self.attr_key,
         }
+        if self.mod_key is not None:
+            data_registry[_constants._DR_MOD_KEY] = self.mod_key
+        return data_registry
 
 
 # Convenience type

--- a/scvi/data/fields/_layer_field.py
+++ b/scvi/data/fields/_layer_field.py
@@ -96,7 +96,7 @@ class LayerField(BaseAnnDataField):
             _verify_and_correct_data_format(adata, self.attr_name, self.attr_key)
         return {
             self.N_VARS_KEY: adata.n_vars,
-            self.COLUMN_NAMES_KEY: np.array(adata.var_names),
+            self.COLUMN_NAMES_KEY: np.asarray(adata.var_names),
         }
 
     def transfer_field(

--- a/scvi/data/fields/_layer_field.py
+++ b/scvi/data/fields/_layer_field.py
@@ -44,7 +44,6 @@ class LayerField(BaseAnnDataField):
         layer: Optional[str],
         is_count_data: bool = True,
         correct_data_format: bool = True,
-        save_column_names: bool = False,
     ) -> None:
         super().__init__()
         self._registry_key = registry_key
@@ -56,7 +55,6 @@ class LayerField(BaseAnnDataField):
         self._attr_key = layer
         self.is_count_data = is_count_data
         self.correct_data_format = correct_data_format
-        self.save_column_names = save_column_names
         self.count_stat_key = (
             self.N_VARS_KEY
             if self.registry_key == REGISTRY_KEYS.X_KEY
@@ -96,12 +94,10 @@ class LayerField(BaseAnnDataField):
         super().register_field(adata)
         if self.correct_data_format:
             _verify_and_correct_data_format(adata, self.attr_name, self.attr_key)
-        state_registry = {
+        return {
             self.N_VARS_KEY: adata.n_vars,
+            self.COLUMN_NAMES_KEY: np.array(adata.var_names),
         }
-        if self.save_column_names:
-            state_registry[self.COLUMN_NAMES_KEY] = np.array(adata.var_names)
-        return state_registry
 
     def transfer_field(
         self, state_registry: dict, adata_target: AnnData, **kwargs

--- a/scvi/data/fields/_layer_field.py
+++ b/scvi/data/fields/_layer_field.py
@@ -11,6 +11,7 @@ from scvi.data._utils import (
 )
 
 from ._base_field import BaseAnnDataField
+from ._mudata import MuDataWrapper
 
 
 class LayerField(BaseAnnDataField):
@@ -105,3 +106,6 @@ class LayerField(BaseAnnDataField):
 
     def view_state_registry(self, _state_registry: dict) -> Optional[rich.table.Table]:
         return None
+
+
+MuDataLayerField = MuDataWrapper(LayerField)

--- a/scvi/data/fields/_layer_field.py
+++ b/scvi/data/fields/_layer_field.py
@@ -35,6 +35,8 @@ class LayerField(BaseAnnDataField):
         If True, saves var names to the associated state registry as ``column_names``.
     """
 
+    N_OBS_KEY = "n_obs"
+    N_CELLS_KEY = "n_cells"
     N_VARS_KEY = "n_vars"
     COLUMN_NAMES_KEY = "column_names"
 
@@ -95,6 +97,7 @@ class LayerField(BaseAnnDataField):
         if self.correct_data_format:
             _verify_and_correct_data_format(adata, self.attr_name, self.attr_key)
         return {
+            self.N_OBS_KEY: adata.n_obs,
             self.N_VARS_KEY: adata.n_vars,
             self.COLUMN_NAMES_KEY: np.asarray(adata.var_names),
         }
@@ -114,7 +117,10 @@ class LayerField(BaseAnnDataField):
         return self.register_field(adata_target)
 
     def get_summary_stats(self, state_registry: dict) -> dict:
-        return {self.count_stat_key: state_registry[self.N_VARS_KEY]}
+        summary_stats = {self.count_stat_key: state_registry[self.N_VARS_KEY]}
+        if self.registry_key == REGISTRY_KEYS.X_KEY:
+            summary_stats[self.N_CELLS_KEY] = state_registry[self.N_OBS_KEY]
+        return summary_stats
 
     def view_state_registry(self, _state_registry: dict) -> Optional[rich.table.Table]:
         return None

--- a/scvi/data/fields/_layer_field.py
+++ b/scvi/data/fields/_layer_field.py
@@ -31,6 +31,8 @@ class LayerField(BaseAnnDataField):
     correct_data_format
         If True, checks and corrects that the AnnData field is C_CONTIGUOUS and csr
         if it is dense numpy or sparse respectively.
+    save_column_names
+        If True, saves var names to the associated state registry as ``column_names``.
     """
 
     N_VARS_KEY = "n_vars"
@@ -42,6 +44,7 @@ class LayerField(BaseAnnDataField):
         layer: Optional[str],
         is_count_data: bool = True,
         correct_data_format: bool = True,
+        save_column_names: bool = False,
     ) -> None:
         super().__init__()
         self._registry_key = registry_key
@@ -53,6 +56,7 @@ class LayerField(BaseAnnDataField):
         self._attr_key = layer
         self.is_count_data = is_count_data
         self.correct_data_format = correct_data_format
+        self.save_column_names = save_column_names
         self.count_stat_key = (
             self.N_VARS_KEY
             if self.registry_key == REGISTRY_KEYS.X_KEY
@@ -92,10 +96,12 @@ class LayerField(BaseAnnDataField):
         super().register_field(adata)
         if self.correct_data_format:
             _verify_and_correct_data_format(adata, self.attr_name, self.attr_key)
-        return {
+        state_registry = {
             self.N_VARS_KEY: adata.n_vars,
-            self.COLUMN_NAMES_KEY: np.array(adata.var_names),
         }
+        if self.save_column_names:
+            state_registry[self.COLUMN_NAMES_KEY] = np.array(adata.var_names)
+        return state_registry
 
     def transfer_field(
         self, state_registry: dict, adata_target: AnnData, **kwargs

--- a/scvi/data/fields/_mudata.py
+++ b/scvi/data/fields/_mudata.py
@@ -19,18 +19,22 @@ class BaseMuDataWrapper(BaseAnnDataField):
 
     @property
     def registry_key(self) -> str:
+        """The key that is referenced by models via a data loader."""
         return self.adata_field.registry_key
 
     @property
     def mod_key(self) -> Optional[str]:
+        """The modality key of the data field within the MuData (if applicable)."""
         return self._mod_key
 
     @property
     def attr_name(self) -> str:
+        """The name of the AnnData/MuData attribute where the data is stored."""
         return self.adata_field.attr_name
 
     @property
     def attr_key(self) -> Optional[str]:
+        """The key of the data field within the relevant AnnData/MuData attribute."""
         return self.adata_field.attr_key
 
     @property

--- a/scvi/data/fields/_mudata.py
+++ b/scvi/data/fields/_mudata.py
@@ -1,0 +1,92 @@
+from typing import Callable, Optional
+
+import rich
+from mudata import MuData
+
+from scvi._types import AnnDataField, AnnOrMuData
+from scvi.data.fields import BaseAnnDataField
+
+
+class BaseMuDataWrapper(BaseAnnDataField):
+    def __init__(self, mod_key: Optional[str] = None) -> None:
+        super().__init__()
+        self._mod_key = mod_key
+        self._preregister = lambda _: None
+
+    @property
+    def adata_field(self) -> AnnDataField:
+        return self._adata_field
+
+    @property
+    def preregister(self, mdata: MuData) -> None:
+        return self._preregister
+
+    @property
+    def registry_key(self) -> str:
+        return self.adata_field.registry_key
+
+    @property
+    def mod_key(self) -> Optional[str]:
+        return self._mod_key
+
+    @property
+    def attr_name(self) -> str:
+        return self.adata_field.attr_name
+
+    @property
+    def attr_key(self) -> Optional[str]:
+        return self.adata_field.attr_key
+
+    @property
+    def is_empty(self) -> bool:
+        return self.adata_field.is_empty
+
+    def get_modality(self, mdata: MuData) -> AnnOrMuData:
+        bdata = mdata
+        if self.mod_key is not None:
+            if self.mod_key not in mdata.mod:
+                raise ValueError(f"Modality {self.mod_key} not found in mdata.mod.")
+            bdata = mdata.mod[self.mod_key]
+        return bdata
+
+    def validate_field(self, mdata: MuData) -> None:
+        bdata = self.get_modality(mdata)
+        return self.adata_field.validate_field(bdata)
+
+    def register_field(self, mdata: MuData) -> dict:
+        self.preregister(mdata)
+        bdata = self.get_modality(mdata)
+        return self.adata_field.register_field(bdata)
+
+    def transfer_field(
+        self, state_registry: dict, mdata_target: MuData, **kwargs
+    ) -> dict:
+        bdata_target = self.get_modality(mdata_target)
+        return self.adata_field.transfer_field(state_registry, bdata_target, **kwargs)
+
+    def get_summary_stats(self, state_registry: dict) -> dict:
+        return self.adata_field.get_summary_stats(state_registry)
+
+    def view_state_registry(self, state_registry: dict) -> Optional[rich.table.Table]:
+        return self.adata_field.view_state_registry(state_registry)
+
+
+def MuDataWrapper(
+    adata_field_cls: AnnDataField, preregister_fn: Optional[Callable] = None
+) -> AnnDataField:
+    if not isinstance(adata_field_cls, type):
+        raise ValueError("`adata_field_cls` must be a class, not an instance.")
+
+    def mudata_field_init(self, *args, mod_key: Optional[str] = None, **kwargs):
+        BaseMuDataWrapper.__init__(self, mod_key=mod_key)
+        self._adata_field = adata_field_cls.__init__(*args, **kwargs)
+        if preregister_fn is not None:
+            self._preregister = preregister_fn
+
+    return type(
+        f"MuDataWrapped{adata_field_cls.__name__}",
+        (BaseMuDataWrapper,),
+        {
+            "__init__": mudata_field_init,
+        },
+    )

--- a/scvi/data/fields/_mudata.py
+++ b/scvi/data/fields/_mudata.py
@@ -3,23 +3,19 @@ from typing import Callable, Optional
 import rich
 from mudata import MuData
 
-from scvi._types import AnnDataField, AnnOrMuData
-from scvi.data.fields import BaseAnnDataField
+from scvi._types import AnnOrMuData
+from scvi.data.fields import AnnDataField, BaseAnnDataField
 
 
 class BaseMuDataWrapper(BaseAnnDataField):
     def __init__(self, mod_key: Optional[str] = None) -> None:
         super().__init__()
         self._mod_key = mod_key
-        self._preregister = lambda _: None
+        self._preregister = lambda _self, _mdata: None
 
     @property
     def adata_field(self) -> AnnDataField:
         return self._adata_field
-
-    @property
-    def preregister(self, mdata: MuData) -> None:
-        return self._preregister
 
     @property
     def registry_key(self) -> str:
@@ -53,6 +49,9 @@ class BaseMuDataWrapper(BaseAnnDataField):
         bdata = self.get_modality(mdata)
         return self.adata_field.validate_field(bdata)
 
+    def preregister(self, mdata: MuData) -> None:
+        return self._preregister(self, mdata)
+
     def register_field(self, mdata: MuData) -> dict:
         self.preregister(mdata)
         bdata = self.get_modality(mdata)
@@ -79,12 +78,12 @@ def MuDataWrapper(
 
     def mudata_field_init(self, *args, mod_key: Optional[str] = None, **kwargs):
         BaseMuDataWrapper.__init__(self, mod_key=mod_key)
-        self._adata_field = adata_field_cls.__init__(*args, **kwargs)
+        self._adata_field = adata_field_cls(*args, **kwargs)
         if preregister_fn is not None:
             self._preregister = preregister_fn
 
     return type(
-        f"MuDataWrapped{adata_field_cls.__name__}",
+        f"MuData{adata_field_cls.__name__}",
         (BaseMuDataWrapper,),
         {
             "__init__": mudata_field_init,

--- a/scvi/data/fields/_mudata.py
+++ b/scvi/data/fields/_mudata.py
@@ -71,6 +71,7 @@ class BaseMuDataWrapper(BaseAnnDataField):
     def transfer_field(
         self, state_registry: dict, mdata_target: MuData, **kwargs
     ) -> dict:
+        self.preregister(mdata_target)
         bdata_target = self.get_modality(mdata_target)
         return self.adata_field.transfer_field(state_registry, bdata_target, **kwargs)
 

--- a/scvi/data/fields/_mudata.py
+++ b/scvi/data/fields/_mudata.py
@@ -112,7 +112,6 @@ def MuDataWrapper(
     """
     Wraps an AnnDataField with :class:`~scvi.data.fields.BaseMuDataWrapperClass`.
 
-
     Parameters
     ----------
     adata_field_cls

--- a/scvi/data/fields/_mudata.py
+++ b/scvi/data/fields/_mudata.py
@@ -80,9 +80,10 @@ class BaseMuDataWrapperClass(BaseAnnDataField):
 
     def preregister(self, mdata: MuData) -> None:
         """
+        Function that is called prior to registering fields.
+
         Function that is be called at the beginning of :func:`~scvi.data.fields.BaseMuDataWrapperClass.register_field`
         and :func:`~scvi.data.fields.BaseMuDataWrapperClass.transfer_field`.
-
         Used when data manipulation is necessary across modalities.
         """
         return self._preregister(self, mdata)

--- a/scvi/data/fields/_mudata.py
+++ b/scvi/data/fields/_mudata.py
@@ -28,7 +28,9 @@ class BaseMuDataWrapperClass(BaseAnnDataField):
     ) -> None:
         super().__init__()
         if mod_required and mod_key is None:
-            raise ValueError("Modality required for MuDataField but not provided.")
+            raise ValueError(
+                f"Modality required for {self.__class__.__name__} but not provided."
+            )
         self._mod_key = mod_key
         self._preregister = lambda _self, _mdata: None
 

--- a/scvi/data/fields/_obs_field.py
+++ b/scvi/data/fields/_obs_field.py
@@ -96,6 +96,9 @@ class NumericalObsField(BaseObsField):
         return None
 
 
+MuDataNumericalObsField = MuDataWrapper(NumericalObsField)
+
+
 class CategoricalObsField(BaseObsField):
     """
     An AnnDataField for categorical .obs attributes in the AnnData data structure.

--- a/scvi/data/fields/_obs_field.py
+++ b/scvi/data/fields/_obs_field.py
@@ -10,6 +10,7 @@ from scvi.data import _constants
 from scvi.data._utils import _make_column_categorical, get_anndata_attribute
 
 from ._base_field import BaseAnnDataField
+from ._mudata import MuDataWrapper
 
 logger = logging.getLogger(__name__)
 
@@ -214,3 +215,6 @@ class CategoricalObsField(BaseObsField):
             else:
                 t.add_row("", str(cat), str(i))
         return t
+
+
+MuDataCategoricalObsField = MuDataWrapper(CategoricalObsField)

--- a/scvi/data/fields/_obsm_field.py
+++ b/scvi/data/fields/_obsm_field.py
@@ -14,6 +14,7 @@ from scvi.data._utils import (
     _make_column_categorical,
     _verify_and_correct_data_format,
 )
+from scvi.data.fields import MuDataWrapper
 
 from ._base_field import BaseAnnDataField
 
@@ -167,6 +168,9 @@ class ObsmField(BaseObsmField):
         return None
 
 
+MuDataObsmField = MuDataWrapper(ObsmField)
+
+
 class JointObsField(BaseObsmField):
     """
     An abstract AnnDataField for a collection of .obs fields in the AnnData data structure.
@@ -264,6 +268,9 @@ class NumericalJointObsField(JointObsField):
         for key in state_registry[self.COLUMNS_KEY]:
             t.add_row("adata.obs['{}']".format(key))
         return t
+
+
+MuDataNumericalJointObsField = MuDataWrapper(NumericalJointObsField)
 
 
 class CategoricalJointObsField(JointObsField):
@@ -392,3 +399,6 @@ class CategoricalJointObsField(JointObsField):
                     t.add_row("", str(mapping), str(i))
             t.add_row("", "")
         return t
+
+
+MuDataCategoricalJointObsField = MuDataWrapper(CategoricalJointObsField)

--- a/scvi/data/fields/_protein.py
+++ b/scvi/data/fields/_protein.py
@@ -7,7 +7,7 @@ from anndata import AnnData
 from mudata import MuData
 
 from ._layer_field import LayerField
-from ._mudata import BaseMuDataWrapper, MuDataWrapper
+from ._mudata import BaseMuDataWrapperClass, MuDataWrapper
 from ._obsm_field import ObsmField
 
 logger = logging.getLogger(__name__)
@@ -157,7 +157,7 @@ class ProteinLayerField(ProteinFieldMixin, LayerField):
 def copy_over_batch_attr(self, mdata: MuData):
     # Assign self.batch_field if not yet assigned to MuDataWrapped field.
     # Then, reassign self.adata_field.batch_field to the batch AnnDataField.
-    if isinstance(self.adata_field.batch_field, BaseMuDataWrapper):
+    if isinstance(self.adata_field.batch_field, BaseMuDataWrapperClass):
         self.batch_field = self.adata_field.batch_field
         self.adata_field.batch_field = self.batch_field.adata_field
 

--- a/scvi/model/_totalvi.py
+++ b/scvi/model/_totalvi.py
@@ -1316,6 +1316,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
                 use_batch_mask=True,
                 batch_field=batch_field,
                 is_count_data=True,
+                save_column_names=True,
             ),
         ]
         adata_manager = AnnDataManager(

--- a/scvi/model/_totalvi.py
+++ b/scvi/model/_totalvi.py
@@ -1316,7 +1316,6 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
                 use_batch_mask=True,
                 batch_field=batch_field,
                 is_count_data=True,
-                save_column_names=True,
             ),
         ]
         adata_manager = AnnDataManager(

--- a/scvi/model/_totalvi.py
+++ b/scvi/model/_totalvi.py
@@ -1265,26 +1265,18 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
 
         if modalities is None:
             raise ValueError("Modalities cannot be None.")
-        modalities = modalities.copy()
-        batch_mod = modalities.pop("batch_key", None)
-        rna_mod = modalities.pop("rna_layer", None)
-        protein_mod = modalities.pop("protein_layer", None)
-        size_factor_mod = modalities.pop("size_factor_key", None)
-        categorical_covariate_mod = modalities.pop("categorical_covariate_keys", None)
-        continuous_covariate_mod = modalities.pop("continuous_covariate_keys", None)
-        if len(modalities) > 0:
-            raise ValueError(f"Extraneous modality mapping(s) detected: {modalities}")
+        modalities = cls._create_modalities_attr_dict(modalities, setup_method_args)
 
         batch_field = fields.MuDataCategoricalObsField(
             REGISTRY_KEYS.BATCH_KEY,
             batch_key,
-            mod_key=batch_mod,
+            mod_key=modalities.batch_key,
         )
         mudata_fields = [
             fields.MuDataLayerField(
                 REGISTRY_KEYS.X_KEY,
                 rna_layer,
-                mod_key=rna_mod,
+                mod_key=modalities.rna_layer,
                 is_count_data=True,
                 mod_required=True,
             ),
@@ -1297,23 +1289,23 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
             fields.MuDataNumericalObsField(
                 REGISTRY_KEYS.SIZE_FACTOR_KEY,
                 size_factor_key,
-                mod_key=size_factor_mod,
+                mod_key=modalities.size_factor_key,
                 required=False,
             ),
             fields.MuDataCategoricalJointObsField(
                 REGISTRY_KEYS.CAT_COVS_KEY,
                 categorical_covariate_keys,
-                mod_key=categorical_covariate_mod,
+                mod_key=modalities.categorical_covariate_keys,
             ),
             fields.MuDataNumericalJointObsField(
                 REGISTRY_KEYS.CONT_COVS_KEY,
                 continuous_covariate_keys,
-                mod_key=continuous_covariate_mod,
+                mod_key=modalities.continuous_covariate_keys,
             ),
             fields.MuDataProteinLayerField(
                 REGISTRY_KEYS.PROTEIN_EXP_KEY,
                 protein_layer,
-                mod_key=protein_mod,
+                mod_key=modalities.protein_layer,
                 use_batch_mask=True,
                 batch_field=batch_field,
                 is_count_data=True,

--- a/scvi/model/_totalvi.py
+++ b/scvi/model/_totalvi.py
@@ -1154,7 +1154,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
 
                 # average distribution over cells
                 batch_avg_mu = np.mean(mus)
-                batch_avg_scale = np.sqrt(np.sum(np.square(scales)) / (n_cells ** 2))
+                batch_avg_scale = np.sqrt(np.sum(np.square(scales)) / (n_cells**2))
 
                 batch_avg_mus.append(batch_avg_mu)
                 batch_avg_scales.append(batch_avg_scale)

--- a/scvi/model/_totalvi.py
+++ b/scvi/model/_totalvi.py
@@ -10,26 +10,13 @@ import torch
 from anndata import AnnData
 from mudata import MuData
 
+import scvi.data.fields as fields
 from scvi import REGISTRY_KEYS
 from scvi._compat import Literal
 from scvi._types import Number
 from scvi._utils import _doc_params
 from scvi.data import AnnDataManager
 from scvi.data._utils import _check_nonnegative_integers
-from scvi.data.fields import (
-    CategoricalJointObsField,
-    CategoricalObsField,
-    LayerField,
-    MuDataCategoricalJointObsField,
-    MuDataCategoricalObsField,
-    MuDataLayerField,
-    MuDataNumericalJointObsField,
-    MuDataNumericalObsField,
-    MuDataProteinLayerField,
-    NumericalJointObsField,
-    NumericalObsField,
-    ProteinObsmField,
-)
 from scvi.dataloaders import DataSplitter
 from scvi.model._utils import (
     _get_batch_code_from_category,
@@ -127,7 +114,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
             REGISTRY_KEYS.PROTEIN_EXP_KEY
         )
         if (
-            ProteinObsmField.PROTEIN_BATCH_MASK in self.protein_state_registry
+            fields.ProteinObsmField.PROTEIN_BATCH_MASK in self.protein_state_registry
             and not override_missing_proteins
         ):
             batch_mask = self.protein_state_registry.protein_batch_mask
@@ -156,7 +143,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
 
         n_cats_per_cov = (
             self.adata_manager.get_state_registry(REGISTRY_KEYS.CAT_COVS_KEY)[
-                CategoricalJointObsField.N_CATS_PER_KEY
+                fields.CategoricalJointObsField.N_CATS_PER_KEY
             ]
             if REGISTRY_KEYS.CAT_COVS_KEY in self.adata_manager.data_registry
             else None
@@ -1103,10 +1090,10 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
             )
             batch_mask = adata_manager.get_state_registry(
                 REGISTRY_KEYS.PROTEIN_EXP_KEY
-            ).get(ProteinObsmField.PROTEIN_BATCH_MASK)
+            ).get(fields.ProteinObsmField.PROTEIN_BATCH_MASK)
             batch = adata_manager.get_from_registry(REGISTRY_KEYS.BATCH_KEY).ravel()
             cats = adata_manager.get_state_registry(REGISTRY_KEYS.BATCH_KEY)[
-                CategoricalObsField.CATEGORICAL_MAPPING_KEY
+                fields.CategoricalObsField.CATEGORICAL_MAPPING_KEY
             ]
             codes = np.arange(len(cats))
 
@@ -1230,23 +1217,23 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
         %(returns)s
         """
         setup_method_args = cls._get_setup_method_args(**locals())
-        batch_field = CategoricalObsField(REGISTRY_KEYS.BATCH_KEY, batch_key)
+        batch_field = fields.CategoricalObsField(REGISTRY_KEYS.BATCH_KEY, batch_key)
         anndata_fields = [
-            LayerField(REGISTRY_KEYS.X_KEY, layer, is_count_data=True),
-            CategoricalObsField(
+            fields.LayerField(REGISTRY_KEYS.X_KEY, layer, is_count_data=True),
+            fields.CategoricalObsField(
                 REGISTRY_KEYS.LABELS_KEY, None
             ),  # Default labels field for compatibility with TOTALVAE
             batch_field,
-            NumericalObsField(
+            fields.NumericalObsField(
                 REGISTRY_KEYS.SIZE_FACTOR_KEY, size_factor_key, required=False
             ),
-            CategoricalJointObsField(
+            fields.CategoricalJointObsField(
                 REGISTRY_KEYS.CAT_COVS_KEY, categorical_covariate_keys
             ),
-            NumericalJointObsField(
+            fields.NumericalJointObsField(
                 REGISTRY_KEYS.CONT_COVS_KEY, continuous_covariate_keys
             ),
-            ProteinObsmField(
+            fields.ProteinObsmField(
                 REGISTRY_KEYS.PROTEIN_EXP_KEY,
                 protein_expression_obsm_key,
                 use_batch_mask=True,
@@ -1288,42 +1275,42 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
         if len(modalities) > 0:
             raise ValueError(f"Extraneous modality mapping(s) detected: {modalities}")
 
-        batch_field = MuDataCategoricalObsField(
+        batch_field = fields.MuDataCategoricalObsField(
             REGISTRY_KEYS.BATCH_KEY,
             batch_key,
             mod_key=batch_mod,
         )
         mudata_fields = [
-            MuDataLayerField(
+            fields.MuDataLayerField(
                 REGISTRY_KEYS.X_KEY,
                 rna_layer,
                 mod_key=rna_mod,
                 is_count_data=True,
                 mod_required=True,
             ),
-            MuDataCategoricalObsField(
+            fields.MuDataCategoricalObsField(
                 REGISTRY_KEYS.LABELS_KEY,
                 None,
                 mod_key=None,
             ),  # Default labels field for compatibility with TOTALVAE
             batch_field,
-            MuDataNumericalObsField(
+            fields.MuDataNumericalObsField(
                 REGISTRY_KEYS.SIZE_FACTOR_KEY,
                 size_factor_key,
                 mod_key=size_factor_mod,
                 required=False,
             ),
-            MuDataCategoricalJointObsField(
+            fields.MuDataCategoricalJointObsField(
                 REGISTRY_KEYS.CAT_COVS_KEY,
                 categorical_covariate_keys,
                 mod_key=categorical_covariate_mod,
             ),
-            MuDataNumericalJointObsField(
+            fields.MuDataNumericalJointObsField(
                 REGISTRY_KEYS.CONT_COVS_KEY,
                 continuous_covariate_keys,
                 mod_key=continuous_covariate_mod,
             ),
-            MuDataProteinLayerField(
+            fields.MuDataProteinLayerField(
                 REGISTRY_KEYS.PROTEIN_EXP_KEY,
                 protein_layer,
                 mod_key=protein_mod,

--- a/scvi/model/_totalvi.py
+++ b/scvi/model/_totalvi.py
@@ -1154,7 +1154,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
 
                 # average distribution over cells
                 batch_avg_mu = np.mean(mus)
-                batch_avg_scale = np.sqrt(np.sum(np.square(scales)) / (n_cells**2))
+                batch_avg_scale = np.sqrt(np.sum(np.square(scales)) / (n_cells ** 2))
 
                 batch_avg_mus.append(batch_avg_mu)
                 batch_avg_scales.append(batch_avg_scale)
@@ -1239,7 +1239,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
                 REGISTRY_KEYS.PROTEIN_EXP_KEY,
                 protein_expression_obsm_key,
                 use_batch_mask=True,
-                batch_key=batch_field.attr_key,
+                batch_field=batch_field,
                 colnames_uns_key=protein_names_uns_key,
                 is_count_data=True,
             ),

--- a/scvi/model/_utils.py
+++ b/scvi/model/_utils.py
@@ -278,4 +278,4 @@ def _init_library_size(
 def _get_var_names_from_manager(
     adata_manager: AnnDataManager, registry_key: str = REGISTRY_KEYS.X_KEY
 ) -> np.ndarray:
-    return np.array(adata_manager.get_state_registry(registry_key).column_names)
+    return np.asarray(adata_manager.get_state_registry(registry_key).column_names)

--- a/scvi/model/_utils.py
+++ b/scvi/model/_utils.py
@@ -273,3 +273,9 @@ def _init_library_size(
         library_log_vars[i_batch] = np.var(log_counts).astype(np.float32)
 
     return library_log_means.reshape(1, -1), library_log_vars.reshape(1, -1)
+
+
+def _get_var_names_from_manager(
+    adata_manager: AnnDataManager, registry_key: str = REGISTRY_KEYS.X_KEY
+) -> np.ndarray:
+    return np.array(adata_manager.get_state_registry(registry_key).column_names)

--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -16,18 +16,13 @@ from mudata import MuData
 from scvi import settings
 from scvi._types import AnnOrMuData
 from scvi.data import AnnDataManager
-<<<<<<< HEAD
 from scvi.data._compat import registry_from_setup_dict
-from scvi.data._constants import _MODEL_NAME_KEY, _SCVI_UUID_KEY, _SETUP_ARGS_KEY
-=======
-from scvi.data._compat import manager_from_setup_dict
 from scvi.data._constants import (
     _MODEL_NAME_KEY,
     _SCVI_UUID_KEY,
     _SETUP_ARGS_KEY,
     _SETUP_METHOD_NAME,
 )
->>>>>>> c19643cf (implement setup_mudata on totalvi)
 from scvi.data._utils import _assign_adata_uuid, _check_if_view
 from scvi.dataloaders import AnnDataLoader
 from scvi.model._utils import parse_use_gpu_arg
@@ -622,32 +617,20 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
                 "It appears you are loading a model from a different class."
             )
 
-<<<<<<< HEAD
         if _SETUP_ARGS_KEY not in registry:
             raise ValueError(
                 "Saved model does not contain original setup inputs. "
                 "Cannot load the original setup."
-=======
-            if _SETUP_ARGS_KEY not in registry:
-                raise ValueError(
-                    "Saved model does not contain original setup inputs. "
-                    "Cannot load the original setup."
-                )
-
-            # Calling ``setup_anndata`` method with the original arguments passed into
-            # the saved model. This enables simple backwards compatibility in the case of
-            # newly introduced fields or parameters.
-            method_name = registry.get(_SETUP_METHOD_NAME, "setup_anndata")
-            print(method_name)
-            getattr(cls, method_name)(
-                adata, source_registry=registry, **registry[_SETUP_ARGS_KEY]
->>>>>>> c19643cf (implement setup_mudata on totalvi)
             )
 
         # Calling ``setup_anndata`` method with the original arguments passed into
         # the saved model. This enables simple backwards compatibility in the case of
         # newly introduced fields or parameters.
-        cls.setup_anndata(adata, source_registry=registry, **registry[_SETUP_ARGS_KEY])
+        method_name = registry.get(_SETUP_METHOD_NAME, "setup_anndata")
+        print(method_name)
+        getattr(cls, method_name)(
+            adata, source_registry=registry, **registry[_SETUP_ARGS_KEY]
+        )
 
         model = _initialize_model(cls, adata, attr_dict)
 

--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 
 _UNTRAINED_WARNING_MESSAGE = "Trying to query inferred values from an untrained model. Please train the model first."
 
-_SETUP_INPUTS_EXCLUDED_PARAMS = {"adata", "kwargs"}
+_SETUP_INPUTS_EXCLUDED_PARAMS = {"adata", "mdata", "kwargs"}
 
 
 class BaseModelMetaClass(ABCMeta):
@@ -473,7 +473,9 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
         init_params = [p.name for p in parameters]
         all_params = {p: locals[p] for p in locals if p in init_params}
         all_params = {
-            k: v for (k, v) in all_params.items() if not isinstance(v, AnnData)
+            k: v
+            for (k, v) in all_params.items()
+            if not isinstance(v, AnnData) and not isinstance(v, MuData)
         }
         # not very efficient but is explicit
         # seperates variable params (**kwargs) from non variable params into two dicts
@@ -635,7 +637,8 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
             # Calling ``setup_anndata`` method with the original arguments passed into
             # the saved model. This enables simple backwards compatibility in the case of
             # newly introduced fields or parameters.
-            method_name = getattr(registry, _SETUP_METHOD_NAME, "setup_anndata")
+            method_name = registry.get(_SETUP_METHOD_NAME, "setup_anndata")
+            print(method_name)
             getattr(cls, method_name)(
                 adata, source_registry=registry, **registry[_SETUP_ARGS_KEY]
 >>>>>>> c19643cf (implement setup_mudata on totalvi)

--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -627,7 +627,6 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
         # the saved model. This enables simple backwards compatibility in the case of
         # newly introduced fields or parameters.
         method_name = registry.get(_SETUP_METHOD_NAME, "setup_anndata")
-        print(method_name)
         getattr(cls, method_name)(
             adata, source_registry=registry, **registry[_SETUP_ARGS_KEY]
         )

--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -13,10 +13,11 @@ import torch
 from anndata import AnnData
 
 from scvi import settings
+from scvi._types import AnnOrMuData
 from scvi.data import AnnDataManager
 from scvi.data._compat import registry_from_setup_dict
 from scvi.data._constants import _MODEL_NAME_KEY, _SCVI_UUID_KEY, _SETUP_ARGS_KEY
-from scvi.data._utils import _assign_adata_uuid
+from scvi.data._utils import _assign_adata_uuid, _check_if_view
 from scvi.dataloaders import AnnDataLoader
 from scvi.model._utils import parse_use_gpu_arg
 from scvi.model.base._utils import _load_legacy_saved_files
@@ -58,7 +59,7 @@ class BaseModelMetaClass(ABCMeta):
 class BaseModelClass(metaclass=BaseModelMetaClass):
     """Abstract class for scvi-tools models."""
 
-    def __init__(self, adata: Optional[AnnData] = None):
+    def __init__(self, adata: Optional[AnnOrMuData] = None):
         self.id = str(uuid4())  # Used for cls._manager_store keys.
         if adata is not None:
             self._adata = adata
@@ -79,12 +80,12 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
         self._data_loader_cls = AnnDataLoader
 
     @property
-    def adata(self) -> AnnData:
+    def adata(self) -> AnnOrMuData:
         """Data attached to model instance."""
         return self._adata
 
     @adata.setter
-    def adata(self, adata: AnnData):
+    def adata(self, adata: AnnOrMuData):
         if adata is None:
             raise ValueError("adata cannot be None.")
         self._validate_anndata(adata)
@@ -174,7 +175,7 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
 
     @classmethod
     def _get_most_recent_anndata_manager(
-        cls, adata: AnnData, required: bool = False
+        cls, adata: AnnOrMuData, required: bool = False
     ) -> Optional[AnnDataManager]:
         """
         Retrieves the :class:`~scvi.data.AnnDataManager` for a given AnnData object specific to this model class.
@@ -217,7 +218,7 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
         return adata_manager
 
     def get_anndata_manager(
-        self, adata: AnnData, required: bool = False
+        self, adata: AnnOrMuData, required: bool = False
     ) -> Optional[AnnDataManager]:
         """
         Retrieves the :class:`~scvi.data.AnnDataManager` for a given AnnData object specific to this model instance.
@@ -268,7 +269,7 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
 
     def get_from_registry(
         self,
-        adata: AnnData,
+        adata: AnnOrMuData,
         registry_key: str,
     ) -> np.ndarray:
         """
@@ -298,7 +299,7 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
 
     def _make_data_loader(
         self,
-        adata: AnnData,
+        adata: AnnOrMuData,
         indices: Optional[Sequence[int]] = None,
         batch_size: Optional[int] = None,
         shuffle: bool = False,
@@ -351,19 +352,13 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
         return dl
 
     def _validate_anndata(
-        self, adata: Optional[AnnData] = None, copy_if_view: bool = True
+        self, adata: Optional[AnnOrMuData] = None, copy_if_view: bool = True
     ) -> AnnData:
         """Validate anndata has been properly registered, transfer if necessary."""
         if adata is None:
             adata = self.adata
-        if adata.is_view:
-            if copy_if_view:
-                logger.info("Received view of anndata, making copy.")
-                adata._init_as_actual(adata.copy())
-                # Reassign AnnData UUID to produce a separate AnnDataManager.
-                _assign_adata_uuid(adata, overwrite=True)
-            else:
-                raise ValueError("Please run `adata = adata.copy()`")
+
+        _check_if_view(adata, copy_if_view=copy_if_view)
 
         adata_manager = self.get_anndata_manager(adata)
         if adata_manager is None:
@@ -740,7 +735,7 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
         AnnDataManager.view_setup_method_args(registry)
 
     def view_anndata_setup(
-        self, adata: Optional[AnnData] = None, hide_state_registries: bool = False
+        self, adata: Optional[AnnOrMuData] = None, hide_state_registries: bool = False
     ) -> None:
         """
         Print summary of the setup for the initial AnnData or a given AnnData object.

--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -11,12 +11,23 @@ import pyro
 import rich
 import torch
 from anndata import AnnData
+from mudata import MuData
 
 from scvi import settings
 from scvi._types import AnnOrMuData
 from scvi.data import AnnDataManager
+<<<<<<< HEAD
 from scvi.data._compat import registry_from_setup_dict
 from scvi.data._constants import _MODEL_NAME_KEY, _SCVI_UUID_KEY, _SETUP_ARGS_KEY
+=======
+from scvi.data._compat import manager_from_setup_dict
+from scvi.data._constants import (
+    _MODEL_NAME_KEY,
+    _SCVI_UUID_KEY,
+    _SETUP_ARGS_KEY,
+    _SETUP_METHOD_NAME,
+)
+>>>>>>> c19643cf (implement setup_mudata on totalvi)
 from scvi.data._utils import _assign_adata_uuid, _check_if_view
 from scvi.dataloaders import AnnDataLoader
 from scvi.model._utils import parse_use_gpu_arg
@@ -134,12 +145,22 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
         to avoid the inclusion of any extraneous variables.
         """
         cls = setup_locals.pop("cls")
+        method_name = None
+        if "adata" in setup_locals:
+            method_name = "setup_anndata"
+        elif "mdata" in setup_locals:
+            method_name = "setup_mudata"
+
         model_name = cls.__name__
         setup_args = dict()
         for k, v in setup_locals.items():
             if k not in _SETUP_INPUTS_EXCLUDED_PARAMS:
                 setup_args[k] = v
-        return {_MODEL_NAME_KEY: model_name, _SETUP_ARGS_KEY: setup_args}
+        return {
+            _MODEL_NAME_KEY: model_name,
+            _SETUP_METHOD_NAME: method_name,
+            _SETUP_ARGS_KEY: setup_args,
+        }
 
     @classmethod
     def register_manager(cls, adata_manager: AnnDataManager):
@@ -510,8 +531,13 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
         file_name_prefix = prefix or ""
 
         if save_anndata:
+            file_suffix = ""
+            if isinstance(self.adata, AnnData):
+                file_suffix = "adata.h5ad"
+            elif isinstance(self.adata, MuData):
+                file_suffix = "mdata.h5mu"
             self.adata.write(
-                os.path.join(dir_path, f"{file_name_prefix}adata.h5ad"),
+                os.path.join(dir_path, f"{file_name_prefix}{file_suffix}"),
                 **anndata_write_kwargs,
             )
 
@@ -541,7 +567,7 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
     def load(
         cls,
         dir_path: str,
-        adata: Optional[AnnData] = None,
+        adata: Optional[AnnOrMuData] = None,
         use_gpu: Optional[Union[str, int, bool]] = None,
         prefix: Optional[str] = None,
         backup_url: Optional[str] = None,
@@ -594,10 +620,25 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
                 "It appears you are loading a model from a different class."
             )
 
+<<<<<<< HEAD
         if _SETUP_ARGS_KEY not in registry:
             raise ValueError(
                 "Saved model does not contain original setup inputs. "
                 "Cannot load the original setup."
+=======
+            if _SETUP_ARGS_KEY not in registry:
+                raise ValueError(
+                    "Saved model does not contain original setup inputs. "
+                    "Cannot load the original setup."
+                )
+
+            # Calling ``setup_anndata`` method with the original arguments passed into
+            # the saved model. This enables simple backwards compatibility in the case of
+            # newly introduced fields or parameters.
+            method_name = getattr(registry, _SETUP_METHOD_NAME, "setup_anndata")
+            getattr(cls, method_name)(
+                adata, source_registry=registry, **registry[_SETUP_ARGS_KEY]
+>>>>>>> c19643cf (implement setup_mudata on totalvi)
             )
 
         # Calling ``setup_anndata`` method with the original arguments passed into

--- a/scvi/model/base/_utils.py
+++ b/scvi/model/base/_utils.py
@@ -5,12 +5,15 @@ import warnings
 from collections.abc import Iterable as IterableClass
 from typing import List, Optional, Tuple, Union
 
+import anndata
+import mudata
 import numpy as np
 import pandas as pd
 import torch
 from anndata import AnnData, read
 
 from scvi._compat import Literal
+from scvi.data._constants import _SETUP_METHOD_NAME
 from scvi.data._download import _download
 from scvi.utils import track
 
@@ -75,14 +78,19 @@ def _load_saved_files(
     var_names = model["var_names"]
     attr_dict = model["attr_dict"]
 
-    if load_adata:
-        adata_path = os.path.join(dir_path, f"{file_name_prefix}adata.h5ad")
-        if os.path.exists(adata_path):
-            adata = read(adata_path)
-        elif not os.path.exists(adata_path):
-            raise ValueError(
-                "Save path contains no saved anndata and no adata was passed."
-            )
+    is_mudata = False
+    registry = attr_dict["registry_"]
+    is_mudata = getattr(registry, _SETUP_METHOD_NAME, None) == "setup_mudata"
+    file_suffix = "adata.h5ad" if not is_mudata else "mdata.h5mu"
+    adata_path = os.path.join(dir_path, f"{file_name_prefix}{file_suffix}")
+
+    if os.path.exists(adata_path) and load_adata:
+        if is_mudata:
+            adata = mudata.read(adata_path)
+        else:
+            adata = anndata.read(adata_path)
+    elif not os.path.exists(adata_path):
+        raise ValueError("Save path contains no saved anndata and no adata was passed.")
     else:
         adata = None
 
@@ -141,7 +149,7 @@ def _validate_var_names(adata, source_var_names):
 def _prepare_obs(
     idx1: Union[List[bool], np.ndarray, str],
     idx2: Union[List[bool], np.ndarray, str],
-    adata: AnnData,
+    adata: anndata.AnnData,
 ):
     """
     Construct an array used for masking.

--- a/scvi/model/base/_utils.py
+++ b/scvi/model/base/_utils.py
@@ -80,7 +80,7 @@ def _load_saved_files(
 
     is_mudata = False
     registry = attr_dict["registry_"]
-    is_mudata = getattr(registry, _SETUP_METHOD_NAME, None) == "setup_mudata"
+    is_mudata = registry.get(_SETUP_METHOD_NAME) == "setup_mudata"
     file_suffix = "adata.h5ad" if not is_mudata else "mdata.h5mu"
     adata_path = os.path.join(dir_path, f"{file_name_prefix}{file_suffix}")
 

--- a/scvi/model/base/_utils.py
+++ b/scvi/model/base/_utils.py
@@ -84,13 +84,16 @@ def _load_saved_files(
     file_suffix = "adata.h5ad" if not is_mudata else "mdata.h5mu"
     adata_path = os.path.join(dir_path, f"{file_name_prefix}{file_suffix}")
 
-    if os.path.exists(adata_path) and load_adata:
-        if is_mudata:
-            adata = mudata.read(adata_path)
+    if load_adata:
+        if os.path.exists(adata_path):
+            if is_mudata:
+                adata = mudata.read(adata_path)
+            else:
+                adata = anndata.read(adata_path)
         else:
-            adata = anndata.read(adata_path)
-    elif not os.path.exists(adata_path):
-        raise ValueError("Save path contains no saved anndata and no adata was passed.")
+            raise ValueError(
+                "Save path contains no saved anndata and no adata was passed."
+            )
     else:
         adata = None
 

--- a/tests/dataset/test_anndata.py
+++ b/tests/dataset/test_anndata.py
@@ -288,7 +288,7 @@ def test_setup_anndata():
         adata_manager.get_from_registry(REGISTRY_KEYS.X_KEY), true_x
     )
 
-    # test that it creates layers and batch if no layers_key is passed
+    # test that it creates labels and batch if no layers_key is passed
     adata = synthetic_iid()
     adata_manager = generic_setup_adata_manager(
         adata,

--- a/tests/dataset/test_mudata.py
+++ b/tests/dataset/test_mudata.py
@@ -1,0 +1,17 @@
+import mudata
+import numpy as np
+
+from scvi import REGISTRY_KEYS
+from scvi.data import synthetic_iid
+
+from .utils import generic_setup_mudata_manager
+
+
+def test_setup_mudata():
+    # test regular setup
+    adata = synthetic_iid()
+    mdata = mudata.MuData({"rna": adata})
+    adata_manager = generic_setup_mudata_manager(mdata, layer=None, layer_mod="rna")
+    np.testing.assert_array_equal(
+        adata_manager.get_from_registry(REGISTRY_KEYS.X_KEY), adata.X
+    )

--- a/tests/dataset/test_mudata.py
+++ b/tests/dataset/test_mudata.py
@@ -265,7 +265,7 @@ def test_transfer_fields_diff_batch_mapping():
         REGISTRY_KEYS.BATCH_KEY
     ).categorical_mapping
     correct_batch = np.where(batch_mapping == "batch_1")[0][0]
-    adata2.obs["_scvi_batch"][0] == correct_batch
+    assert adata2.obs["_scvi_batch"][0] == correct_batch
 
 
 def test_transfer_fields_missing_batch():

--- a/tests/dataset/test_mudata.py
+++ b/tests/dataset/test_mudata.py
@@ -8,10 +8,18 @@ from .utils import generic_setup_mudata_manager
 
 
 def test_setup_mudata():
-    # test regular setup
     adata = synthetic_iid()
-    mdata = mudata.MuData({"rna": adata})
-    adata_manager = generic_setup_mudata_manager(mdata, layer=None, layer_mod="rna")
+    protein_adata = synthetic_iid()
+    mdata = mudata.MuData({"rna": adata, "protein": protein_adata})
+    adata_manager = generic_setup_mudata_manager(
+        mdata,
+        layer=None,
+        layer_mod="rna",
+        batch_mod="rna",
+        batch_key="batch",
+        protein_expression_mod="protein",
+        protein_expression_layer=None,
+    )
     np.testing.assert_array_equal(
         adata_manager.get_from_registry(REGISTRY_KEYS.X_KEY), adata.X
     )

--- a/tests/dataset/test_mudata.py
+++ b/tests/dataset/test_mudata.py
@@ -1,3 +1,5 @@
+import os
+
 import mudata
 import numpy as np
 import pytest
@@ -6,6 +8,209 @@ from scvi import REGISTRY_KEYS
 from scvi.data import synthetic_iid
 
 from .utils import generic_setup_mudata_manager
+
+
+def test_transfer_fields():
+    # test transfer_fields function
+    adata1 = synthetic_iid()
+    protein_adata1 = synthetic_iid()
+    mdata1 = mudata.MuData({"rna": adata1, "protein": protein_adata1})
+    adata2 = synthetic_iid()
+    adata2.X = adata1.X
+    protein_adata2 = synthetic_iid()
+    mdata2 = mudata.MuData({"rna": adata2, "protein": protein_adata2})
+
+    adata1_manager = generic_setup_mudata_manager(
+        mdata1,
+        layer_mod="rna",
+        layer=None,
+        batch_mod="rna",
+        batch_key="batch",
+        protein_expression_mod="protein",
+        protein_expression_layer=None,
+    )
+    adata1_manager.transfer_fields(mdata2)
+    np.testing.assert_array_equal(adata1.obs["_scvi_batch"], adata2.obs["_scvi_batch"])
+
+
+def test_transfer_fields_view():
+    # test transfer_fields function
+    adata1 = synthetic_iid()
+    protein_adata1 = synthetic_iid()
+    mdata1 = mudata.MuData({"rna": adata1, "protein": protein_adata1})
+    adata2 = synthetic_iid()
+    adata2.X = adata1.X
+    protein_adata2 = synthetic_iid()
+    mdata2 = mudata.MuData({"rna": adata2, "protein": protein_adata2})[:50]
+
+    adata1_manager = generic_setup_mudata_manager(
+        mdata1,
+        layer_mod="rna",
+        layer=None,
+        batch_mod="rna",
+        batch_key="batch",
+        protein_expression_mod="protein",
+        protein_expression_layer=None,
+    )
+    with pytest.raises(ValueError):
+        adata1_manager.transfer_fields(mdata2)
+
+
+def test_transfer_fields_layer():
+    # test if layer was used initially, again used in transfer setup
+    adata1 = synthetic_iid()
+    raw_counts = adata1.X.copy()
+    adata1.layers["raw"] = raw_counts
+    protein_adata1 = synthetic_iid()
+    mdata1 = mudata.MuData({"rna": adata1, "protein": protein_adata1})
+    adata2 = synthetic_iid()
+    adata2.layers["raw"] = raw_counts
+    protein_adata2 = synthetic_iid()
+    mdata2 = mudata.MuData({"rna": adata2, "protein": protein_adata2})
+
+    zeros = np.zeros_like(adata1.X)
+    ones = np.ones_like(adata1.X)
+    adata1.X = zeros
+    adata2.X = ones
+
+    adata_manager = generic_setup_mudata_manager(
+        mdata1,
+        layer_mod="rna",
+        layer="raw",
+        batch_mod="rna",
+        batch_key="batch",
+        protein_expression_mod="protein",
+        protein_expression_layer=None,
+    )
+    adata_manager.transfer_fields(mdata2)
+    np.testing.assert_array_equal(adata1.obs["_scvi_batch"], adata2.obs["_scvi_batch"])
+
+
+def test_transfer_fields_unknown_batch():
+    # test that an unknown batch throws an error
+    adata1 = synthetic_iid()
+    protein_adata1 = synthetic_iid()
+    mdata1 = mudata.MuData({"rna": adata1, "protein": protein_adata1})
+    adata2 = synthetic_iid()
+    adata2.X = adata1.X
+    protein_adata2 = synthetic_iid()
+    mdata2 = mudata.MuData({"rna": adata2, "protein": protein_adata2})
+    adata2.obs["batch"] = [2] * adata2.n_obs
+    adata1_manager = generic_setup_mudata_manager(
+        mdata1, layer_mod="rna", batch_mod="rna", batch_key="batch"
+    )
+    with pytest.raises(ValueError):
+        adata1_manager.transfer_fields(mdata2)
+
+
+def test_transfer_fields_diff_batch_mapping():
+    # test that correct mapping was applied
+    adata1 = synthetic_iid()
+    protein_adata1 = synthetic_iid()
+    mdata1 = mudata.MuData({"rna": adata1, "protein": protein_adata1})
+    adata2 = synthetic_iid()
+    adata2.X = adata1.X
+    protein_adata2 = synthetic_iid()
+    mdata2 = mudata.MuData({"rna": adata2, "protein": protein_adata2})
+    adata2.obs["labels"] = ["batch_1"] * adata2.n_obs
+    adata1_manager = generic_setup_mudata_manager(
+        mdata1, layer_mod="rna", batch_mod="rna", batch_key="batch"
+    )
+    adata1_manager.transfer_fields(mdata2)
+    batch_mapping = adata1_manager.get_state_registry(
+        REGISTRY_KEYS.BATCH_KEY
+    ).categorical_mapping
+    correct_batch = np.where(batch_mapping == "batch_1")[0][0]
+    adata2.obs["_scvi_batch"][0] == correct_batch
+
+
+def test_transfer_fields_missing_batch():
+    # test that transfer_fields correctly looks for adata.obs['batch']
+    adata1 = synthetic_iid()
+    protein_adata1 = synthetic_iid()
+    mdata1 = mudata.MuData({"rna": adata1, "protein": protein_adata1})
+    adata2 = synthetic_iid()
+    del adata2.obs["batch"]
+    adata2.X = adata1.X
+    protein_adata2 = synthetic_iid()
+    mdata2 = mudata.MuData({"rna": adata2, "protein": protein_adata2})
+    adata1_manager = generic_setup_mudata_manager(
+        mdata1, layer_mod="rna", batch_mod="rna", batch_key="batch"
+    )
+    with pytest.raises(KeyError):
+        adata1_manager.transfer_fields(mdata2)
+
+
+def test_transfer_fields_default_batch():
+    # test that transfer_fields assigns same batch to cells
+    # if the original anndata was also same batch
+    adata1 = synthetic_iid()
+    protein_adata1 = synthetic_iid()
+    mdata1 = mudata.MuData({"rna": adata1, "protein": protein_adata1})
+    adata2 = synthetic_iid()
+    del adata2.obs["batch"]
+    adata2.X = adata1.X
+    protein_adata2 = synthetic_iid()
+    mdata2 = mudata.MuData({"rna": adata2, "protein": protein_adata2})
+    adata1_manager = generic_setup_mudata_manager(
+        mdata1, layer_mod="rna", batch_mod="rna", batch_key=None
+    )
+    adata1_manager.transfer_fields(mdata2)
+    assert adata2.obs["_scvi_batch"][0] == 0
+
+
+def test_data_format():
+    # if data was dense np array, check after setup_anndata, data is C_CONTIGUOUS
+    adata = synthetic_iid()
+    protein_adata = synthetic_iid()
+    mdata = mudata.MuData({"rna": adata, "protein": protein_adata})
+
+    old_x = adata.X
+    old_pro = protein_adata.X
+    old_obs = adata.obs
+    adata.X = np.asfortranarray(old_x)
+    protein_adata.X = np.asfortranarray(old_pro)
+    assert adata.X.flags["C_CONTIGUOUS"] is False
+    assert protein_adata.X.flags["C_CONTIGUOUS"] is False
+
+    adata_manager = generic_setup_mudata_manager(
+        mdata, layer_mod="rna", protein_expression_mod="protein"
+    )
+    assert adata.X.flags["C_CONTIGUOUS"] is True
+    assert protein_adata.X.flags["C_CONTIGUOUS"] is True
+
+    assert np.array_equal(old_x, adata.X)
+    assert np.array_equal(old_pro, protein_adata.X)
+    assert np.array_equal(old_obs, adata.obs)
+
+    assert np.array_equal(adata.X, adata_manager.get_from_registry(REGISTRY_KEYS.X_KEY))
+    assert np.array_equal(
+        protein_adata.X,
+        adata_manager.get_from_registry(REGISTRY_KEYS.PROTEIN_EXP_KEY),
+    )
+
+    # if obsm is dataframe, make it C_CONTIGUOUS if it isnt
+    adata = synthetic_iid()
+    protein_adata = synthetic_iid()
+    mdata = mudata.MuData({"rna": adata, "protein": protein_adata})
+
+    pe = np.asfortranarray(protein_adata.X)
+    protein_adata.X = pe
+    assert protein_adata.X.flags["C_CONTIGUOUS"] is False
+
+    adata_manager = generic_setup_mudata_manager(
+        mdata, layer_mod="rna", protein_expression_mod="protein"
+    )
+    new_pe = adata_manager.get_from_registry(REGISTRY_KEYS.PROTEIN_EXP_KEY)
+    assert new_pe.flags["C_CONTIGUOUS"] is True
+    assert np.array_equal(pe, new_pe)
+    assert np.array_equal(adata.X, adata_manager.get_from_registry(REGISTRY_KEYS.X_KEY))
+    assert np.array_equal(
+        protein_adata.X,
+        adata_manager.get_from_registry(REGISTRY_KEYS.PROTEIN_EXP_KEY),
+    )
+    assert adata.X.flags["C_CONTIGUOUS"] is True
+    assert protein_adata.X.flags["C_CONTIGUOUS"] is True
 
 
 def test_setup_mudata():
@@ -83,3 +288,34 @@ def test_setup_mudata():
         generic_setup_mudata_manager(
             mdata, layer_mod="rna", batch_mod="rna", batch_key="batch"
         )
+
+
+def test_save_setup_mudata(save_path):
+    adata = synthetic_iid()
+    mdata = mudata.MuData({"rna": adata})
+    generic_setup_mudata_manager(
+        mdata,
+        layer_mod="rna",
+        batch_mod="rna",
+        batch_key="batch",
+    )
+    temp_path = os.path.join(save_path, "test.h5mu")
+    mdata.write(temp_path)
+    mudata.read(temp_path)
+
+
+def test_view_registry():
+    adata = synthetic_iid()
+    protein_adata = synthetic_iid()
+    mdata = mudata.MuData({"rna": adata, "protein": protein_adata})
+    adata_manager = generic_setup_mudata_manager(
+        mdata,
+        layer_mod="rna",
+        layer=None,
+        batch_mod="rna",
+        batch_key="batch",
+        protein_expression_mod="protein",
+        protein_expression_layer=None,
+    )
+    adata_manager.view_registry()
+    adata_manager.view_registry(hide_state_registries=True)

--- a/tests/dataset/test_mudata.py
+++ b/tests/dataset/test_mudata.py
@@ -1,5 +1,6 @@
 import mudata
 import numpy as np
+import pytest
 
 from scvi import REGISTRY_KEYS
 from scvi.data import synthetic_iid
@@ -23,3 +24,62 @@ def test_setup_mudata():
     np.testing.assert_array_equal(
         adata_manager.get_from_registry(REGISTRY_KEYS.X_KEY), adata.X
     )
+    np.testing.assert_array_equal(
+        adata_manager.get_from_registry(REGISTRY_KEYS.BATCH_KEY),
+        np.array(adata.obs["_scvi_batch"]).reshape((-1, 1)),
+    )
+    np.testing.assert_array_equal(
+        adata_manager.get_from_registry(REGISTRY_KEYS.PROTEIN_EXP_KEY),
+        protein_adata.X,
+    )
+
+    # test that error is thrown if its a view:
+    adata = synthetic_iid()
+    mdata = mudata.MuData({"rna": adata[1]})
+    with pytest.raises(ValueError):
+        generic_setup_mudata_manager(mdata, layer_mod="rna")
+
+    adata = synthetic_iid()
+    mdata = mudata.MuData({"rna": adata})
+    with pytest.raises(ValueError):
+        generic_setup_mudata_manager(mdata[1], layer_mod="rna")
+
+    # test that error is thrown if an anndata is passed in:
+    adata = synthetic_iid()
+    with pytest.raises(AssertionError):
+        generic_setup_mudata_manager(adata, layer_mod="rna")
+
+    # test that layer is working properly
+    adata = synthetic_iid()
+    true_x = adata.X
+    adata.layers["X"] = true_x
+    adata.X = np.ones_like(adata.X)
+    mdata = mudata.MuData({"rna": adata})
+    adata_manager = generic_setup_mudata_manager(mdata, layer_mod="rna", layer="X")
+    np.testing.assert_array_equal(
+        adata_manager.get_from_registry(REGISTRY_KEYS.X_KEY), true_x
+    )
+
+    # test that it creates batch if no layers_key is passed
+    adata = synthetic_iid()
+    mdata = mudata.MuData({"rna": adata})
+    adata_manager = generic_setup_mudata_manager(
+        mdata, layer_mod="rna", batch_mod="rna"
+    )
+    np.testing.assert_array_equal(
+        adata_manager.get_from_registry(REGISTRY_KEYS.BATCH_KEY),
+        np.zeros((adata.shape[0], 1)),
+    )
+    np.testing.assert_array_equal(
+        adata_manager.get_from_registry(REGISTRY_KEYS.BATCH_KEY),
+        adata.obs["_scvi_batch"].to_numpy().reshape(-1, 1),
+    )
+
+    # test error is thrown when categorical obs field contains nans
+    adata = synthetic_iid()
+    adata.obs["batch"][:10] = np.nan
+    mdata = mudata.MuData({"rna": adata})
+    with pytest.raises(ValueError):
+        generic_setup_mudata_manager(
+            mdata, layer_mod="rna", batch_mod="rna", batch_key="batch"
+        )

--- a/tests/dataset/test_mudata.py
+++ b/tests/dataset/test_mudata.py
@@ -13,8 +13,8 @@ def test_setup_mudata():
     mdata = mudata.MuData({"rna": adata, "protein": protein_adata})
     adata_manager = generic_setup_mudata_manager(
         mdata,
-        layer=None,
         layer_mod="rna",
+        layer=None,
         batch_mod="rna",
         batch_key="batch",
         protein_expression_mod="protein",

--- a/tests/dataset/test_mudata.py
+++ b/tests/dataset/test_mudata.py
@@ -10,6 +10,123 @@ from scvi.data import synthetic_iid
 from .utils import generic_setup_mudata_manager
 
 
+def test_setup_mudata():
+    adata = synthetic_iid()
+    adata.obs["cont1"] = np.random.normal(size=(adata.shape[0],))
+    adata.obs["cont2"] = np.random.normal(size=(adata.shape[0],))
+    adata.obs["cat1"] = np.random.randint(0, 5, size=(adata.shape[0],))
+    adata.obs["cat2"] = np.random.randint(0, 5, size=(adata.shape[0],))
+    protein_adata = synthetic_iid()
+    mdata = mudata.MuData({"rna": adata, "protein": protein_adata})
+    adata_manager = generic_setup_mudata_manager(
+        mdata,
+        layer_mod="rna",
+        layer=None,
+        batch_mod="rna",
+        batch_key="batch",
+        categorical_covariate_mod="rna",
+        categorical_covariate_keys=["cat1", "cat2"],
+        continuous_covariate_mod="rna",
+        continuous_covariate_keys=["cont1", "cont2"],
+        protein_expression_mod="protein",
+        protein_expression_layer=None,
+    )
+    np.testing.assert_array_equal(
+        adata_manager.get_from_registry(REGISTRY_KEYS.X_KEY), adata.X
+    )
+    np.testing.assert_array_equal(
+        adata_manager.get_from_registry(REGISTRY_KEYS.BATCH_KEY),
+        np.array(adata.obs["_scvi_batch"]).reshape((-1, 1)),
+    )
+    np.testing.assert_array_equal(
+        adata_manager.get_from_registry(REGISTRY_KEYS.CONT_COVS_KEY),
+        adata.obs[["cont1", "cont2"]],
+    )
+    np.testing.assert_array_equal(
+        adata_manager.get_from_registry(REGISTRY_KEYS.CAT_COVS_KEY),
+        adata.obs[["cat1", "cat2"]],
+    )
+    np.testing.assert_array_equal(
+        adata_manager.get_from_registry(REGISTRY_KEYS.PROTEIN_EXP_KEY),
+        protein_adata.X,
+    )
+
+
+def test_setup_mudata_view():
+    # test that error is thrown if its a view:
+    adata = synthetic_iid()
+    mdata = mudata.MuData({"rna": adata[1]})
+    with pytest.raises(ValueError):
+        generic_setup_mudata_manager(mdata, layer_mod="rna")
+
+    adata = synthetic_iid()
+    mdata = mudata.MuData({"rna": adata})
+    with pytest.raises(ValueError):
+        generic_setup_mudata_manager(mdata[1], layer_mod="rna")
+
+
+def test_setup_mudata_anndata():
+    # test that error is thrown if an anndata is passed in:
+    adata = synthetic_iid()
+    with pytest.raises(AssertionError):
+        generic_setup_mudata_manager(adata, layer_mod="rna")
+
+
+def test_setup_mudata_layer():
+    # test that layer is working properly
+    adata = synthetic_iid()
+    true_x = adata.X
+    adata.layers["X"] = true_x
+    adata.X = np.ones_like(adata.X)
+    mdata = mudata.MuData({"rna": adata})
+    adata_manager = generic_setup_mudata_manager(mdata, layer_mod="rna", layer="X")
+    np.testing.assert_array_equal(
+        adata_manager.get_from_registry(REGISTRY_KEYS.X_KEY), true_x
+    )
+
+
+def test_setup_mudata_default_batch():
+    # test that it creates batch if no batch_key is passed
+    adata = synthetic_iid()
+    mdata = mudata.MuData({"rna": adata})
+    adata_manager = generic_setup_mudata_manager(
+        mdata, layer_mod="rna", batch_mod="rna"
+    )
+    np.testing.assert_array_equal(
+        adata_manager.get_from_registry(REGISTRY_KEYS.BATCH_KEY),
+        np.zeros((adata.shape[0], 1)),
+    )
+    np.testing.assert_array_equal(
+        adata_manager.get_from_registry(REGISTRY_KEYS.BATCH_KEY),
+        adata.obs["_scvi_batch"].to_numpy().reshape(-1, 1),
+    )
+
+
+def test_setup_mudata_nan_batch():
+    # test error is thrown when categorical obs field contains nans
+    adata = synthetic_iid()
+    adata.obs["batch"][:10] = np.nan
+    mdata = mudata.MuData({"rna": adata})
+    with pytest.raises(ValueError):
+        generic_setup_mudata_manager(
+            mdata, layer_mod="rna", batch_mod="rna", batch_key="batch"
+        )
+
+
+def test_save_setup_mudata(save_path):
+    adata = synthetic_iid()
+    mdata = mudata.MuData({"rna": adata})
+    generic_setup_mudata_manager(
+        mdata,
+        layer_mod="rna",
+        batch_mod="rna",
+        batch_key="batch",
+    )
+    temp_path = os.path.join(save_path, "test.h5mu")
+    mdata.write(temp_path)
+    mudata.read(temp_path)
+
+
 def test_transfer_fields():
     # test transfer_fields function
     adata1 = synthetic_iid()
@@ -159,6 +276,42 @@ def test_transfer_fields_default_batch():
     assert adata2.obs["_scvi_batch"][0] == 0
 
 
+def test_transfer_fields_covariates():
+    adata1 = synthetic_iid()
+    adata1.obs["cont1"] = np.random.normal(size=(adata1.shape[0],))
+    adata1.obs["cont2"] = np.random.normal(size=(adata1.shape[0],))
+    adata1.obs["cat1"] = np.random.randint(0, 5, size=(adata1.shape[0],))
+    adata1.obs["cat2"] = np.random.randint(0, 5, size=(adata1.shape[0],))
+    mdata1 = mudata.MuData({"rna": adata1})
+    adata_manager = generic_setup_mudata_manager(
+        mdata1,
+        layer_mod="rna",
+        batch_mod="rna",
+        continuous_covariate_mod="rna",
+        continuous_covariate_keys=["cont1", "cont2"],
+        categorical_covariate_mod="rna",
+        categorical_covariate_keys=["cat1", "cat2"],
+    )
+    adata2 = synthetic_iid()
+    adata2.obs["cont1"] = np.random.normal(size=(adata2.shape[0],))
+    adata2.obs["cont2"] = np.random.normal(size=(adata2.shape[0],))
+    adata2.obs["cat1"] = 0
+    adata2.obs["cat2"] = 1
+    mdata2 = mudata.MuData({"rna": adata2})
+
+    adata_manager.transfer_fields(mdata2)
+
+    # give it a new category
+    adata2.obs["cat1"] = 6
+    adata_manager2 = adata_manager.transfer_fields(mdata2, extend_categories=True)
+    assert (
+        adata_manager2.get_state_registry(REGISTRY_KEYS.CAT_COVS_KEY).mappings["cat1"][
+            -1
+        ]
+        == 6
+    )
+
+
 def test_data_format():
     # if data was dense np array, check after setup_anndata, data is C_CONTIGUOUS
     adata = synthetic_iid()
@@ -211,97 +364,6 @@ def test_data_format():
     )
     assert adata.X.flags["C_CONTIGUOUS"] is True
     assert protein_adata.X.flags["C_CONTIGUOUS"] is True
-
-
-def test_setup_mudata():
-    adata = synthetic_iid()
-    protein_adata = synthetic_iid()
-    mdata = mudata.MuData({"rna": adata, "protein": protein_adata})
-    adata_manager = generic_setup_mudata_manager(
-        mdata,
-        layer_mod="rna",
-        layer=None,
-        batch_mod="rna",
-        batch_key="batch",
-        protein_expression_mod="protein",
-        protein_expression_layer=None,
-    )
-    np.testing.assert_array_equal(
-        adata_manager.get_from_registry(REGISTRY_KEYS.X_KEY), adata.X
-    )
-    np.testing.assert_array_equal(
-        adata_manager.get_from_registry(REGISTRY_KEYS.BATCH_KEY),
-        np.array(adata.obs["_scvi_batch"]).reshape((-1, 1)),
-    )
-    np.testing.assert_array_equal(
-        adata_manager.get_from_registry(REGISTRY_KEYS.PROTEIN_EXP_KEY),
-        protein_adata.X,
-    )
-
-    # test that error is thrown if its a view:
-    adata = synthetic_iid()
-    mdata = mudata.MuData({"rna": adata[1]})
-    with pytest.raises(ValueError):
-        generic_setup_mudata_manager(mdata, layer_mod="rna")
-
-    adata = synthetic_iid()
-    mdata = mudata.MuData({"rna": adata})
-    with pytest.raises(ValueError):
-        generic_setup_mudata_manager(mdata[1], layer_mod="rna")
-
-    # test that error is thrown if an anndata is passed in:
-    adata = synthetic_iid()
-    with pytest.raises(AssertionError):
-        generic_setup_mudata_manager(adata, layer_mod="rna")
-
-    # test that layer is working properly
-    adata = synthetic_iid()
-    true_x = adata.X
-    adata.layers["X"] = true_x
-    adata.X = np.ones_like(adata.X)
-    mdata = mudata.MuData({"rna": adata})
-    adata_manager = generic_setup_mudata_manager(mdata, layer_mod="rna", layer="X")
-    np.testing.assert_array_equal(
-        adata_manager.get_from_registry(REGISTRY_KEYS.X_KEY), true_x
-    )
-
-    # test that it creates batch if no layers_key is passed
-    adata = synthetic_iid()
-    mdata = mudata.MuData({"rna": adata})
-    adata_manager = generic_setup_mudata_manager(
-        mdata, layer_mod="rna", batch_mod="rna"
-    )
-    np.testing.assert_array_equal(
-        adata_manager.get_from_registry(REGISTRY_KEYS.BATCH_KEY),
-        np.zeros((adata.shape[0], 1)),
-    )
-    np.testing.assert_array_equal(
-        adata_manager.get_from_registry(REGISTRY_KEYS.BATCH_KEY),
-        adata.obs["_scvi_batch"].to_numpy().reshape(-1, 1),
-    )
-
-    # test error is thrown when categorical obs field contains nans
-    adata = synthetic_iid()
-    adata.obs["batch"][:10] = np.nan
-    mdata = mudata.MuData({"rna": adata})
-    with pytest.raises(ValueError):
-        generic_setup_mudata_manager(
-            mdata, layer_mod="rna", batch_mod="rna", batch_key="batch"
-        )
-
-
-def test_save_setup_mudata(save_path):
-    adata = synthetic_iid()
-    mdata = mudata.MuData({"rna": adata})
-    generic_setup_mudata_manager(
-        mdata,
-        layer_mod="rna",
-        batch_mod="rna",
-        batch_key="batch",
-    )
-    temp_path = os.path.join(save_path, "test.h5mu")
-    mdata.write(temp_path)
-    mudata.read(temp_path)
 
 
 def test_view_registry():

--- a/tests/dataset/test_mudata.py
+++ b/tests/dataset/test_mudata.py
@@ -256,7 +256,7 @@ def test_transfer_fields_diff_batch_mapping():
     adata2.X = adata1.X
     protein_adata2 = synthetic_iid()
     mdata2 = mudata.MuData({"rna": adata2, "protein": protein_adata2})
-    adata2.obs["labels"] = ["batch_1"] * adata2.n_obs
+    adata2.obs["batch"] = ["batch_1"] * adata2.n_obs
     adata1_manager = generic_setup_mudata_manager(
         mdata1, layer_mod="rna", batch_mod="rna", batch_key="batch"
     )
@@ -264,6 +264,7 @@ def test_transfer_fields_diff_batch_mapping():
     batch_mapping = adata1_manager.get_state_registry(
         REGISTRY_KEYS.BATCH_KEY
     ).categorical_mapping
+    print(batch_mapping)
     correct_batch = np.where(batch_mapping == "batch_1")[0][0]
     assert adata2.obs["_scvi_batch"][0] == correct_batch
 

--- a/tests/dataset/utils.py
+++ b/tests/dataset/utils.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 
 import torch
 from anndata import AnnData
+from mudata import MuData
 
 from scvi import REGISTRY_KEYS
 from scvi.data import AnnDataManager
@@ -11,6 +12,7 @@ from scvi.data.fields import (
     CategoricalObsField,
     LabelsWithUnlabeledObsField,
     LayerField,
+    MuDataLayerField,
     NumericalJointObsField,
     ProteinObsmField,
 )
@@ -93,3 +95,24 @@ def scanvi_setup_adata_manager(
     )
     adata_manager.register_fields(adata)
     return adata_manager
+
+
+def generic_setup_mudata_manager(
+    mdata: MuData,
+    layer: Optional[str] = None,
+    layer_mod: Optional[str] = None,
+) -> AnnDataManager:
+    setup_args = locals()
+    setup_args.pop("mdata")
+    setup_method_args = {_MODEL_NAME_KEY: "TestModel", _SETUP_ARGS_KEY: setup_args}
+
+    anndata_fields = [
+        MuDataLayerField(
+            REGISTRY_KEYS.X_KEY, layer, mod_key=layer_mod, is_count_data=True
+        ),
+    ]
+    mdata_manager = AnnDataManager(
+        fields=anndata_fields, setup_method_args=setup_method_args
+    )
+    mdata_manager.register_fields(mdata)
+    return mdata_manager

--- a/tests/dataset/utils.py
+++ b/tests/dataset/utils.py
@@ -12,9 +12,11 @@ from scvi.data.fields import (
     CategoricalObsField,
     LabelsWithUnlabeledObsField,
     LayerField,
-    MuDataLayerField,
     NumericalJointObsField,
     ProteinObsmField,
+    MuDataLayerField,
+    MuDataCategoricalObsField,
+    MuDataProteinLayerField,
 )
 from scvi.model import SCVI
 
@@ -63,7 +65,7 @@ def generic_setup_adata_manager(
                 REGISTRY_KEYS.PROTEIN_EXP_KEY,
                 protein_expression_obsm_key,
                 use_batch_mask=True,
-                batch_key=batch_field.attr_key,
+                batch_field=batch_field,
                 colnames_uns_key=protein_names_uns_key,
                 is_count_data=True,
             )
@@ -99,16 +101,31 @@ def scanvi_setup_adata_manager(
 
 def generic_setup_mudata_manager(
     mdata: MuData,
-    layer: Optional[str] = None,
     layer_mod: Optional[str] = None,
+    layer: Optional[str] = None,
+    batch_mod: Optional[str] = None,
+    batch_key: Optional[str] = None,
+    protein_expression_mod: Optional[str] = None,
+    protein_expression_layer: Optional[str] = None,
 ) -> AnnDataManager:
     setup_args = locals()
     setup_args.pop("mdata")
     setup_method_args = {_MODEL_NAME_KEY: "TestModel", _SETUP_ARGS_KEY: setup_args}
 
+    batch_field = MuDataCategoricalObsField(
+        REGISTRY_KEYS.BATCH_KEY, batch_key, mod_key=batch_mod
+    )
     anndata_fields = [
         MuDataLayerField(
             REGISTRY_KEYS.X_KEY, layer, mod_key=layer_mod, is_count_data=True
+        ),
+        batch_field,
+        MuDataProteinLayerField(
+            REGISTRY_KEYS.PROTEIN_EXP_KEY,
+            protein_expression_layer,
+            mod_key=protein_expression_mod,
+            use_batch_mask=True,
+            batch_field=batch_field,
         ),
     ]
     mdata_manager = AnnDataManager(

--- a/tests/dataset/utils.py
+++ b/tests/dataset/utils.py
@@ -101,7 +101,7 @@ def scanvi_setup_adata_manager(
 
 def generic_setup_mudata_manager(
     mdata: MuData,
-    layer_mod: Optional[str] = None,
+    layer_mod,
     layer: Optional[str] = None,
     batch_mod: Optional[str] = None,
     batch_key: Optional[str] = None,
@@ -117,17 +117,25 @@ def generic_setup_mudata_manager(
     )
     anndata_fields = [
         MuDataLayerField(
-            REGISTRY_KEYS.X_KEY, layer, mod_key=layer_mod, is_count_data=True
+            REGISTRY_KEYS.X_KEY,
+            layer,
+            mod_key=layer_mod,
+            is_count_data=True,
+            mod_required=True,
         ),
         batch_field,
-        MuDataProteinLayerField(
-            REGISTRY_KEYS.PROTEIN_EXP_KEY,
-            protein_expression_layer,
-            mod_key=protein_expression_mod,
-            use_batch_mask=True,
-            batch_field=batch_field,
-        ),
     ]
+    if protein_expression_mod is not None:
+        anndata_fields.append(
+            MuDataProteinLayerField(
+                REGISTRY_KEYS.PROTEIN_EXP_KEY,
+                protein_expression_layer,
+                mod_key=protein_expression_mod,
+                mod_required=True,
+                use_batch_mask=True,
+                batch_field=batch_field,
+            )
+        )
     mdata_manager = AnnDataManager(
         fields=anndata_fields, setup_method_args=setup_method_args
     )

--- a/tests/dataset/utils.py
+++ b/tests/dataset/utils.py
@@ -12,11 +12,11 @@ from scvi.data.fields import (
     CategoricalObsField,
     LabelsWithUnlabeledObsField,
     LayerField,
+    MuDataCategoricalObsField,
+    MuDataLayerField,
+    MuDataProteinLayerField,
     NumericalJointObsField,
     ProteinObsmField,
-    MuDataLayerField,
-    MuDataCategoricalObsField,
-    MuDataProteinLayerField,
 )
 from scvi.model import SCVI
 

--- a/tests/dataset/utils.py
+++ b/tests/dataset/utils.py
@@ -12,8 +12,10 @@ from scvi.data.fields import (
     CategoricalObsField,
     LabelsWithUnlabeledObsField,
     LayerField,
+    MuDataCategoricalJointObsField,
     MuDataCategoricalObsField,
     MuDataLayerField,
+    MuDataNumericalJointObsField,
     MuDataProteinLayerField,
     NumericalJointObsField,
     ProteinObsmField,
@@ -105,6 +107,10 @@ def generic_setup_mudata_manager(
     layer: Optional[str] = None,
     batch_mod: Optional[str] = None,
     batch_key: Optional[str] = None,
+    categorical_covariate_mod: Optional[str] = None,
+    categorical_covariate_keys: Optional[List[str]] = None,
+    continuous_covariate_mod: Optional[str] = None,
+    continuous_covariate_keys: Optional[List[str]] = None,
     protein_expression_mod: Optional[str] = None,
     protein_expression_layer: Optional[str] = None,
 ) -> AnnDataManager:
@@ -124,6 +130,16 @@ def generic_setup_mudata_manager(
             mod_required=True,
         ),
         batch_field,
+        MuDataCategoricalJointObsField(
+            REGISTRY_KEYS.CAT_COVS_KEY,
+            categorical_covariate_keys,
+            mod_key=categorical_covariate_mod,
+        ),
+        MuDataNumericalJointObsField(
+            REGISTRY_KEYS.CONT_COVS_KEY,
+            continuous_covariate_keys,
+            mod_key=continuous_covariate_mod,
+        ),
     ]
     if protein_expression_mod is not None:
         anndata_fields.append(

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -533,6 +533,24 @@ def test_saving_and_loading(save_path):
     m.train(1)
 
 
+def assert_dict_is_subset(d1, d2):
+    if type(d1) != dict:
+        raise AssertionError(f"{d1} is not a dictionary.")
+    elif type(d2) != dict:
+        raise AssertionError(f"{d2} is not a dictionary.")
+
+    for k, v in d1.items():
+        if k not in d2:
+            raise AssertionError(f"{k} missing from {d2}.")
+        v2 = d2[k]
+        if type(v) == dict:
+            assert_dict_is_subset(v, v2)
+        elif type(v) == np.ndarray:
+            np.testing.assert_array_equal(v, v2)
+        elif v != v2:
+            raise AssertionError(f"Mismatch between {v} and {v2}.")
+
+
 def test_new_setup_compat():
     adata = synthetic_iid()
     adata.obs["cat1"] = np.random.randint(0, 5, size=(adata.shape[0],))
@@ -563,9 +581,9 @@ def test_new_setup_compat():
 
     # Backwards compatibility test.
     registry = registry_from_setup_dict(SCVI, LEGACY_SETUP_DICT)
-    np.testing.assert_equal(
-        field_registries_legacy_subset,
+    assert_dict_is_subset(
         registry[_constants._FIELD_REGISTRIES_KEY],
+        field_registries_legacy_subset,
     )
 
     # Test transfer.

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -534,18 +534,18 @@ def test_saving_and_loading(save_path):
 
 
 def assert_dict_is_subset(d1, d2):
-    if type(d1) != dict:
+    if not isinstance(d1, dict):
         raise AssertionError(f"{d1} is not a dictionary.")
-    elif type(d2) != dict:
+    elif not isinstance(d2, dict):
         raise AssertionError(f"{d2} is not a dictionary.")
 
     for k, v in d1.items():
         if k not in d2:
             raise AssertionError(f"{k} missing from {d2}.")
         v2 = d2[k]
-        if type(v) == dict:
+        if isinstance(v, dict):
             assert_dict_is_subset(v, v2)
-        elif type(v) == np.ndarray:
+        elif isinstance(v, np.ndarray):
             np.testing.assert_array_equal(v, v2)
         elif v != v2:
             raise AssertionError(f"Mismatch between {v} and {v2}.")

--- a/tests/models/test_mudata_models.py
+++ b/tests/models/test_mudata_models.py
@@ -1,1 +1,242 @@
-# For TOTALVI and MULTVI
+import numpy as np
+import pytest
+from anndata import AnnData
+from mudata import MuData
+
+import scvi
+from scvi.data import synthetic_iid
+from scvi.model import TOTALVI
+
+
+def test_totalvi(save_path):
+    adata = synthetic_iid()
+    protein_adata = synthetic_iid(n_genes=50)
+    mdata = MuData({"rna": adata, "protein": protein_adata})
+    TOTALVI.setup_mudata(
+        mdata,
+        layer_mod="rna",
+        batch_mod="rna",
+        batch_key="batch",
+        protein_expression_mod="protein",
+    )
+
+    n_obs = mdata.n_obs
+    n_genes = adata.n_vars
+    n_proteins = protein_adata.X.shape[1]
+    n_latent = 10
+
+    model = TOTALVI(mdata, n_latent=n_latent)
+    model.train(1, train_size=0.5)
+    assert model.is_trained is True
+    z = model.get_latent_representation()
+    assert z.shape == (n_obs, n_latent)
+    model.get_elbo()
+    model.get_marginal_ll(n_mc_samples=3)
+    model.get_reconstruction_error()
+    model.get_normalized_expression()
+    model.get_normalized_expression(transform_batch=["batch_0", "batch_1"])
+    model.get_latent_library_size()
+    model.get_protein_foreground_probability()
+    model.get_protein_foreground_probability(transform_batch=["batch_0", "batch_1"])
+    post_pred = model.posterior_predictive_sample(n_samples=2)
+    assert post_pred.shape == (n_obs, n_genes + n_proteins, 2)
+    post_pred = model.posterior_predictive_sample(n_samples=1)
+    assert post_pred.shape == (n_obs, n_genes + n_proteins)
+    feature_correlation_matrix1 = model.get_feature_correlation_matrix(
+        correlation_type="spearman"
+    )
+    feature_correlation_matrix1 = model.get_feature_correlation_matrix(
+        correlation_type="spearman", transform_batch=["batch_0", "batch_1"]
+    )
+    feature_correlation_matrix2 = model.get_feature_correlation_matrix(
+        correlation_type="pearson"
+    )
+    assert feature_correlation_matrix1.shape == (
+        n_genes + n_proteins,
+        n_genes + n_proteins,
+    )
+    assert feature_correlation_matrix2.shape == (
+        n_genes + n_proteins,
+        n_genes + n_proteins,
+    )
+
+    model.get_elbo(indices=model.validation_indices)
+    model.get_marginal_ll(indices=model.validation_indices, n_mc_samples=3)
+    model.get_reconstruction_error(indices=model.validation_indices)
+
+    adata2 = synthetic_iid()
+    protein_adata2 = synthetic_iid(n_genes=50)
+    mdata2 = MuData({"rna": adata, "protein": protein_adata})
+    TOTALVI.setup_mudata(
+        mdata2,
+        layer_mod="rna",
+        batch_mod="rna",
+        batch_key="batch",
+        protein_expression_mod="protein",
+    )
+    norm_exp = model.get_normalized_expression(mdata2, indices=[1, 2, 3])
+    assert norm_exp[0].shape == (3, adata2.n_vars)
+    assert norm_exp[1].shape == (3, protein_adata2.n_vars)
+    norm_exp = model.get_normalized_expression(
+        mdata2,
+        gene_list=adata2.var_names[:5].to_list(),
+        protein_list=protein_adata2.var_names[:3].to_list(),
+        transform_batch=["batch_0", "batch_1"],
+    )
+
+    latent_lib_size = model.get_latent_library_size(mdata2, indices=[1, 2, 3])
+    assert latent_lib_size.shape == (3, 1)
+
+    pro_foreground_prob = model.get_protein_foreground_probability(
+        mdata2, indices=[1, 2, 3], protein_list=["1", "2"]
+    )
+    assert pro_foreground_prob.shape == (3, 2)
+    model.posterior_predictive_sample(mdata2)
+    model.get_feature_correlation_matrix(mdata2)
+
+    # test transfer_anndata_setup + view
+    adata2 = synthetic_iid()
+    protein_adata2 = synthetic_iid(n_genes=50)
+    mdata2 = MuData({"rna": adata2, "protein": protein_adata2})
+    model.get_elbo(mdata2[:10])
+
+
+def test_totalvi_auto_transfer(save_path):
+    # test automatic transfer_fields
+    adata = synthetic_iid()
+    protein_adata = synthetic_iid(n_genes=50)
+    mdata = MuData({"rna": adata, "protein": protein_adata})
+    TOTALVI.setup_mudata(
+        mdata,
+        layer_mod="rna",
+        batch_mod="rna",
+        batch_key="batch",
+        protein_expression_mod="protein",
+    )
+    model = TOTALVI(mdata)
+    adata2 = synthetic_iid()
+    protein_adata2 = synthetic_iid(n_genes=50)
+    mdata2 = MuData({"rna": adata2, "protein": protein_adata2})
+    model.get_elbo(mdata2)
+
+
+def test_totalvi_incorrect_mapping(save_path):
+    # test that we catch incorrect mappings
+    adata = synthetic_iid()
+    protein_adata = synthetic_iid(n_genes=50)
+    mdata = MuData({"rna": adata, "protein": protein_adata})
+    TOTALVI.setup_mudata(
+        mdata,
+        layer_mod="rna",
+        batch_mod="rna",
+        batch_key="batch",
+        protein_expression_mod="protein",
+    )
+    model = TOTALVI(mdata)
+    adata2 = synthetic_iid()
+    protein_adata2 = synthetic_iid(n_genes=50)
+    mdata2 = MuData({"rna": adata2, "protein": protein_adata2})
+    adata2.obs.batch.cat.rename_categories(["batch_0", "batch_10"], inplace=True)
+    with pytest.raises(ValueError):
+        model.get_elbo(mdata2)
+
+
+def test_totalvi_reordered_mapping(save_path):
+    # test that same mapping different order is okay
+    adata = synthetic_iid()
+    protein_adata = synthetic_iid(n_genes=50)
+    mdata = MuData({"rna": adata, "protein": protein_adata})
+    TOTALVI.setup_mudata(
+        mdata,
+        layer_mod="rna",
+        batch_mod="rna",
+        batch_key="batch",
+        protein_expression_mod="protein",
+    )
+    model = TOTALVI(mdata)
+    adata2 = synthetic_iid()
+    protein_adata2 = synthetic_iid(n_genes=50)
+    mdata2 = MuData({"rna": adata2, "protein": protein_adata2})
+    adata2.obs.batch.cat.rename_categories(["batch_1", "batch_0"], inplace=True)
+    model.get_elbo(mdata2)
+
+
+def test_totalvi_missing_proteins(save_path):
+    # test with missing proteins
+    adata = scvi.data.pbmcs_10x_cite_seq(
+        save_path=save_path,
+        protein_join="outer",
+    )
+    protein_adata = AnnData(adata.obsm["protein_expression"])
+    mdata = MuData({"rna": adata, "protein": protein_adata})
+    TOTALVI.setup_mudata(
+        mdata,
+        layer_mod="rna",
+        batch_mod="rna",
+        batch_key="batch",
+        protein_expression_mod="protein",
+    )
+    model = TOTALVI(mdata)
+    assert model.module.protein_batch_mask is not None
+    model.train(1, train_size=0.5)
+
+    model = TOTALVI(mdata, override_missing_proteins=True)
+    assert model.module.protein_batch_mask is None
+    model.train(1, train_size=0.5)
+
+
+def test_totalvi_model_library_size(save_path):
+    adata = synthetic_iid()
+    protein_adata = synthetic_iid(n_genes=50)
+    mdata = MuData({"rna": adata, "protein": protein_adata})
+    TOTALVI.setup_mudata(
+        mdata,
+        layer_mod="rna",
+        batch_mod="rna",
+        batch_key="batch",
+        protein_expression_mod="protein",
+    )
+
+    n_latent = 10
+    model = TOTALVI(mdata, n_latent=n_latent, use_observed_lib_size=False)
+    assert hasattr(model.module, "library_log_means") and hasattr(
+        model.module, "library_log_vars"
+    )
+    model.train(1, train_size=0.5)
+    assert model.is_trained is True
+    model.get_elbo()
+    model.get_marginal_ll(n_mc_samples=3)
+    model.get_latent_library_size()
+
+
+def test_totalvi_size_factor():
+    adata = synthetic_iid()
+    adata.obs["size_factor"] = np.random.randint(1, 5, size=(adata.shape[0],))
+    protein_adata = synthetic_iid(n_genes=50)
+    mdata = MuData({"rna": adata, "protein": protein_adata})
+    TOTALVI.setup_mudata(
+        mdata,
+        layer_mod="rna",
+        batch_mod="rna",
+        batch_key="batch",
+        protein_expression_mod="protein",
+        size_factor_mod="rna",
+        size_factor_key="size_factor",
+    )
+
+    n_latent = 10
+
+    # Test size_factor_key overrides use_observed_lib_size.
+    model = TOTALVI(mdata, n_latent=n_latent, use_observed_lib_size=False)
+    assert not hasattr(model.module, "library_log_means") and not hasattr(
+        model.module, "library_log_vars"
+    )
+    assert model.module.use_size_factor_key
+    model.train(1, train_size=0.5)
+
+    model = TOTALVI(mdata, n_latent=n_latent, use_observed_lib_size=True)
+    assert not hasattr(model.module, "library_log_means") and not hasattr(
+        model.module, "library_log_vars"
+    )
+    assert model.module.use_size_factor_key
+    model.train(1, train_size=0.5)

--- a/tests/models/test_mudata_models.py
+++ b/tests/models/test_mudata_models.py
@@ -16,10 +16,8 @@ def test_totalvi(save_path):
     mdata = MuData({"rna": adata, "protein": protein_adata})
     TOTALVI.setup_mudata(
         mdata,
-        layer_mod="rna",
-        batch_mod="rna",
         batch_key="batch",
-        protein_expression_mod="protein",
+        modalities=dict(rna_layer="rna", batch_key="rna", protein_layer="protein"),
     )
 
     n_obs = mdata.n_obs
@@ -71,10 +69,8 @@ def test_totalvi(save_path):
     mdata2 = MuData({"rna": adata, "protein": protein_adata})
     TOTALVI.setup_mudata(
         mdata2,
-        layer_mod="rna",
-        batch_mod="rna",
         batch_key="batch",
-        protein_expression_mod="protein",
+        modalities=dict(rna_layer="rna", batch_key="rna", protein_layer="protein"),
     )
     norm_exp = model.get_normalized_expression(mdata2, indices=[1, 2, 3])
     assert norm_exp[0].shape == (3, adata2.n_vars)
@@ -110,10 +106,8 @@ def test_totalvi_auto_transfer(save_path):
     mdata = MuData({"rna": adata, "protein": protein_adata})
     TOTALVI.setup_mudata(
         mdata,
-        layer_mod="rna",
-        batch_mod="rna",
         batch_key="batch",
-        protein_expression_mod="protein",
+        modalities=dict(rna_layer="rna", batch_key="rna", protein_layer="protein"),
     )
     model = TOTALVI(mdata)
     adata2 = synthetic_iid()
@@ -129,10 +123,8 @@ def test_totalvi_incorrect_mapping(save_path):
     mdata = MuData({"rna": adata, "protein": protein_adata})
     TOTALVI.setup_mudata(
         mdata,
-        layer_mod="rna",
-        batch_mod="rna",
         batch_key="batch",
-        protein_expression_mod="protein",
+        modalities=dict(rna_layer="rna", batch_key="rna", protein_layer="protein"),
     )
     model = TOTALVI(mdata)
     adata2 = synthetic_iid()
@@ -150,10 +142,8 @@ def test_totalvi_reordered_mapping(save_path):
     mdata = MuData({"rna": adata, "protein": protein_adata})
     TOTALVI.setup_mudata(
         mdata,
-        layer_mod="rna",
-        batch_mod="rna",
         batch_key="batch",
-        protein_expression_mod="protein",
+        modalities=dict(rna_layer="rna", batch_key="rna", protein_layer="protein"),
     )
     model = TOTALVI(mdata)
     adata2 = synthetic_iid()
@@ -173,10 +163,8 @@ def test_totalvi_missing_proteins(save_path):
     mdata = MuData({"rna": adata, "protein": protein_adata})
     TOTALVI.setup_mudata(
         mdata,
-        layer_mod="rna",
-        batch_mod="rna",
         batch_key="batch",
-        protein_expression_mod="protein",
+        modalities=dict(rna_layer="rna", batch_key="rna", protein_layer="protein"),
     )
     model = TOTALVI(mdata)
     assert model.module.protein_batch_mask is not None
@@ -193,10 +181,8 @@ def test_totalvi_model_library_size(save_path):
     mdata = MuData({"rna": adata, "protein": protein_adata})
     TOTALVI.setup_mudata(
         mdata,
-        layer_mod="rna",
-        batch_mod="rna",
         batch_key="batch",
-        protein_expression_mod="protein",
+        modalities=dict(rna_layer="rna", batch_key="rna", protein_layer="protein"),
     )
 
     n_latent = 10
@@ -218,12 +204,14 @@ def test_totalvi_size_factor():
     mdata = MuData({"rna": adata, "protein": protein_adata})
     TOTALVI.setup_mudata(
         mdata,
-        layer_mod="rna",
-        batch_mod="rna",
         batch_key="batch",
-        protein_expression_mod="protein",
-        size_factor_mod="rna",
         size_factor_key="size_factor",
+        modalities=dict(
+            rna_layer="rna",
+            batch_key="rna",
+            protein_layer="protein",
+            size_factor_key="rna",
+        ),
     )
 
     n_latent = 10
@@ -250,10 +238,8 @@ def test_totalvi_saving_and_loading(save_path):
     mdata = MuData({"rna": adata, "protein": protein_adata})
     TOTALVI.setup_mudata(
         mdata,
-        layer_mod="rna",
-        batch_mod="rna",
         batch_key="batch",
-        protein_expression_mod="protein",
+        modalities=dict(rna_layer="rna", batch_key="rna", protein_layer="protein"),
     )
     model = TOTALVI(mdata)
     model.train(1, train_size=0.2)
@@ -304,8 +290,6 @@ def test_totalvi_saving_and_loading(save_path):
     mdata2 = MuData({"rna": adata2, "protein": protein_adata2})
     TOTALVI.setup_mudata(
         mdata2,
-        layer_mod="rna",
-        batch_mod="rna",
         batch_key="batch",
-        protein_expression_mod="protein",
+        modalities=dict(rna_layer="rna", batch_key="rna", protein_layer="protein"),
     )

--- a/tests/models/test_mudata_models.py
+++ b/tests/models/test_mudata_models.py
@@ -1,0 +1,1 @@
+# For TOTALVI and MULTVI


### PR DESCRIPTION
This PR adds mudata support as an extension to AnnDataField classes. This is done using dynamic class generation via the `MuDataWrapper` function. As an initial test, `TOTALVI.setup_mudata` has been implemented and tested.