### PR TITLE
Allow additional arguments for SCVI encoder and decoder

### DIFF
--- a/scvi/module/_vae.py
+++ b/scvi/module/_vae.py
@@ -112,6 +112,8 @@ class VAE(BaseModuleClass):
         library_log_means: Optional[np.ndarray] = None,
         library_log_vars: Optional[np.ndarray] = None,
         var_activation: Optional[Callable] = None,
+        encoder_kwargs: dict = {},
+        decoder_kwargs: dict = {},
     ):
         super().__init__()
         self.dispersion = dispersion
@@ -177,6 +179,7 @@ class VAE(BaseModuleClass):
             use_batch_norm=use_batch_norm_encoder,
             use_layer_norm=use_layer_norm_encoder,
             var_activation=var_activation,
+            **encoder_kwargs
         )
         # l encoder goes from n_input-dimensional data to 1-d library size
         self.l_encoder = Encoder(
@@ -190,6 +193,7 @@ class VAE(BaseModuleClass):
             use_batch_norm=use_batch_norm_encoder,
             use_layer_norm=use_layer_norm_encoder,
             var_activation=var_activation,
+            **encoder_kwargs
         )
         # decoder goes from n_latent-dimensional space to n_input-d data
         n_input_decoder = n_latent + n_continuous_cov
@@ -203,6 +207,7 @@ class VAE(BaseModuleClass):
             use_batch_norm=use_batch_norm_decoder,
             use_layer_norm=use_layer_norm_decoder,
             scale_activation="softplus" if use_size_factor_key else "softmax",
+            **decoder_kwargs
         )
 
     def _get_inference_input(self, tensors):

--- a/scvi/module/_vae.py
+++ b/scvi/module/_vae.py
@@ -179,7 +179,7 @@ class VAE(BaseModuleClass):
             use_batch_norm=use_batch_norm_encoder,
             use_layer_norm=use_layer_norm_encoder,
             var_activation=var_activation,
-            **encoder_kwargs
+            **encoder_kwargs,
         )
         # l encoder goes from n_input-dimensional data to 1-d library size
         self.l_encoder = Encoder(
@@ -193,7 +193,7 @@ class VAE(BaseModuleClass):
             use_batch_norm=use_batch_norm_encoder,
             use_layer_norm=use_layer_norm_encoder,
             var_activation=var_activation,
-            **encoder_kwargs
+            **encoder_kwargs,
         )
         # decoder goes from n_latent-dimensional space to n_input-d data
         n_input_decoder = n_latent + n_continuous_cov
@@ -207,7 +207,7 @@ class VAE(BaseModuleClass):
             use_batch_norm=use_batch_norm_decoder,
             use_layer_norm=use_layer_norm_decoder,
             scale_activation="softplus" if use_size_factor_key else "softmax",
-            **decoder_kwargs
+            **decoder_kwargs,
         )
 
     def _get_inference_input(self, tensors):

--- a/scvi/nn/_base_components.py
+++ b/scvi/nn/_base_components.py
@@ -341,6 +341,7 @@ class DecoderSCVI(nn.Module):
         use_batch_norm: bool = False,
         use_layer_norm: bool = False,
         scale_activation: Literal["softmax", "softplus"] = "softmax",
+        **kwargs,
     ):
         super().__init__()
         self.px_decoder = FCLayers(
@@ -353,6 +354,7 @@ class DecoderSCVI(nn.Module):
             inject_covariates=inject_covariates,
             use_batch_norm=use_batch_norm,
             use_layer_norm=use_layer_norm,
+            **kwargs,
         )
 
         # mean gamma


### PR DESCRIPTION
related to https://github.com/scverse/scvi-tools/issues/1510

Allows to do this
`set_activation = dict(activation_fn=torch.nn.Softplus)`
`vae = scvi.model.SCVI(adata, encoder_kwargs=set_activation, decoder_kwargs=set_activation)`