### PR TITLE
scanvi scarches fixes

### DIFF
--- a/docs/release_notes/v0.16.1.md
+++ b/docs/release_notes/v0.16.1.md
@@ -1,4 +1,4 @@
-# New in 0.16.1 (2022-MM-DD)
+# New in 0.16.1 (2022-04-22)
 
 ## Changes
 
@@ -7,13 +7,17 @@
 
 ## Bug Fixes
 - Bug fixed in {class}`~scvi.model.SCANVI` where `self._labeled_indices` was being improperly set ([#1515]).
+- Fix issue where {class}`~scvi.model.SCANVI.load_query_data` would not properly add an obs column with the unlabeled category when the `labels_key` was not present in the query data.
+- Disable extension of categories for labels in {class}`~scvi.model.SCANVI.load_query_data` ([#1519]).
 
 ## Contributors
 
 - [@jjhong922]
 - [@adamgayoso]
 
-[#1505]: https://github.com/YosefLab/scvi-tools/pull/1515
+[#1515]: https://github.com/YosefLab/scvi-tools/pull/1515
+[#1519]: https://github.com/YosefLab/scvi-tools/pull/1519
+
 
 [@adamgayoso]: https://github.com/adamgayoso
 [@jjhong922]: https://github.com/jjhong922

--- a/scvi/data/fields/_scanvi.py
+++ b/scvi/data/fields/_scanvi.py
@@ -97,7 +97,7 @@ class LabelsWithUnlabeledObsField(CategoricalObsField):
             )
 
         transfer_state_registry = super().transfer_field(
-            state_registry, adata_target, **kwargs
+            state_registry, adata_target, extend_categories=False, **kwargs
         )
         mapping = transfer_state_registry[self.CATEGORICAL_MAPPING_KEY]
         return self._remap_unlabeled_to_final_category(adata_target, mapping)

--- a/scvi/data/fields/_scanvi.py
+++ b/scvi/data/fields/_scanvi.py
@@ -96,6 +96,10 @@ class LabelsWithUnlabeledObsField(CategoricalObsField):
                 self._original_attr_key,
             )
 
+        # don't extend labels for query data
+        ec = "extend_categories"
+        if ec in kwargs:
+            kwargs.pop(ec)
         transfer_state_registry = super().transfer_field(
             state_registry, adata_target, extend_categories=False, **kwargs
         )

--- a/scvi/data/fields/_scanvi.py
+++ b/scvi/data/fields/_scanvi.py
@@ -77,18 +77,17 @@ class LabelsWithUnlabeledObsField(CategoricalObsField):
         self,
         state_registry: dict,
         adata_target: AnnData,
-        extend_categories: bool = False,
         allow_missing_labels: bool = False,
         **kwargs,
     ) -> dict:
         if (
             allow_missing_labels
-            and self.attr_key is not None
-            and self.attr_key not in adata_target.obs
+            and self._original_attr_key is not None
+            and self._original_attr_key not in adata_target.obs
         ):
             # Fill in original .obs attribute with unlabeled_category values.
             warnings.warn(
-                f"Missing labels key {self.attr_key}. Filling in with unlabeled category {self._unlabeled_category}."
+                f"Missing labels key {self._original_attr_key}. Filling in with unlabeled category {self._unlabeled_category}."
             )
             _set_data_in_registry(
                 adata_target,
@@ -98,7 +97,7 @@ class LabelsWithUnlabeledObsField(CategoricalObsField):
             )
 
         transfer_state_registry = super().transfer_field(
-            state_registry, adata_target, extend_categories=extend_categories, **kwargs
+            state_registry, adata_target, **kwargs
         )
         mapping = transfer_state_registry[self.CATEGORICAL_MAPPING_KEY]
         return self._remap_unlabeled_to_final_category(adata_target, mapping)

--- a/tests/models/test_scarches.py
+++ b/tests/models/test_scarches.py
@@ -234,11 +234,7 @@ def test_scanvi_online_update(save_path):
     model.predict()
 
     # query has all missing labels and no labels key
-    adata2 = synthetic_iid()
-    adata2.obs["batch"] = adata2.obs.batch.cat.rename_categories(["batch_2", "batch_3"])
     del adata2.obs["labels"]
-    adata2.obs["cont1"] = np.random.normal(size=(adata2.shape[0],))
-    adata2.obs["cont2"] = np.random.normal(size=(adata2.shape[0],))
 
     model = SCANVI.load_query_data(adata2, dir_path, freeze_batchnorm_encoder=True)
     model.train(max_epochs=1)


### PR DESCRIPTION
1. `allow_missing_labels` wasn't working properly if `_scvi_labels` was in obs because it should be looking for the original attr key. This can occur if the query data was already used for `SCVI` but without a labels key in setup anndata
2. We should not allow extending the categories of labels (seeing labels in query that weren't in reference)