### PR TITLE
Create release.yml github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,9 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
+      # will use ref/SHA that triggered it
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,6 @@ jobs:
         with:
           poetry-version: 1.1.11
 
-      - name: Update PATH
-        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
-
       - name: Build project for distribution
         run: poetry build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,10 @@ jobs:
         with:
           python-version: "3.9"
 
-      - name: Install Poetry
-        run: python install-poetry.py -y
+      - name: Install poetry
+        uses: abatilo/actions-poetry@v2.0.0
+        with:
+          poetry-version: 1.1.11
 
       - name: Update PATH
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+
+      - name: Install Poetry
+        run: python install-poetry.py -y
+
+      - name: Update PATH
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Build project for distribution
+        run: poetry build
+
+      - name: Check Version
+        id: check-version
+        run: |
+          [[ "$(poetry version --short)" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+            || echo ::set-output name=prerelease::true
+
+      - name: Publish to PyPI
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
+        run: poetry publish


### PR DESCRIPTION
this came from https://github.com/python-poetry/poetry/blob/master/.github/workflows/release.yml

My token has been added to the secrets in the repo.

Since this action will initiate whenever a tag with name meeting `"*.*.*"` is met, I'm inclined to force everyone to use forks for all PRs. Only admins would have write permissions.