### PR TITLE
Pin pytorch lightning version >=1.6.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ pyro-ppl = ">=1.6.0"
 pytest = {version = ">=4.4", optional = true}
 python = ">=3.7,<4.0"
 python-igraph = {version = "*", optional = true}
-pytorch-lightning = "~1.6"
+pytorch-lightning = ">=1.6.4"
 rich = ">=9.1.0"
 scanpy = {version = ">=1.6", optional = true}
 scanpydoc = {version = ">=0.5", optional = true}


### PR DESCRIPTION
Previous versions cause issues on import due to #1551 