### PR TITLE
Backport PR #1555: update versions of pytorch lightning, jinja, sphinx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,13 +63,13 @@ pyro-ppl = ">=1.6.0"
 pytest = {version = ">=4.4", optional = true}
 python = ">=3.7,<4.0"
 python-igraph = {version = "*", optional = true}
-pytorch-lightning = "~1.5"
+pytorch-lightning = ">=1.6.4,<1.7.0"
 rich = ">=9.1.0"
 scanpy = {version = ">=1.6", optional = true}
 scanpydoc = {version = ">=0.5", optional = true}
 scikit-learn = ">=0.21.2"
 scikit-misc = {version = ">=0.1.3", optional = true}
-sphinx = {version = ">=4.1,<4.4", optional = true}
+sphinx = {version = ">=4.1", optional = true}
 sphinx-autodoc-typehints = {version = "*", optional = true}
 sphinx-design = {version = "*", optional = true}
 sphinx-gallery = {version = ">0.6", optional = true}
@@ -80,7 +80,6 @@ torch = ">=1.8.0"
 torchmetrics = ">=0.6.0"
 tqdm = ">=4.56.0"
 typing_extensions = {version = "*", python = "<3.8", optional = true}
-Jinja2 = {version = "<3.1.0", optional = true}
 
 [tool.poetry.extras]
 dev = ["black", "pytest", "flake8", "codecov", "scanpy", "loompy", "jupyter", "nbformat", "nbconvert", "pre-commit", "isort"]
@@ -88,7 +87,6 @@ docs = [
   "sphinx",
   "scanpydoc",
   "nbsphinx",
-  "Jinja2", # https://github.com/spatialaudio/nbsphinx/issues/641#issuecomment-1078061858
   "nbsphinx-link",
   "ipython",
   "furo",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ openpyxl = ">=3.0"
 optax = "*"
 pandas = ">=1.0"
 pre-commit = {version = ">=2.7.1", optional = true}
+protobuf = "<=3.20.1" # lightning not compatible with future version until after 1.6
 pymde = {version = "*", optional = true}
 pynndescent = {version = "*", optional = true}
 pyro-ppl = ">=1.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ pyro-ppl = ">=1.6.0"
 pytest = {version = ">=4.4", optional = true}
 python = ">=3.7,<4.0"
 python-igraph = {version = "*", optional = true}
-pytorch-lightning = ">=1.6.4,<1.7.0"
+pytorch-lightning = "~1.5"
 rich = ">=9.1.0"
 scanpy = {version = ">=1.6", optional = true}
 scanpydoc = {version = ">=0.5", optional = true}


### PR DESCRIPTION
Note that this backport changes the PR to keep pytorch lightning >1.5 and <=1.6, while adding the upper bound protobuf dependency that pytorch lightning added in 1.6.x