### PR TITLE
Fix Jax device management for minimal situations

### DIFF
--- a/docs/release_notes/v0.17.0.md
+++ b/docs/release_notes/v0.17.0.md
@@ -7,6 +7,7 @@
 - Major changes to Jax support for scvi-tools models to generalize beyond {class}`~scvi.model.JaxSCVI`. Support for Jax remains experimental and is subject to breaking changes:
     - Consistent module interface for Flax modules (Jax-backed) via {class}`~scvi.module.base.JaxModuleWrapper`, such that they are compatible with the existing {class}`~scvi.model.base.BaseModelClass` [#1506].
     - {class}`~scvi.train.JaxTrainingPlan` now leverages Pytorch Lightning to factor out Jax-specific training loop implementation [#1506].
+    - Enable basic device management in Jax-backed modules [#1585].
 
 # Minor changes
 - Add {meth}`~scvi.module.base.PyroBaseModuleClass.on_load` callback which is called on {meth}`~scvi.model.base.BaseModuleClass.load` prior to loading the module state dict [#1542].
@@ -29,6 +30,7 @@
 [#1542]: https://github.com/YosefLab/scvi-tools/pull/1542
 [#1548]: https://github.com/YosefLab/scvi-tools/pull/1548
 [#1575]: https://github.com/YosefLab/scvi-tools/pull/1575
+[#1585]: https://github.com/YosefLab/scvi-tools/pull/1585
 
 [@jjhong922]: https://github.com/jjhong922
 [@adamgayoso]: https://github.com/adamgayoso

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,11 @@ ipython = {version = ">=7.20", optional = true, python = ">=3.7"}
 ipywidgets = "*"
 isort = {version = ">=5.7", optional = true}
 jax = ">=0.3"
+jaxlib = "*"
 jupyter = {version = ">=1.0", optional = true}
 leidenalg = {version = "*", optional = true}
 loompy = {version = ">=3.0.6", optional = true}
-mudata = ">=0.1.2" 
+mudata = ">=0.1.2"
 myst-parser = {version = "*", optional = true}
 nbconvert = {version = ">=5.4.0", optional = true}
 nbformat = {version = ">=4.4.0", optional = true}

--- a/scvi/model/base/_jaxmixin.py
+++ b/scvi/model/base/_jaxmixin.py
@@ -1,3 +1,4 @@
+import warnings
 from asyncio.log import logger
 from typing import Optional
 
@@ -54,7 +55,12 @@ class JaxTrainingMixin:
             use_gpu=use_gpu,
             **trainer_kwargs,
         )
-        runner()
+        # Ignore Pytorch Lightning warnings for Jax workarounds.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", category=UserWarning, module=r"pytorch_lightning.*"
+            )
+            runner()
 
         self.is_trained_ = True
         self.module.eval()

--- a/scvi/model/base/_jaxmixin.py
+++ b/scvi/model/base/_jaxmixin.py
@@ -27,7 +27,7 @@ class JaxTrainingMixin:
             try:
                 self.module.to(jax.devices("gpu")[0])
             except RuntimeError:
-                logger.debug("No GPU available.")
+                logger.debug("No GPU available to Jax.")
 
         data_splitter = DataSplitter(
             self.adata_manager,

--- a/scvi/model/base/_jaxmixin.py
+++ b/scvi/model/base/_jaxmixin.py
@@ -27,6 +27,10 @@ class JaxTrainingMixin:
         if use_gpu is None or use_gpu is True:
             try:
                 self.module.to(jax.devices("gpu")[0])
+                logger.debug(
+                    "Jax module moved to GPU successfully. "
+                    "Note: Pytorch lightning will show GPU is not being used for the Trainer."
+                )
             except RuntimeError:
                 logger.debug("No GPU available to Jax.")
 
@@ -47,18 +51,18 @@ class JaxTrainingMixin:
             trainer_kwargs["callbacks"] = []
         trainer_kwargs["callbacks"].append(JaxModuleInit())
 
-        runner = TrainRunner(
-            self,
-            training_plan=self.training_plan,
-            data_splitter=data_splitter,
-            max_epochs=max_epochs,
-            use_gpu=use_gpu,
-            **trainer_kwargs,
-        )
         # Ignore Pytorch Lightning warnings for Jax workarounds.
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore", category=UserWarning, module=r"pytorch_lightning.*"
+            )
+            runner = TrainRunner(
+                self,
+                training_plan=self.training_plan,
+                data_splitter=data_splitter,
+                max_epochs=max_epochs,
+                use_gpu=use_gpu,
+                **trainer_kwargs,
             )
             runner()
 

--- a/scvi/model/base/_jaxmixin.py
+++ b/scvi/model/base/_jaxmixin.py
@@ -28,11 +28,16 @@ class JaxTrainingMixin:
             try:
                 self.module.to(jax.devices("gpu")[0])
                 logger.debug(
-                    "Jax module moved to GPU successfully. "
+                    "Jax module moved to GPU. "
                     "Note: Pytorch lightning will show GPU is not being used for the Trainer."
                 )
             except RuntimeError:
                 logger.debug("No GPU available to Jax.")
+        else:
+            cpu_device = jax.devices("cpu")[0]
+            if self.module.device is not cpu_device:
+                self.module.to(cpu_device)
+                logger.debug("Jax module moved back to CPU. ")
 
         data_splitter = DataSplitter(
             self.adata_manager,

--- a/scvi/model/base/_jaxmixin.py
+++ b/scvi/model/base/_jaxmixin.py
@@ -1,5 +1,5 @@
+import logging
 import warnings
-from asyncio.log import logger
 from typing import Optional
 
 import jax
@@ -7,6 +7,8 @@ import numpy as np
 
 from scvi.dataloaders import DataSplitter
 from scvi.train import JaxModuleInit, JaxTrainingPlan, TrainRunner
+
+logger = logging.getLogger(__name__)
 
 
 class JaxTrainingMixin:
@@ -35,9 +37,8 @@ class JaxTrainingMixin:
                 logger.debug("No GPU available to Jax.")
         else:
             cpu_device = jax.devices("cpu")[0]
-            if self.module.device is not cpu_device:
-                self.module.to(cpu_device)
-                logger.debug("Jax module moved back to CPU. ")
+            self.module.to(cpu_device)
+            logger.debug("Jax module moved to CPU.")
 
         data_splitter = DataSplitter(
             self.adata_manager,

--- a/scvi/model/base/_jaxmixin.py
+++ b/scvi/model/base/_jaxmixin.py
@@ -51,7 +51,7 @@ class JaxTrainingMixin:
             training_plan=self.training_plan,
             data_splitter=data_splitter,
             max_epochs=max_epochs,
-            use_gpu=False,
+            use_gpu=use_gpu,
             **trainer_kwargs,
         )
         runner()

--- a/scvi/model/base/_jaxmixin.py
+++ b/scvi/model/base/_jaxmixin.py
@@ -66,7 +66,7 @@ class JaxTrainingMixin:
                 training_plan=self.training_plan,
                 data_splitter=data_splitter,
                 max_epochs=max_epochs,
-                use_gpu=use_gpu,
+                use_gpu=False,
                 **trainer_kwargs,
             )
             runner()

--- a/scvi/model/base/_jaxmixin.py
+++ b/scvi/model/base/_jaxmixin.py
@@ -29,7 +29,7 @@ class JaxTrainingMixin:
         if use_gpu is None or use_gpu is True:
             try:
                 self.module.to(jax.devices("gpu")[0])
-                logger.debug(
+                logger.info(
                     "Jax module moved to GPU. "
                     "Note: Pytorch lightning will show GPU is not being used for the Trainer."
                 )
@@ -38,7 +38,7 @@ class JaxTrainingMixin:
         else:
             cpu_device = jax.devices("cpu")[0]
             self.module.to(cpu_device)
-            logger.debug("Jax module moved to CPU.")
+            logger.info("Jax module moved to CPU.")
 
         data_splitter = DataSplitter(
             self.adata_manager,

--- a/scvi/model/base/_jaxmixin.py
+++ b/scvi/model/base/_jaxmixin.py
@@ -23,7 +23,7 @@ class JaxTrainingMixin:
             n_cells = self.adata.n_obs
             max_epochs = np.min([round((20000 / n_cells) * 400), 400])
 
-        if use_gpu is None:
+        if use_gpu is None or use_gpu is True:
             try:
                 self.module.to(jax.devices("gpu")[0])
             except RuntimeError:

--- a/scvi/module/base/_jax_module_wrapper.py
+++ b/scvi/module/base/_jax_module_wrapper.py
@@ -150,4 +150,5 @@ class JaxModuleWrapper:
         """Move module to device."""
         # TODO: move params and other state as well
         # TODO: be able to run device_get to get to CPU
+        self.seed_rng = jax.device_put(self.seed_rng, device)
         self._rngs = jax.device_put(self._rngs, device)

--- a/scvi/module/base/_jax_module_wrapper.py
+++ b/scvi/module/base/_jax_module_wrapper.py
@@ -6,7 +6,7 @@ import jax.numpy as jnp
 from flax.core import FrozenDict
 from flax.training import train_state
 from jax import random
-from jaxlib.xla_extension import CpuDevice, Device
+from jaxlib.xla_extension import Device
 
 from scvi.utils._jax import device_selecting_PRNGKey
 
@@ -149,5 +149,5 @@ class JaxModuleWrapper:
     def to(self, device: Device):
         """Move module to device."""
         # TODO: move params and other state as well
-        fn = jax.device_get if not isinstance(device, CpuDevice) else jax.device_put
-        self._rngs = fn(self._rngs, device)
+        # TODO: be able to run device_get to get to CPU
+        self._rngs = jax.device_put(self._rngs, device)

--- a/scvi/module/base/_jax_module_wrapper.py
+++ b/scvi/module/base/_jax_module_wrapper.py
@@ -151,7 +151,7 @@ class JaxModuleWrapper:
         # TODO: move params and other state as well
         # TODO: be able to run device_get to get to CPU
         if device is not self.device:
-            if self.train_state is None:
+            if self.train_state is not None:
                 raise NotImplementedError(
                     "Currently unable to move module across devices with an "
                     "existing train state."

--- a/scvi/module/base/_jax_module_wrapper.py
+++ b/scvi/module/base/_jax_module_wrapper.py
@@ -150,5 +150,12 @@ class JaxModuleWrapper:
         """Move module to device."""
         # TODO: move params and other state as well
         # TODO: be able to run device_get to get to CPU
-        self.seed_rng = jax.device_put(self.seed_rng, device)
-        self._rngs = jax.device_put(self._rngs, device)
+        if device is not self.device:
+            if self.train_state is None:
+                raise NotImplementedError(
+                    "Currently unable to move module across devices with an "
+                    "existing train state."
+                )
+
+            self.seed_rng = jax.device_put(self.seed_rng, device)
+            self._rngs = jax.device_put(self._rngs, device)

--- a/scvi/train/_trainingplans.py
+++ b/scvi/train/_trainingplans.py
@@ -4,6 +4,7 @@ from typing import Callable, Dict, Optional, Union
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 import optax
 import pyro
 import pytorch_lightning as pl
@@ -942,7 +943,7 @@ class JaxTrainingPlan(pl.LightningModule):
     @jax.jit
     def jit_training_step(
         state: TrainStateWithBatchNorm,
-        batch: Dict[str, jnp.ndarray],
+        batch: Dict[str, np.ndarray],
         rngs: Dict[str, jnp.ndarray],
         **kwargs,
     ):
@@ -995,7 +996,7 @@ class JaxTrainingPlan(pl.LightningModule):
     def jit_validation_step(
         self,
         state: TrainStateWithBatchNorm,
-        batch: Dict[str, jnp.ndarray],
+        batch: Dict[str, np.ndarray],
         rngs: Dict[str, jnp.ndarray],
         **kwargs,
     ):

--- a/scvi/train/_trainrunner.py
+++ b/scvi/train/_trainrunner.py
@@ -63,6 +63,7 @@ class TrainRunner:
         gpus, device = parse_use_gpu_arg(use_gpu)
         self.gpus = gpus
         self.device = device
+        print(gpus)
         self.trainer = Trainer(max_epochs=max_epochs, gpus=gpus, **trainer_kwargs)
 
     def __call__(self):

--- a/scvi/train/_trainrunner.py
+++ b/scvi/train/_trainrunner.py
@@ -63,7 +63,6 @@ class TrainRunner:
         gpus, device = parse_use_gpu_arg(use_gpu)
         self.gpus = gpus
         self.device = device
-        print(gpus)
         self.trainer = Trainer(max_epochs=max_epochs, gpus=gpus, **trainer_kwargs)
 
     def __call__(self):

--- a/scvi/utils/_jax.py
+++ b/scvi/utils/_jax.py
@@ -4,7 +4,7 @@ import jax
 from jax import random
 
 
-def device_selecting_PRNGKey(use_cpu: bool) -> Callable:
+def device_selecting_PRNGKey(use_cpu: bool = True) -> Callable:
     # if key is generated on CPU, model params will be on CPU
     # we have to pay the price of a JIT compilation though
     if use_cpu is True:

--- a/scvi/utils/_jax.py
+++ b/scvi/utils/_jax.py
@@ -4,10 +4,10 @@ import jax
 from jax import random
 
 
-def device_selecting_PRNGKey(use_gpu: bool) -> Callable:
+def device_selecting_PRNGKey(use_cpu: bool) -> Callable:
     # if key is generated on CPU, model params will be on CPU
     # we have to pay the price of a JIT compilation though
-    if use_gpu is False:
+    if use_cpu is True:
         key = jax.jit(lambda i: random.PRNGKey(i), backend="cpu")
     else:
         # dummy function


### PR DESCRIPTION
Properly move jax state to GPU when using `use_gpu=True` in `model.train()`. Still fails if attempting to move the module after having done some training. This will be addressed in #1553.

Tested in colab.