### PR TITLE
Set full state update to false in `ElboMetric`

### DIFF
--- a/scvi/train/_metrics.py
+++ b/scvi/train/_metrics.py
@@ -24,7 +24,9 @@ class ElboMetric(Metric):
         Keyword args for :class:`torchmetrics.Metric`
     """
 
-    full_state_update = True # Needs to be explicitly set to avoid TorchMetrics UserWarning.
+    full_state_update = (
+        True  # Needs to be explicitly set to avoid TorchMetrics UserWarning.
+    )
     _N_OBS_MINIBATCH_KEY = "n_obs_minibatch"
 
     def __init__(

--- a/scvi/train/_metrics.py
+++ b/scvi/train/_metrics.py
@@ -24,7 +24,7 @@ class ElboMetric(Metric):
         Keyword args for :class:`torchmetrics.Metric`
     """
 
-    full_state_update = True
+    full_state_update = True # Needs to be explicitly set to avoid TorchMetrics UserWarning.
     _N_OBS_MINIBATCH_KEY = "n_obs_minibatch"
 
     def __init__(

--- a/scvi/train/_metrics.py
+++ b/scvi/train/_metrics.py
@@ -24,6 +24,7 @@ class ElboMetric(Metric):
         Keyword args for :class:`torchmetrics.Metric`
     """
 
+    full_state_update = True
     _N_OBS_MINIBATCH_KEY = "n_obs_minibatch"
 
     def __init__(

--- a/scvi/train/_metrics.py
+++ b/scvi/train/_metrics.py
@@ -24,9 +24,8 @@ class ElboMetric(Metric):
         Keyword args for :class:`torchmetrics.Metric`
     """
 
-    full_state_update = (
-        True  # Needs to be explicitly set to avoid TorchMetrics UserWarning.
-    )
+    # Needs to be explicitly set to avoid TorchMetrics UserWarning.
+    full_state_update = True
     _N_OBS_MINIBATCH_KEY = "n_obs_minibatch"
 
     def __init__(


### PR DESCRIPTION
Removes warning from torchmetrics, checked with their util function `check_forward_full_state_property`