### PR TITLE
Fix `encode`/`decode` calls in JVAE by replacing them with `inference`/`generative` calls

### DIFF
--- a/tests/external/test_gimvi.py
+++ b/tests/external/test_gimvi.py
@@ -140,6 +140,7 @@ def test_gimvi():
     model.train(1, check_val_every_n_epoch=1, train_size=0.5)
     model.get_latent_representation()
     model.get_imputed_values()
+    model.get_imputed_values(normalized=False)
 
     adata_spatial.var_names += "asdf"
     GIMVI.setup_anndata(


### PR DESCRIPTION
Fixes #1588

For posterity: `encode` and `decode` functions were removed in [this](https://github.com/scverse/scvi-tools/commit/014ec33a9cd51bd6d9dd15fca4d8ef2b95d4f930) commit (but their call sites were not updated)