### PR TITLE
Add register_new_fields method to manager

### DIFF
--- a/scvi/data/_manager.py
+++ b/scvi/data/_manager.py
@@ -278,8 +278,7 @@ class AnnDataManager:
             of the setup method that will be used to update the existing values
             in the registry of this instance.
         """
-        if setup_method_args is not None:
-            self._registry[_constants._SETUP_ARGS_KEY].update(setup_method_args)
+        self._registry[_constants._SETUP_ARGS_KEY].update(setup_method_args)
 
     @property
     def adata_uuid(self) -> str:

--- a/scvi/data/_manager.py
+++ b/scvi/data/_manager.py
@@ -191,7 +191,8 @@ class AnnDataManager:
         self._assign_most_recent_manager_uuid()
 
     def register_new_fields(self, fields: List[AnnDataField]):
-        """Register new fields to a manager instance.
+        """
+        Register new fields to a manager instance.
 
         This is useful to augment the functionality of an existing manager.
 
@@ -267,7 +268,8 @@ class AnnDataManager:
             self.register_fields(adata, self._source_registry, **self._transfer_kwargs)
 
     def update_setup_method_args(self, setup_method_args: dict):
-        """Update setup method args.
+        """
+        Update setup method args.
 
         Parameters
         ----------

--- a/scvi/data/_manager.py
+++ b/scvi/data/_manager.py
@@ -230,7 +230,7 @@ class AnnDataManager:
         if self._source_registry is not None:
             self._source_registry = deepcopy(self._registry)
 
-        self.fields.append(fields)
+        self.fields += fields
 
     def transfer_fields(self, adata_target: AnnOrMuData, **kwargs) -> AnnDataManager:
         """

--- a/scvi/data/_manager.py
+++ b/scvi/data/_manager.py
@@ -206,6 +206,10 @@ class AnnDataManager:
             )
         field_registries = self._registry[_constants._FIELD_REGISTRIES_KEY]
         for field in fields:
+            if field.registry_key in field_registries:
+                raise ValueError(
+                    f"Registry key {field.registry_key} for field already taken."
+                )
             field_registries[field.registry_key] = {
                 _constants._DATA_REGISTRY_KEY: field.get_data_registry(),
                 _constants._STATE_REGISTRY_KEY: dict(),
@@ -225,6 +229,8 @@ class AnnDataManager:
         # However, with newly registered fields the equality breaks so we reset it
         if self._source_registry is not None:
             self._source_registry = deepcopy(self._registry)
+
+        self.fields.append(fields)
 
     def transfer_fields(self, adata_target: AnnOrMuData, **kwargs) -> AnnDataManager:
         """

--- a/scvi/data/_manager.py
+++ b/scvi/data/_manager.py
@@ -174,10 +174,6 @@ class AnnDataManager:
     ):
         """Internal function for adding a field with optional transferring."""
         field_registries = self._registry[_constants._FIELD_REGISTRIES_KEY]
-        if field.registry_key in field_registries:
-            raise ValueError(
-                f"Registry key {field.registry_key} for field already taken."
-            )
         field_registries[field.registry_key] = {
             _constants._DATA_REGISTRY_KEY: field.get_data_registry(),
             _constants._STATE_REGISTRY_KEY: dict(),

--- a/scvi/data/_manager.py
+++ b/scvi/data/_manager.py
@@ -148,38 +148,13 @@ class AnnDataManager:
             )
 
         self._validate_anndata_object(adata)
-        field_registries = self._registry[_constants._FIELD_REGISTRIES_KEY]
 
         for field in self.fields:
-            field_registries[field.registry_key] = {
-                _constants._DATA_REGISTRY_KEY: field.get_data_registry(),
-                _constants._STATE_REGISTRY_KEY: dict(),
-            }
-            field_registry = field_registries[field.registry_key]
-
-            # A field can be empty if the model has optional fields (e.g. extra covariates).
-            # If empty, we skip registering the field.
-            if not field.is_empty:
-                # Transfer case: Source registry is used for validation and/or setup.
-                if source_registry is not None:
-                    field_registry[
-                        _constants._STATE_REGISTRY_KEY
-                    ] = field.transfer_field(
-                        source_registry[_constants._FIELD_REGISTRIES_KEY][
-                            field.registry_key
-                        ][_constants._STATE_REGISTRY_KEY],
-                        adata,
-                        **transfer_kwargs,
-                    )
-                else:
-                    field_registry[
-                        _constants._STATE_REGISTRY_KEY
-                    ] = field.register_field(adata)
-
-            # Compute and set summary stats for the given field.
-            state_registry = field_registry[_constants._STATE_REGISTRY_KEY]
-            field_registry[_constants._SUMMARY_STATS_KEY] = field.get_summary_stats(
-                state_registry
+            self._add_field(
+                field=field,
+                adata=adata,
+                source_registry=source_registry,
+                **transfer_kwargs,
             )
 
         # Save arguments for register_fields.
@@ -189,6 +164,47 @@ class AnnDataManager:
         self.adata = adata
         self._assign_uuid()
         self._assign_most_recent_manager_uuid()
+
+    def _add_field(
+        self,
+        field: AnnDataField,
+        adata: AnnOrMuData,
+        source_registry: Optional[dict] = None,
+        **transfer_kwargs,
+    ):
+        """Internal function for adding a field with optional transferring."""
+        field_registries = self._registry[_constants._FIELD_REGISTRIES_KEY]
+        if field.registry_key in field_registries:
+            raise ValueError(
+                f"Registry key {field.registry_key} for field already taken."
+            )
+        field_registries[field.registry_key] = {
+            _constants._DATA_REGISTRY_KEY: field.get_data_registry(),
+            _constants._STATE_REGISTRY_KEY: dict(),
+        }
+        field_registry = field_registries[field.registry_key]
+
+        # A field can be empty if the model has optional fields (e.g. extra covariates).
+        # If empty, we skip registering the field.
+        if not field.is_empty:
+            # Transfer case: Source registry is used for validation and/or setup.
+            if source_registry is not None:
+                field_registry[_constants._STATE_REGISTRY_KEY] = field.transfer_field(
+                    source_registry[_constants._FIELD_REGISTRIES_KEY][
+                        field.registry_key
+                    ][_constants._STATE_REGISTRY_KEY],
+                    adata,
+                    **transfer_kwargs,
+                )
+            else:
+                field_registry[_constants._STATE_REGISTRY_KEY] = field.register_field(
+                    adata
+                )
+        # Compute and set summary stats for the given field.
+        state_registry = field_registry[_constants._STATE_REGISTRY_KEY]
+        field_registry[_constants._SUMMARY_STATS_KEY] = field.get_summary_stats(
+            state_registry
+        )
 
     def register_new_fields(self, fields: List[AnnDataField]):
         """
@@ -205,24 +221,11 @@ class AnnDataManager:
             raise AssertionError(
                 "No AnnData object has been registered with this Manager instance."
             )
-        field_registries = self._registry[_constants._FIELD_REGISTRIES_KEY]
+        self.validate()
         for field in fields:
-            if field.registry_key in field_registries:
-                raise ValueError(
-                    f"Registry key {field.registry_key} for field already taken."
-                )
-            field_registries[field.registry_key] = {
-                _constants._DATA_REGISTRY_KEY: field.get_data_registry(),
-                _constants._STATE_REGISTRY_KEY: dict(),
-            }
-            field_registry = field_registries[field.registry_key]
-            field_registry[_constants._STATE_REGISTRY_KEY] = field.register_field(
-                self.adata
-            )
-            # Compute and set summary stats for the given field.
-            state_registry = field_registry[_constants._STATE_REGISTRY_KEY]
-            field_registry[_constants._SUMMARY_STATS_KEY] = field.get_summary_stats(
-                state_registry
+            self._add_field(
+                field=field,
+                adata=self.adata,
             )
 
         # Source registry is not None if this manager was created from transfer_fields

--- a/scvi/data/_manager.py
+++ b/scvi/data/_manager.py
@@ -200,9 +200,9 @@ class AnnDataManager:
         fields
             List of AnnDataFields to register
         """
-        if self.adata is not None:
+        if self.adata is None:
             raise AssertionError(
-                "Existing AnnData object registered with this Manager instance."
+                "No AnnData object has been registered with this Manager instance."
             )
         field_registries = self._registry[_constants._FIELD_REGISTRIES_KEY]
         for field in fields:

--- a/tests/dataset/test_anndata.py
+++ b/tests/dataset/test_anndata.py
@@ -190,9 +190,6 @@ def test_register_new_fields(adata):
         )
     ]
     incremental_adata_manager.register_new_fields(new_fields)
-    with pytest.raises(ValueError):
-        incremental_adata_manager.register_new_fields(new_fields)
-
     adata_manager = generic_setup_adata_manager(
         adata, protein_expression_obsm_key="protein_expression"
     )


### PR DESCRIPTION
This allows updating an instance of an AnnDataManager with new fields (assuming it has already been registered with an AnnData object).

We will use this to help put models in latent mode, in which latent dists are cached in anndata and used in forward passes instead of encoding.