### PR TITLE
Faster inference in PyTorch with `torch.inference_mode`.

### DIFF
--- a/scvi/data/_preprocessing.py
+++ b/scvi/data/_preprocessing.py
@@ -13,7 +13,7 @@ from ._utils import _check_nonnegative_integers
 logger = logging.getLogger(__name__)
 
 
-@torch.no_grad()
+@torch.inference_mode()
 def poisson_gene_selection(
     adata,
     layer: Optional[str] = None,

--- a/scvi/distributions/_negative_binomial.py
+++ b/scvi/distributions/_negative_binomial.py
@@ -461,11 +461,11 @@ class ZeroInflatedNegativeBinomial(NegativeBinomial):
     def sample(
         self, sample_shape: Union[torch.Size, Tuple] = torch.Size()
     ) -> torch.Tensor:
-        with torch.no_grad():
+        with torch.inference_mode():
             samp = super().sample(sample_shape=sample_shape)
             is_zero = torch.rand_like(samp) <= self.zi_probs
-            samp[is_zero] = 0.0
-            return samp
+            samp_ = torch.where(is_zero, 0.0, samp)
+            return samp_
 
     def log_prob(self, value: torch.Tensor) -> torch.Tensor:
         try:
@@ -546,7 +546,7 @@ class NegativeBinomialMixture(Distribution):
     def sample(
         self, sample_shape: Union[torch.Size, Tuple] = torch.Size()
     ) -> torch.Tensor:
-        with torch.no_grad():
+        with torch.inference_mode():
             pi = self.mixture_probs
             mixing_sample = torch.distributions.Bernoulli(pi).sample()
             mu = self.mu1 * mixing_sample + self.mu2 * (1 - mixing_sample)

--- a/scvi/distributions/_negative_binomial.py
+++ b/scvi/distributions/_negative_binomial.py
@@ -346,7 +346,7 @@ class NegativeBinomial(Distribution):
     def sample(
         self, sample_shape: Union[torch.Size, Tuple] = torch.Size()
     ) -> torch.Tensor:
-        with torch.no_grad():
+        with torch.inference_mode():
             gamma_d = self._gamma()
             p_means = gamma_d.sample(sample_shape)
 

--- a/scvi/external/cellassign/_model.py
+++ b/scvi/external/cellassign/_model.py
@@ -112,7 +112,7 @@ class CellAssign(UnsupervisedTrainingMixin, BaseModelClass):
         )
         self.init_params_ = self._get_init_params(locals())
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def predict(self) -> pd.DataFrame:
         """Predict soft cell type assignment probability for each cell."""
         adata = self._validate_anndata(None)
@@ -270,6 +270,6 @@ class ClampCallback(Callback):
         super().__init__()
 
     def on_batch_end(self, trainer, pl_module):
-        with torch.no_grad():
+        with torch.inference_mode():
             pl_module.module.delta_log.clamp_(np.log(pl_module.module.min_delta))
         super().on_batch_end(trainer, pl_module)

--- a/scvi/external/cellassign/_module.py
+++ b/scvi/external/cellassign/_module.py
@@ -238,7 +238,7 @@ class CellAssignModule(BaseModuleClass):
             loss, q_per_cell, torch.zeros_like(q_per_cell), prior_log_prob
         )
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def sample(
         self,
         tensors,

--- a/scvi/external/gimvi/_model.py
+++ b/scvi/external/gimvi/_model.py
@@ -253,7 +253,7 @@ class GIMVI(VAEMixin, BaseModelClass):
 
         return post_list
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_latent_representation(
         self,
         adatas: List[AnnData] = None,
@@ -295,7 +295,7 @@ class GIMVI(VAEMixin, BaseModelClass):
 
         return latents
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_imputed_values(
         self,
         adatas: List[AnnData] = None,

--- a/scvi/external/solo/_model.py
+++ b/scvi/external/solo/_model.py
@@ -347,7 +347,7 @@ class SOLO(BaseModelClass):
         )
         return runner()
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def predict(
         self, soft: bool = True, include_simulated_doublets: bool = False
     ) -> pd.DataFrame:

--- a/scvi/external/stereoscope/_module.py
+++ b/scvi/external/stereoscope/_module.py
@@ -48,7 +48,7 @@ class RNADeconv(BaseModuleClass):
             ct_weight = torch.ones((self.n_labels,), dtype=torch.float32)
         self.register_buffer("ct_weight", ct_weight)
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_params(self) -> Tuple[np.ndarray]:
         """
         Returns the parameters for feeding into the spatial data.
@@ -110,7 +110,7 @@ class RNADeconv(BaseModuleClass):
 
         return LossRecorder(loss, reconst_loss, torch.zeros((1,)), torch.tensor(0.0))
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def sample(
         self,
         tensors,
@@ -161,7 +161,7 @@ class SpatialDeconv(BaseModuleClass):
         # additive gene bias
         self.beta = torch.nn.Parameter(0.01 * torch.randn(self.n_genes))
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_proportions(self, keep_noise=False) -> np.ndarray:
         """Returns the loadings."""
         # get estimated unadjusted proportions
@@ -238,7 +238,7 @@ class SpatialDeconv(BaseModuleClass):
             loss, reconst_loss, torch.zeros((1,)), neg_log_likelihood_prior
         )
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def sample(
         self,
         tensors,
@@ -247,7 +247,7 @@ class SpatialDeconv(BaseModuleClass):
     ):
         raise NotImplementedError("No sampling method for Stereoscope")
 
-    @torch.no_grad()
+    @torch.inference_mode()
     @auto_move_data
     def get_ct_specific_expression(self, y):
         """

--- a/scvi/model/_autozi.py
+++ b/scvi/model/_autozi.py
@@ -158,7 +158,7 @@ class AUTOZI(VAEMixin, UnsupervisedTrainingMixin, BaseModelClass):
         """Return parameters of Bernoulli Beta distributions in a dictionary."""
         return self.module.get_alphas_betas(as_numpy=as_numpy)
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_marginal_ll(
         self,
         adata: Optional[AnnData] = None,

--- a/scvi/model/_condscvi.py
+++ b/scvi/model/_condscvi.py
@@ -91,7 +91,7 @@ class CondSCVI(RNASeqMixin, VAEMixin, UnsupervisedTrainingMixin, BaseModelClass)
         ).format(n_hidden, n_latent, n_layers, dropout_rate, weight_obs)
         self.init_params_ = self._get_init_params(locals())
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_vamp_prior(
         self, adata: Optional[AnnData] = None, p: int = 10
     ) -> np.ndarray:

--- a/scvi/model/_multivi.py
+++ b/scvi/model/_multivi.py
@@ -291,7 +291,7 @@ class MULTIVI(VAEMixin, UnsupervisedTrainingMixin, BaseModelClass):
         )
         return runner()
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_library_size_factors(
         self,
         adata: Optional[AnnData] = None,
@@ -332,14 +332,14 @@ class MULTIVI(VAEMixin, UnsupervisedTrainingMixin, BaseModelClass):
             "accessibility": torch.cat(lib_acc).numpy().squeeze(),
         }
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_region_factors(self) -> np.ndarray:
         """Return region-specific factors."""
         if self.module.region_factors is None:
             raise RuntimeError("region factors were not included in this model")
         return torch.sigmoid(self.module.region_factors).cpu().numpy()
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_latent_representation(
         self,
         adata: Optional[AnnData] = None,
@@ -412,7 +412,7 @@ class MULTIVI(VAEMixin, UnsupervisedTrainingMixin, BaseModelClass):
             latent += [z.cpu()]
         return torch.cat(latent).numpy()
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_accessibility_estimates(
         self,
         adata: Optional[AnnData] = None,
@@ -530,7 +530,7 @@ class MULTIVI(VAEMixin, UnsupervisedTrainingMixin, BaseModelClass):
                 columns=adata.var_names[self.n_genes :][region_mask],
             )
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_normalized_expression(
         self,
         adata: Optional[AnnData] = None,

--- a/scvi/model/_peakvi.py
+++ b/scvi/model/_peakvi.py
@@ -243,7 +243,7 @@ class PEAKVI(ArchesMixin, VAEMixin, UnsupervisedTrainingMixin, BaseModelClass):
             **kwargs,
         )
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_library_size_factors(
         self,
         adata: Optional[AnnData] = None,
@@ -280,14 +280,14 @@ class PEAKVI(ArchesMixin, VAEMixin, UnsupervisedTrainingMixin, BaseModelClass):
 
         return torch.cat(library_sizes).numpy().squeeze()
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_region_factors(self):
         """Return region-specific factors."""
         if self.module.region_factors is None:
             raise RuntimeError("region factors were not included in this model")
         return torch.sigmoid(self.module.region_factors).cpu().numpy()
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_accessibility_estimates(
         self,
         adata: Optional[AnnData] = None,

--- a/scvi/model/_totalvi.py
+++ b/scvi/model/_totalvi.py
@@ -299,7 +299,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
         )
         return runner()
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_latent_library_size(
         self,
         adata: Optional[AnnData] = None,
@@ -343,7 +343,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
             libraries += [library.cpu()]
         return torch.cat(libraries).numpy()
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_normalized_expression(
         self,
         adata=None,
@@ -536,7 +536,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
         else:
             return scale_list_gene, scale_list_pro
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_protein_foreground_probability(
         self,
         adata: Optional[AnnData] = None,
@@ -777,7 +777,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
 
         return result
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def posterior_predictive_sample(
         self,
         adata: Optional[AnnData] = None,
@@ -849,7 +849,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
 
         return scdl_list
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def _get_denoised_samples(
         self,
         adata=None,
@@ -890,7 +890,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
 
             generative_kwargs = dict(transform_batch=transform_batch)
             inference_kwargs = dict(n_samples=n_samples)
-            with torch.no_grad():
+            with torch.inference_mode():
                 inference_outputs, generative_outputs, = self.module.forward(
                     tensors,
                     inference_kwargs=inference_kwargs,
@@ -931,7 +931,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
 
         return np.concatenate(scdl_list, axis=0)
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_feature_correlation_matrix(
         self,
         adata=None,
@@ -1023,7 +1023,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
         )
         return pd.DataFrame(corr_matrix, index=names, columns=names)
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_likelihood_parameters(
         self,
         adata: Optional[AnnData] = None,
@@ -1167,7 +1167,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
 
         return batch_avg_mus, batch_avg_scales
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_protein_background_mean(self, adata, indices, batch_size):
         adata = self._validate_anndata(adata)
         scdl = self._make_data_loader(

--- a/scvi/model/base/_archesmixin.py
+++ b/scvi/model/base/_archesmixin.py
@@ -252,7 +252,7 @@ def _set_params_online_update(
     if unfrozen:
         return
 
-    mod_no_grad = set(["encoder_z2_z1", "decoder_z1_z2"])
+    mod_inference_mode = set(["encoder_z2_z1", "decoder_z1_z2"])
     mod_no_hooks_yes_grad = set(["l_encoder"])
     if not freeze_classifier:
         mod_no_hooks_yes_grad.add("classifier")
@@ -266,7 +266,7 @@ def _set_params_online_update(
     def requires_grad(key):
         mod_name = key.split(".")[0]
         # linear weights and bias that need grad
-        one = "fc_layers" in key and ".0." in key and mod_name not in mod_no_grad
+        one = "fc_layers" in key and ".0." in key and mod_name not in mod_inference_mode
         # modules that need grad
         two = mod_name in mod_no_hooks_yes_grad
         three = sum([p in key for p in parameters_yes_grad]) > 0

--- a/scvi/model/base/_differential.py
+++ b/scvi/model/base/_differential.py
@@ -342,7 +342,7 @@ class DifferentialComputation:
 
         return res
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def scale_sampler(
         self,
         selection: Union[List[bool], np.ndarray],

--- a/scvi/model/base/_pyromixin.py
+++ b/scvi/model/base/_pyromixin.py
@@ -153,7 +153,7 @@ class PyroSampleMixin:
     Works using both minibatches and full data.
     """
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def _get_one_posterior_sample(
         self,
         args,

--- a/scvi/model/base/_rnamixin.py
+++ b/scvi/model/base/_rnamixin.py
@@ -32,7 +32,7 @@ class RNASeqMixin:
                 "Transforming batches is not implemented for this model."
             )
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_normalized_expression(
         self,
         adata: Optional[AnnData] = None,
@@ -228,7 +228,7 @@ class RNASeqMixin:
 
         return result
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def posterior_predictive_sample(
         self,
         adata: Optional[AnnData] = None,
@@ -289,7 +289,7 @@ class RNASeqMixin:
 
         return x_new.numpy()
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def _get_denoised_samples(
         self,
         adata: Optional[AnnData] = None,
@@ -367,7 +367,7 @@ class RNASeqMixin:
 
         return np.concatenate(data_loader_list, axis=0)
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_feature_correlation_matrix(
         self,
         adata: Optional[AnnData] = None,
@@ -446,7 +446,7 @@ class RNASeqMixin:
         var_names = adata.var_names
         return pd.DataFrame(corr_matrix, index=var_names, columns=var_names)
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_likelihood_parameters(
         self,
         adata: Optional[AnnData] = None,
@@ -522,7 +522,7 @@ class RNASeqMixin:
 
         return return_dict
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_latent_library_size(
         self,
         adata: Optional[AnnData] = None,

--- a/scvi/model/base/_vaemixin.py
+++ b/scvi/model/base/_vaemixin.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 class VAEMixin:
     """Univseral VAE methods."""
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_elbo(
         self,
         adata: Optional[AnnData] = None,
@@ -43,7 +43,7 @@ class VAEMixin:
         elbo = compute_elbo(self.module, scdl)
         return -elbo
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_marginal_ll(
         self,
         adata: Optional[AnnData] = None,
@@ -87,7 +87,7 @@ class VAEMixin:
         n_samples = len(indices)
         return log_lkl / n_samples
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_reconstruction_error(
         self,
         adata: Optional[AnnData] = None,
@@ -117,7 +117,7 @@ class VAEMixin:
         reconstruction_error = compute_reconstruction_error(self.module, scdl)
         return reconstruction_error
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_latent_representation(
         self,
         adata: Optional[AnnData] = None,

--- a/scvi/module/_amortizedlda.py
+++ b/scvi/module/_amortizedlda.py
@@ -313,7 +313,7 @@ class AmortizedLDAPyroModule(PyroBaseModuleClass):
         )
 
     @auto_move_data
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_topic_distribution(self, x: torch.Tensor, n_samples: int) -> torch.Tensor:
         """
         Converts `x` to its inferred topic distribution.
@@ -344,7 +344,7 @@ class AmortizedLDAPyroModule(PyroBaseModuleClass):
         )
 
     @auto_move_data
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_elbo(self, x: torch.Tensor, library: torch.Tensor, n_obs: int) -> float:
         """
         Computes ELBO.

--- a/scvi/module/_mrdeconv.py
+++ b/scvi/module/_mrdeconv.py
@@ -310,7 +310,7 @@ class MRDeconv(BaseModuleClass):
             loss, reconst_loss, neg_log_likelihood_prior, glo_neg_log_likelihood_prior
         )
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def sample(
         self,
         tensors,
@@ -319,7 +319,7 @@ class MRDeconv(BaseModuleClass):
     ):
         raise NotImplementedError("No sampling method for DestVI")
 
-    @torch.no_grad()
+    @torch.inference_mode()
     @auto_move_data
     def get_proportions(self, x=None, keep_noise=False) -> np.ndarray:
         """Returns the loadings."""
@@ -338,7 +338,7 @@ class MRDeconv(BaseModuleClass):
         res = res / res.sum(axis=1).reshape(-1, 1)
         return res
 
-    @torch.no_grad()
+    @torch.inference_mode()
     @auto_move_data
     def get_gamma(self, x: torch.Tensor = None) -> torch.Tensor:
         """
@@ -359,7 +359,7 @@ class MRDeconv(BaseModuleClass):
         else:
             return self.gamma.cpu().numpy()  # (n_latent, n_labels, n_spots)
 
-    @torch.no_grad()
+    @torch.inference_mode()
     @auto_move_data
     def get_ct_specific_expression(
         self, x: torch.Tensor = None, ind_x: torch.Tensor = None, y: int = None

--- a/scvi/module/_totalvae.py
+++ b/scvi/module/_totalvae.py
@@ -651,10 +651,10 @@ class TOTALVAE(BaseModuleClass):
 
         return LossRecorder(loss, reconst_losses, kl_local, kl_global=torch.tensor(0.0))
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def sample(self, tensors, n_samples=1):
         inference_kwargs = dict(n_samples=n_samples)
-        with torch.no_grad():
+        with torch.inference_mode():
             inference_outputs, generative_outputs, = self.forward(
                 tensors,
                 inference_kwargs=inference_kwargs,
@@ -676,7 +676,7 @@ class TOTALVAE(BaseModuleClass):
 
         return rna_sample, protein_sample
 
-    @torch.no_grad()
+    @torch.inference_mode()
     @auto_move_data
     def marginal_ll(self, tensors, n_mc_samples):
         x = tensors[REGISTRY_KEYS.X_KEY]

--- a/scvi/module/_vae.py
+++ b/scvi/module/_vae.py
@@ -426,7 +426,7 @@ class VAE(BaseModuleClass):
         kl_global = torch.tensor(0.0)
         return LossRecorder(loss, reconst_loss, kl_local, kl_global)
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def sample(
         self,
         tensors,
@@ -475,7 +475,7 @@ class VAE(BaseModuleClass):
 
         return exprs.cpu()
 
-    @torch.no_grad()
+    @torch.inference_mode()
     @auto_move_data
     def marginal_ll(self, tensors, n_mc_samples):
         sample_batch = tensors[REGISTRY_KEYS.X_KEY]
@@ -641,7 +641,7 @@ class LDVAE(VAE):
             bias=bias,
         )
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def get_loadings(self) -> np.ndarray:
         """Extract per-gene weights (for each Z, shape is genes by dim(Z)) in the linear decoder."""
         # This is BW, where B is diag(b) batch norm, W is weight matrix

--- a/scvi/module/_vaec.py
+++ b/scvi/module/_vaec.py
@@ -179,7 +179,7 @@ class VAEC(BaseModuleClass):
 
         return LossRecorder(loss, reconst_loss, kl_divergence_z, torch.tensor(0.0))
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def sample(
         self,
         tensors,

--- a/scvi/train/_trainingplans.py
+++ b/scvi/train/_trainingplans.py
@@ -264,7 +264,7 @@ class TrainingPlan(pl.LightningModule):
         """Passthrough to `model.forward()`."""
         return self.module(*args, **kwargs)
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def compute_and_log_metrics(
         self,
         loss_recorder: LossRecorder,


### PR DESCRIPTION
For the vast majority of cases, we can simply replace `torch.no_grad()` with `torch.inference_mode()` for speedup.  This mode reduces some of the overheads (version counting and metadata tracking) associated with `NoGrad`. Some notes:
- Tensors created during inference mode cannot be used in `Autograd` operations outside the mode, can be addressed by cloning the tensor
- Inference tensors cannot be modified in-place
- Higher speedups are more noticeable for smaller operations where overheads are relatively larger

Closes #1159.