### PR TITLE
Quick fix in poisson sample() function for vae

### DIFF
--- a/scvi/module/_vae.py
+++ b/scvi/module/_vae.py
@@ -461,7 +461,7 @@ class VAE(BaseModuleClass):
 
         dist = generative_outputs["px"]
         if self.gene_likelihood == "poisson":
-            l_train = generative_outputs["px"].mu
+            l_train = generative_outputs["px"].rate
             l_train = torch.clamp(l_train, max=1e8)
             dist = torch.distributions.Poisson(
                 l_train

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -362,6 +362,14 @@ def test_scvi(save_path):
     model = SCVI(adata, gene_likelihood="nb")
     model.get_likelihood_parameters()
 
+    # test different gene_likelihoods
+    for gene_likelihood in ["zinb", "nb", "poisson"]:
+        model = SCVI(adata, gene_likelihood=gene_likelihood)
+        model.train(1, check_val_every_n_epoch=1, train_size=0.5)
+        model.posterior_predictive_sample()
+        model.get_latent_representation()
+        model.get_normalized_expression()
+
     # test train callbacks work
     a = synthetic_iid()
     SCVI.setup_anndata(


### PR DESCRIPTION
Fixed poisson sampling in vae's sample() function, wrote test that would have caught it for the scvi model