### PR TITLE
Add "params" to default rngs for JaxBaseModuleClass

### DIFF
--- a/scvi/module/base/_base_module.py
+++ b/scvi/module/base/_base_module.py
@@ -457,7 +457,7 @@ class JaxBaseModuleClass(flax.linen.Module):
     @abstractmethod
     def required_rngs(self):
         """Returns a tuple of rng sequence names required for this Flax module."""
-        return tuple()
+        return ("params",)
 
     def __call__(
         self,


### PR DESCRIPTION
Fixes #1760 