### PR TITLE
fix issue with cuda compatibility on ZINB sampling

### DIFF
--- a/scvi/distributions/_negative_binomial.py
+++ b/scvi/distributions/_negative_binomial.py
@@ -471,7 +471,7 @@ class ZeroInflatedNegativeBinomial(NegativeBinomial):
         sample_shape = sample_shape or torch.Size()
         samp = super().sample(sample_shape=sample_shape)
         is_zero = torch.rand_like(samp) <= self.zi_probs
-        samp_ = torch.where(is_zero, torch.zeros(samp.shape, device=samp.device), samp)
+        samp_ = torch.where(is_zero, torch.zeros_like(samp), samp)
         return samp_
 
     def log_prob(self, value: torch.Tensor) -> torch.Tensor:

--- a/scvi/distributions/_negative_binomial.py
+++ b/scvi/distributions/_negative_binomial.py
@@ -471,7 +471,7 @@ class ZeroInflatedNegativeBinomial(NegativeBinomial):
         sample_shape = sample_shape or torch.Size()
         samp = super().sample(sample_shape=sample_shape)
         is_zero = torch.rand_like(samp) <= self.zi_probs
-        samp_ = torch.where(is_zero, 0.0, samp)
+        samp_ = torch.where(is_zero, torch.zeros(samp.shape, device=samp.device), samp)
         return samp_
 
     def log_prob(self, value: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Dear scVI developers,

I came across a small issue when using the "generative" part of an SCVI model (scvi.model.SCVI.module.generative), i.e.:

```
Traceback (most recent call last):
File "../sobolev_alignment/generate_artificial_sample.py", line 93, in generate_samples
    samples = dist_param_samples['px'].sample()
  File "../torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "../scvi/distributions/_negative_binomial.py", line 474, in sample
    samp_ = torch.where(is_zero, 0.0, samp)
RuntimeError: expected scalar type double but found float
```

The problematic code is the following (sorry for my routine's dependencies), where `batch_names_ids=None` and `cont_covs=None`.

```
z = torch.Tensor(np.random.normal(size=(int(sample_size), model.init_params_['non_kwargs']['n_latent'])))
dist_param_samples = model.module.generative(
        z=z,
        library=torch.Tensor(np.array(lib_size_samples).reshape(-1, 1)),
        batch_index=batch_name_ids,
        cont_covs=cont_covs
)

# Sample from distribution
samples = dist_param_samples['px'].sample()
```

I ran my code error-free on CPU (MacBook M1), but got this error when running on GPU (cuda 11.3), which suggested a device compatibility issue. I changed the one line that was problematic and it now runs for me. I submit the change as a pull request in case it might be of interest for you.

Best regards,
Soufiane