### PR TITLE
fix sparse backed data loading

### DIFF
--- a/scvi/dataloaders/_anntorchdataset.py
+++ b/scvi/dataloaders/_anntorchdataset.py
@@ -107,7 +107,7 @@ class AnnTorchDataset(Dataset):
                 cur_data, SparseDataset
             ):
                 sliced_data = cur_data[idx]
-                if issparse(cur_data):
+                if issparse(sliced_data):
                     sliced_data = sliced_data.toarray()
                 sliced_data = sliced_data.astype(dtype)
             elif isinstance(cur_data, np.ndarray):

--- a/tests/dataset/test_anndata.py
+++ b/tests/dataset/test_anndata.py
@@ -537,7 +537,8 @@ def test_backed_anndata(adata, save_path):
 
     # test get item
     bd = AnnTorchDataset(adata_manager)
-    bd[np.arange(adata.n_obs)]
+    subset = bd[np.arange(adata.n_obs)]
+    assert isinstance(subset["X"], np.ndarray)
 
 
 def test_backed_anndata_sparse(adata, save_path):
@@ -550,4 +551,5 @@ def test_backed_anndata_sparse(adata, save_path):
 
     # test get item
     bd = AnnTorchDataset(adata_manager)
-    bd[np.arange(adata.n_obs)]
+    subset = bd[np.arange(adata.n_obs)]
+    assert isinstance(subset["X"], np.ndarray)


### PR DESCRIPTION
Backed data currently doesn't work if X is sparse due to a minor bug.

I tested this and it works, with 1200 genes it's about twice as slow to load backed sparse. We can expose setting data loader num_workers to improve speed.