### PR TITLE
Downgrade sphinx-autodoc-typehints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ docs = [
   "nbsphinx",
   "ipython",
   "furo",
-  "sphinx-autodoc-typehints==1.21.3",
+  "sphinx-autodoc-typehints!=1.21.4",
   "sphinx_copybutton",
   "sphinx-design",
   "sphinxext-opengraph",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ docs = [
   "nbsphinx",
   "ipython",
   "furo",
-  "sphinx-autodoc-typehints",
+  "sphinx-autodoc-typehints==1.12.3",
   "sphinx_copybutton",
   "sphinx-design",
   "sphinxext-opengraph",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ docs = [
   "nbsphinx",
   "ipython",
   "furo",
-  "sphinx-autodoc-typehints==1.12.3",
+  "sphinx-autodoc-typehints==1.21.3",
   "sphinx_copybutton",
   "sphinx-design",
   "sphinxext-opengraph",


### PR DESCRIPTION
Temporary fix for docs build until https://github.com/tox-dev/sphinx-autodoc-typehints/issues/302 is addressed.