### PR TITLE
Change `add_dna_sequences` to use `get_seq`

### DIFF
--- a/docs/release_notes/v0.20.0.md
+++ b/docs/release_notes/v0.20.0.md
@@ -8,7 +8,7 @@
 -   {class}`~anndata.AnnData` `.var` and `.varm` attributes can now be registered through new fields in
     {mod}`~scvi.data.fields` {pr}`1830`,{pr}`1839`.
 -   {class}`~scvi.external.SCBASSET`, a reimplementation of the [original scBasset model], is available for
-    representation learning of scATAC-seq data (experimental) {pr}`1839`,{pr}`1844`.
+    representation learning of scATAC-seq data (experimental) {pr}`1839`,{pr}`1844`{pr}`1867`.
 -   {class}`~scvi.train.LowLevelPyroTrainingPlan` and {class}`~scvi.model.base.PyroModelGuideWarmup` added to allow the
     use of vanilla PyTorch optimization on Pyro models {pr}`1845`,{pr}`1847`.
 

--- a/scvi/data/_preprocessing.py
+++ b/scvi/data/_preprocessing.py
@@ -452,6 +452,7 @@ def add_dna_sequence(
             seq = str(g.get_seq(chrom, start, end)).upper()
             seqs.append(list(seq))
 
+        assert len(seqs) == len(chrom_df)
         seq_dfs.append(pd.DataFrame(seqs, index=chrom_df.index))
 
     sequence_df = pd.concat(seq_dfs, axis=0).loc[adata.var_names]

--- a/scvi/external/scbasset/_module.py
+++ b/scvi/external/scbasset/_module.py
@@ -34,14 +34,14 @@ class _Linear(nn.Linear):
             torch.nn.init.zeros_(self.bias)
 
 
-class _GELU(nn.GELU):
+class _GELU(nn.Module):
     """GELU unit approximated by a sigmoid, same as original."""
 
     def __init__(self):
         super().__init__()
 
     def forward(self, x: torch.Tensor):
-        return torch.nn.functional.sigmoid(1.702 * x) * x
+        return torch.sigmoid(1.702 * x) * x
 
 
 class _BatchNorm(nn.BatchNorm1d):


### PR DESCRIPTION
`add_dna_sequence` fails in some datasets such as the Buenrostro 2018 used in scBasset batch correction. See notebook: https://colab.research.google.com/drive/1cTkQqQGmbTAV7jtFiV5bK7sr7nD0g3rJ?usp=sharing. New code outputs the same dna sequence for the initial tutorial.