### PR TITLE
fix elbo metric global kl term used in logging

### DIFF
--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -9,6 +9,16 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
 
 ## Version 0.20
 
+
+### 0.20.1 (2023-MM-DD)
+
+#### Fixed
+
+-   Fixed computation of ELBO during training plan logging when using global kl terms [{pr}`1895`]
+ 
+
+
+
 ### New in 0.20.0 (2023-02-01)
 
 #### Major changes

--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -9,15 +9,11 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
 
 ## Version 0.20
 
-
 ### 0.20.1 (2023-MM-DD)
 
 #### Fixed
 
 -   Fixed computation of ELBO during training plan logging when using global kl terms [{pr}`1895`]
- 
-
-
 
 ### New in 0.20.0 (2023-02-01)
 

--- a/scvi/train/_trainingplans.py
+++ b/scvi/train/_trainingplans.py
@@ -201,7 +201,7 @@ class TrainingPlan(TunableMixin, pl.LightningModule):
         """Initialize ELBO metric and the metric collection."""
         rec_loss = ElboMetric("reconstruction_loss", mode, "obs")
         kl_local = ElboMetric("kl_local", mode, "obs")
-        kl_global = ElboMetric("kl_global", mode, "obs")
+        kl_global = ElboMetric("kl_global", mode, "batch")
         # n_total can be 0 if there is no validation set, this won't ever be used
         # in that case anyway
         n = 1 if n_total is None or n_total < 1 else n_total


### PR DESCRIPTION
in #1529 (released on v0.17.0) we introduced a bug where the kl term was not being averaged correctly.

Now it's being computed correctly `avg_obs_rec_loss + avg_obs_kl_local + 1/n_obs * avg_batch_kl_global`

In other words, rec loss and kl local are averaged over observations, and kl global is averaged over minibatches.