### PR TITLE
Fix Lightning callback hook 

### DIFF
--- a/scvi/train/_callbacks.py
+++ b/scvi/train/_callbacks.py
@@ -86,7 +86,7 @@ class SaveBestState(Callback):
     def check_monitor_top(self, current):  # noqa: D102
         return self.monitor_op(current, self.best_module_metric_val)
 
-    def on_val_epoch_end(self, trainer, pl_module):  # noqa: D102
+    def on_validation_epoch_end(self, trainer, pl_module):  # noqa: D102
         logs = trainer.callback_metrics
         self.epochs_since_last_check += 1
 


### PR DESCRIPTION
Closes #1912. Fixes a bug that was introduced in #1795 where one of the callback hooks was renamed. 