### PR TITLE
Remove setup anndata execution in spatial stereoscope `from_rna_model`

### DIFF
--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -14,6 +14,7 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
 #### Changed
 
 -   Use sphinx book theme for documentation {pr}`1673`
+-   Remove ability to set up ST data in {class}`~scvi.external.SpatialStereoscope.from_rna_model`, which was deprecated. ST data should be set up using {class}`~scvi.external.SpatialStereoscope.setup_anndata` {pr}`1949`.
 
 ## Version 0.20
 

--- a/scvi/external/stereoscope/_model.py
+++ b/scvi/external/stereoscope/_model.py
@@ -225,21 +225,6 @@ class SpatialStereoscope(UnsupervisedTrainingMixin, BaseModelClass):
         **model_kwargs
             Keyword args for :class:`~scvi.external.SpatialDeconv`
         """
-        if (
-            layer is not None
-            or st_adata.uns.get("_scvi_uuid")
-            not in SpatialStereoscope._setup_adata_manager_store
-        ):
-            warnings.warn(
-                """
-                    Setting up adata in SpatialStereoscope.from_rna_model is deprecated and
-                    will be removed in version 1.0.0. Please use SpatialStereoscope.setup_anndata
-                    before initializing model.
-                """,
-                category=DeprecationWarning,
-            )
-            cls.setup_anndata(st_adata, layer=layer)
-
         return cls(
             st_adata,
             sc_model.module.get_params(),

--- a/scvi/external/stereoscope/_model.py
+++ b/scvi/external/stereoscope/_model.py
@@ -205,7 +205,6 @@ class SpatialStereoscope(UnsupervisedTrainingMixin, BaseModelClass):
         st_adata: AnnData,
         sc_model: RNAStereoscope,
         prior_weight: Literal["n_obs", "minibatch"] = "n_obs",
-        layer: Optional[str] = None,
         **model_kwargs,
     ):
         """Alternate constructor for exploiting a pre-trained model on RNA-seq data.
@@ -219,8 +218,6 @@ class SpatialStereoscope(UnsupervisedTrainingMixin, BaseModelClass):
         prior_weight
             how to reweight the minibatches for stochastic optimization. "n_obs" is the valid
             procedure, "minibatch" is the procedure implemented in Stereoscope.
-        layer
-            if not `None`, uses this as the key in `adata.layers` for raw count data. Deprecated.
         **model_kwargs
             Keyword args for :class:`~scvi.external.SpatialDeconv`
         """

--- a/scvi/external/stereoscope/_model.py
+++ b/scvi/external/stereoscope/_model.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 from typing import Literal, Optional, Tuple, Union
 
 import numpy as np

--- a/tests/external/test_stereoscope.py
+++ b/tests/external/test_stereoscope.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from scvi.data import synthetic_iid
 from scvi.external import RNAStereoscope, SpatialStereoscope
@@ -24,14 +23,6 @@ def test_stereoscope(save_path):
     # test save/load
     sc_model.save(save_path, overwrite=True, save_anndata=True)
     sc_model = RNAStereoscope.load(save_path)
-
-    with pytest.warns(DeprecationWarning):
-        dataset = synthetic_iid(
-            n_labels=5,
-        )
-        st_model = SpatialStereoscope.from_rna_model(
-            dataset, sc_model, prior_weight="minibatch"
-        )
     dataset = synthetic_iid(
         n_labels=5,
     )


### PR DESCRIPTION
This removes what we deprecated in #1804 for the 1.0 release