### PR TITLE
Fix fdr gene tagging when integers in var names/obsm columns

### DIFF
--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -15,7 +15,6 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
 
 -   Use sphinx book theme for documentation {pr}`1673`
 
-
 ## Version 0.21
 
 ### 0.21.0 (2023-MM-DD)
@@ -23,7 +22,6 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
 #### Fixed
 
 -   Fix totalVI differential expression when integer sequential protein names are automatically used {pr}`1951`
-
 
 ## Version 0.20
 

--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -23,6 +23,7 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
 
 -   Fix `return_dist` docstring of {meth}`scvi.model.base.VAEMixin.get_latent_representation` {pr}`1932`.
 -   Fix hyperlink to pymde docs {pr}`1944`
+-   Fix totalVI differential expression when integer sequential protein names are automatically used {pr}`1951`
 
 #### Changed
 

--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -7,7 +7,7 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
-## Version 1.0
+## [Unreleased]
 
 ### 1.0.0 (2023-MM-DD)
 
@@ -15,15 +15,13 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
 
 -   Use sphinx book theme for documentation {pr}`1673`
 
-## Version 0.21
+## Version 0.20
 
-### 0.21.0 (2023-MM-DD)
+### 0.20.3 (2023-MM-DD)
 
 #### Fixed
 
 -   Fix totalVI differential expression when integer sequential protein names are automatically used {pr}`1951`
-
-## Version 0.20
 
 ### 0.20.2 (2023-03-10)
 

--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -15,6 +15,16 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
 
 -   Use sphinx book theme for documentation {pr}`1673`
 
+
+## Version 0.21
+
+### 0.21.0 (2023-MM-DD)
+
+#### Fixed
+
+-   Fix totalVI differential expression when integer sequential protein names are automatically used {pr}`1951`
+
+
 ## Version 0.20
 
 ### 0.20.2 (2023-03-10)
@@ -23,7 +33,6 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
 
 -   Fix `return_dist` docstring of {meth}`scvi.model.base.VAEMixin.get_latent_representation` {pr}`1932`.
 -   Fix hyperlink to pymde docs {pr}`1944`
--   Fix totalVI differential expression when integer sequential protein names are automatically used {pr}`1951`
 
 #### Changed
 

--- a/scvi/model/base/_utils.py
+++ b/scvi/model/base/_utils.py
@@ -291,5 +291,5 @@ def _fdr_de_prediction(posterior_probas: pd.Series, fdr: float = 0.05) -> pd.Ser
         np.zeros_like(cumulative_fdr).astype(bool), index=sorted_pgs.index
     )
     is_pred_de.iloc[:d] = True
-    is_pred_de = is_pred_de[original_index]
+    is_pred_de = is_pred_de.loc[original_index]
     return is_pred_de

--- a/scvi/model/base/_utils.py
+++ b/scvi/model/base/_utils.py
@@ -279,15 +279,17 @@ def _de_core(
     return result
 
 
-def _fdr_de_prediction(posterior_probas: np.ndarray, fdr: float = 0.05):
+def _fdr_de_prediction(posterior_probas: pd.Series, fdr: float = 0.05) -> pd.Series:
     """Compute posterior expected FDR and tag features as DE."""
     if not posterior_probas.ndim == 1:
         raise ValueError("posterior_probas should be 1-dimensional")
-    sorted_genes = np.argsort(-posterior_probas)
-    sorted_pgs = posterior_probas[sorted_genes]
+    original_index = posterior_probas.index
+    sorted_pgs = posterior_probas.sort_values(ascending=False)
     cumulative_fdr = (1.0 - sorted_pgs).cumsum() / (1.0 + np.arange(len(sorted_pgs)))
     d = (cumulative_fdr <= fdr).sum()
-    pred_de_genes = sorted_genes[:d]
-    is_pred_de = np.zeros_like(cumulative_fdr).astype(bool)
-    is_pred_de[pred_de_genes] = True
+    is_pred_de = pd.Series(
+        np.zeros_like(cumulative_fdr).astype(bool), index=sorted_pgs.index
+    )
+    is_pred_de.iloc[:d] = True
+    is_pred_de = is_pred_de[original_index]
     return is_pred_de

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -1238,37 +1238,24 @@ def test_totalvi(save_path):
 
     # test automatic transfer_anndata_setup
     adata = synthetic_iid()
+    # no protein names so we test our auto generation
     TOTALVI.setup_anndata(
         adata,
         batch_key="batch",
         protein_expression_obsm_key="protein_expression",
-        protein_names_uns_key="protein_names",
     )
     model = TOTALVI(adata)
+    model.train(1, train_size=0.5)
     adata2 = synthetic_iid()
     model.get_elbo(adata2)
 
     # test that we catch incorrect mappings
-    adata = synthetic_iid()
-    TOTALVI.setup_anndata(
-        adata,
-        batch_key="batch",
-        protein_expression_obsm_key="protein_expression",
-        protein_names_uns_key="protein_names",
-    )
     adata2 = synthetic_iid()
     adata2.obs.batch.cat.rename_categories(["batch_0", "batch_10"], inplace=True)
     with pytest.raises(ValueError):
         model.get_elbo(adata2)
 
     # test that same mapping different order is okay
-    adata = synthetic_iid()
-    TOTALVI.setup_anndata(
-        adata,
-        batch_key="batch",
-        protein_expression_obsm_key="protein_expression",
-        protein_names_uns_key="protein_names",
-    )
     adata2 = synthetic_iid()
     adata2.obs.batch.cat.rename_categories(["batch_1", "batch_0"], inplace=True)
     model.get_elbo(adata2)  # should automatically transfer setup


### PR DESCRIPTION
For more context see the discussion on discourse:

https://discourse.scverse.org/t/questions-about-running-differential-expression/1137/8


When using totalVI, if protein counts are in obsm as np array and no column names are provided, we generate sequential integers. This causes indexing issues in the fdr tagging as the index is mixed between gene names and the integers.