### PR TITLE
Library size estimation: changing prior variance and n_hidden

### DIFF
--- a/scvi/module/_vae.py
+++ b/scvi/module/_vae.py
@@ -86,6 +86,8 @@ class VAE(BaseMinifiedModeModuleClass):
     library_log_vars_weight
         Weight that allows adjusting the expected variance in library sizes that can be attributed to technical 
         rather than biological effect. Set library_log_vars_weight < 1.0 to regularise technical effect.
+    library_n_hidden
+        Number of hidden layers to use for the encoder that learns library sizes. Default: use n_hidden.
     var_activation
         Callable used to ensure positivity of the variational distributions' variance.
         When `None`, defaults to `torch.exp`.
@@ -117,6 +119,7 @@ class VAE(BaseMinifiedModeModuleClass):
         library_log_means: Optional[np.ndarray] = None,
         library_log_vars: Optional[np.ndarray] = None,
         library_log_vars_weight: float = 1.0,
+        library_n_hidden: Optional[int] = None,
         var_activation: Optional[Callable] = None,
     ):
         super().__init__()
@@ -186,12 +189,14 @@ class VAE(BaseMinifiedModeModuleClass):
             return_dist=True,
         )
         # l encoder goes from n_input-dimensional data to 1-d library size
+        if library_n_hidden is None:
+            library_n_hidden = n_hidden
         self.l_encoder = Encoder(
             n_input_encoder,
             1,
             n_layers=1,
             n_cat_list=encoder_cat_list,
-            n_hidden=n_hidden,
+            n_hidden=library_n_hidden,
             dropout_rate=dropout_rate,
             inject_covariates=deeply_inject_covariates,
             use_batch_norm=use_batch_norm_encoder,

--- a/scvi/module/_vae.py
+++ b/scvi/module/_vae.py
@@ -83,6 +83,9 @@ class VAE(BaseMinifiedModeModuleClass):
     library_log_vars
         1 x n_batch array of variances of the log library sizes. Parameterizes prior on library size if
         not using observed library size.
+    library_log_vars_weight
+        Weight that allows adjusting the expected variance in library sizes that can be attributed to technical 
+        rather than biological effect. Set library_log_vars_weight < 1.0 to regularise technical effect.
     var_activation
         Callable used to ensure positivity of the variational distributions' variance.
         When `None`, defaults to `torch.exp`.
@@ -113,6 +116,7 @@ class VAE(BaseMinifiedModeModuleClass):
         use_observed_lib_size: bool = True,
         library_log_means: Optional[np.ndarray] = None,
         library_log_vars: Optional[np.ndarray] = None,
+        library_log_vars_weight: float = 1.0,
         var_activation: Optional[Callable] = None,
     ):
         super().__init__()
@@ -139,7 +143,7 @@ class VAE(BaseMinifiedModeModuleClass):
                 "library_log_means", torch.from_numpy(library_log_means).float()
             )
             self.register_buffer(
-                "library_log_vars", torch.from_numpy(library_log_vars).float()
+                "library_log_vars", torch.from_numpy(library_log_vars * library_log_vars_weight).float()
             )
 
         if self.dispersion == "gene":

--- a/scvi/module/_vae.py
+++ b/scvi/module/_vae.py
@@ -215,7 +215,7 @@ class VAE(BaseMinifiedModeModuleClass):
             inject_covariates=deeply_inject_covariates,
             use_batch_norm=use_batch_norm_decoder,
             use_layer_norm=use_layer_norm_decoder,
-            scale_activation="softplus" if use_size_factor_key else "softmax",
+            scale_activation="softplus" if (use_size_factor_key or not use_observed_lib_size) else "softmax",
         )
 
     def _get_inference_input(


### PR DESCRIPTION
Implementing changes proposed in https://github.com/scverse/scvi-tools/issues/1903#issuecomment-1466746644

1. the prior `l_sigma` is an overestimate of the total variance attributed to the technical effect. A potential fix (and an easy fix) would be adding a hyperparameter to allow the user to reduce variance using a simple weight.

2. Indeed it is possible that softplus would make the computation more stable. Is it easy to change to softplus exclusively for size factors 

3. I assume that the encoder network size, n_hidden is the same both for `z` and `l` which in my example is a pretty large number. This would mean that the network is massively overparameterised. In my trials of amortizing inference for cell2location I observed that such 1d parameters need to be amortized with a much smaller network to achieve numerical stability and avoid loss increase (n_hidden=10). Is it possible to change n_hidden exclusively for this parameter? If yes I would like to try this and report results.

4. [not use_observed_lib_size means scale_activation="softplus"](https://github.com/vitkl/scvi-tools/commit/ef3978ade7e02a5ea48c4ae8810d90c180fc9fd1)
