### PR TITLE
fix peakvi scarches test

### DIFF
--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -22,6 +22,7 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
 #### Fixed
 
 -   Fix totalVI differential expression when integer sequential protein names are automatically used {pr}`1951`
+-   Fix peakVI scArches test case {pr}`1962`
 
 ### 0.20.2 (2023-03-10)
 

--- a/tests/models/test_scarches.py
+++ b/tests/models/test_scarches.py
@@ -445,6 +445,7 @@ def test_peakvi_online_update(save_path):
     model2 = PEAKVI.load_query_data(adata2, dir_path)
     model2.train(max_epochs=1, weight_decay=0.0, save_best=False)
     model2.get_latent_representation()
+    single_pass_for_online_update(model2)
 
     # encoder linear layer equal for peak features
     one = (


### PR DESCRIPTION
This started erroring out with pytorch 2.0, and there must be a new treatment of the .grad attribute