### PR TITLE
fix uns copying issue for minify anndata

### DIFF
--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -19,6 +19,15 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
 
 ### 1.0.0 (2023-MM-DD)
 
+#### Added
+
+-   Add {func}`scvi.data.reads_to_fragments` for scATAC data {pr}`1946`
+-   Add default `stacklevel` for `warnings` in `scvi.settings` {pr}`1971`.
+
+#### Fixed
+
+-   Fix creation of minified adata by copying original uns dict {pr}`2000`. This issue arises with anndata>=0.9.0.
+
 #### Changed
 
 -   Use sphinx book theme for documentation {pr}`1673`.
@@ -38,11 +47,6 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
 -   Remove ability to set up ST data in {class}`~scvi.external.SpatialStereoscope.from_rna_model`, which was deprecated. ST data should be set up using {class}`~scvi.external.SpatialStereoscope.setup_anndata` {pr}`1949`.
 -   Remove custom reusable doc decorator which was used for de docs {pr}`1970`.
 -   Remove `drop_last` as an integer from {class}`~scvi.dataloaders.AnnDataLoader`, add typing and code cleanup {pr}`1975`.
-
-#### Added
-
--   Add {func}`scvi.data.reads_to_fragments` for scATAC data {pr}`1946`
--   Add default `stacklevel` for `warnings` in `scvi.settings` {pr}`1971`.
 
 ## Version 0.20
 

--- a/scvi/model/utils/_minification.py
+++ b/scvi/model/utils/_minification.py
@@ -30,7 +30,7 @@ def get_minified_adata_scrna(
     bdata = AnnData(
         X=all_zeros,
         layers=layers,
-        uns=adata.uns,
+        uns=adata.uns.copy(),
         obs=adata.obs,
         var=adata.var,
         varm=adata.varm,


### PR DESCRIPTION
We were editing the same dict in memory, so the minified adata should copy the original uns so there's no conflict

This issue became apparent with the latest release of anndata, which itself was deepcopying uns under the hood, but this was removed.