### PR TITLE
update totalvi/multivi protein loss to fix handling of missing proteins

### DIFF
--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -27,6 +27,7 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
 #### Fixed
 
 -   Fix creation of minified adata by copying original uns dict {pr}`2000`. This issue arises with anndata>=0.9.0.
+-   Fix {class}`scvi.model.TOTALVI` {class}`scvi.model.MULTIVI` handling of missing protein values {pr}`2009`.
 
 #### Changed
 

--- a/scvi/module/_multivae.py
+++ b/scvi/module/_multivae.py
@@ -1050,10 +1050,7 @@ def get_reconstruction_loss_protein(y, py_, pro_batch_mask_minibatch=None):
     reconst_loss_protein_full = -py_conditional.log_prob(y)
 
     if pro_batch_mask_minibatch is not None:
-        temp_pro_loss_full = torch.zeros_like(reconst_loss_protein_full)
-        temp_pro_loss_full.masked_scatter_(
-            pro_batch_mask_minibatch.bool(), reconst_loss_protein_full
-        )
+        temp_pro_loss_full = pro_batch_mask_minibatch.bool() * reconst_loss_protein_full
         rl_protein = temp_pro_loss_full.sum(dim=-1)
     else:
         rl_protein = reconst_loss_protein_full.sum(dim=-1)

--- a/scvi/module/_totalvae.py
+++ b/scvi/module/_totalvae.py
@@ -311,11 +311,9 @@ class TOTALVAE(BaseModuleClass):
         )
         reconst_loss_protein_full = -py_conditional.log_prob(y)
         if pro_batch_mask_minibatch is not None:
-            temp_pro_loss_full = torch.zeros_like(reconst_loss_protein_full)
-            temp_pro_loss_full.masked_scatter_(
-                pro_batch_mask_minibatch.bool(), reconst_loss_protein_full
+            temp_pro_loss_full = (
+                pro_batch_mask_minibatch.bool() * reconst_loss_protein_full
             )
-
             reconst_loss_protein = temp_pro_loss_full.sum(dim=-1)
         else:
             reconst_loss_protein = reconst_loss_protein_full.sum(dim=-1)
@@ -626,10 +624,7 @@ class TOTALVAE(BaseModuleClass):
             Normal(py_["back_alpha"], py_["back_beta"]), self.back_mean_prior
         )
         if pro_batch_mask_minibatch is not None:
-            kl_div_back_pro = torch.zeros_like(kl_div_back_pro_full)
-            kl_div_back_pro.masked_scatter_(
-                pro_batch_mask_minibatch.bool(), kl_div_back_pro_full
-            )
+            kl_div_back_pro = pro_batch_mask_minibatch.bool() * kl_div_back_pro_full
             kl_div_back_pro = kl_div_back_pro.sum(dim=1)
         else:
             kl_div_back_pro = kl_div_back_pro_full.sum(dim=1)

--- a/scvi/train/_trainingplans.py
+++ b/scvi/train/_trainingplans.py
@@ -525,11 +525,9 @@ class AdversarialTrainingPlan(TrainingPlan):
             cls_target = one_hot(batch_index, n_classes)
         else:
             one_hot_batch = one_hot(batch_index, n_classes)
-            cls_target = torch.zeros_like(one_hot_batch)
             # place zeroes where true label is
-            cls_target.masked_scatter_(
-                ~one_hot_batch.bool(), torch.ones_like(one_hot_batch) / (n_classes - 1)
-            )
+            cls_target = (~one_hot_batch.bool()).float()
+            cls_target = cls_target / (n_classes - 1)
 
         l_soft = cls_logits * cls_target
         loss = -l_soft.sum(dim=1).mean()


### PR DESCRIPTION
Masked scatter was not actually filling in the right elements. Masked fill would do this but only works on 0d tensors. Here we just multiply with the mask to stop the gradients from backpropagating. 

Fixes #2008 