### PR TITLE
Add `deregister_manager` function to base model class

### DIFF
--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -32,6 +32,8 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
 -   Log training loss through Lightning's progress bar {pr}`2043`.
 -   Filter Jax undetected GPU warnings {pr}`2044`.
 -   Raise warning if MPS backend is selected for PyTorch, see https://github.com/pytorch/pytorch/issues/77764 {pr}`2045`.
+-   Add `deregister_manager` function to {class}`scvi.model.base.BaseModelClass`, allowing to clear
+    {class}`scvi.data.AnnDataManager` instances memory {pr}`2060`.
 
 #### Fixed
 

--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -33,7 +33,7 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
 -   Filter Jax undetected GPU warnings {pr}`2044`.
 -   Raise warning if MPS backend is selected for PyTorch, see https://github.com/pytorch/pytorch/issues/77764 {pr}`2045`.
 -   Add `deregister_manager` function to {class}`scvi.model.base.BaseModelClass`, allowing to clear
-    {class}`scvi.data.AnnDataManager` instances memory {pr}`2060`.
+    {class}`scvi.data.AnnDataManager` instances from memory {pr}`2060`.
 
 #### Fixed
 

--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -225,7 +225,7 @@ class BaseModelClass(TunableMixin, metaclass=BaseModelMetaClass):
         instance_manager_store[adata_id] = adata_manager
 
     def deregister_manager(self, adata_manager: Optional[AnnDataManager] = None):
-        """Deregisters an :class:`~scvi.data.AnnDataManager` instance with this model instance.
+        """Deregisters an :class:`~scvi.data.AnnDataManager` instance with this model instance and class.
 
         If `adata_manager` is `None`, deregisters all :class:`~scvi.data.AnnDataManager` instances
         in both the class and instance-specific manager stores, except for the current
@@ -235,16 +235,25 @@ class BaseModelClass(TunableMixin, metaclass=BaseModelMetaClass):
         instance_manager_store = self._per_instance_manager_store[self.id]
 
         if adata_manager is None:
-            manager_ids_to_clear = list(cls_manager_store.keys())
+            instance_managers_to_clear = list(instance_manager_store.keys())
+            cls_managers_to_clear = list(cls_manager_store.keys())
         else:
-            manager_ids_to_clear = [adata_manager.adata_uuid]
+            instance_managers_to_clear = [adata_manager.adata_uuid]
+            if adata_manager.adata_uuid in cls_manager_store:
+                cls_managers_to_clear = [adata_manager.adata_uuid]
+            else:
+                cls_managers_to_clear = []
 
-        for manager_id in manager_ids_to_clear:
+        for manager_id in instance_managers_to_clear:
             if adata_manager is None and manager_id == self.adata_manager.adata_uuid:
                 # don't clear the current manager by default
                 continue
-            if manager_id in instance_manager_store:
-                del instance_manager_store[manager_id]
+            del instance_manager_store[manager_id]
+
+        for manager_id in cls_managers_to_clear:
+            if adata_manager is None and manager_id == self.adata_manager.adata_uuid:
+                # don't clear the current manager by default
+                continue
             del cls_manager_store[manager_id]
 
     @classmethod
@@ -336,7 +345,6 @@ class BaseModelClass(TunableMixin, metaclass=BaseModelMetaClass):
             _assign_adata_uuid(adata, overwrite=True)
             adata_manager = self.adata_manager.transfer_fields(adata)
             self._register_manager_for_instance(adata_manager)
-            self.register_manager(adata_manager)
 
         return adata_manager
 
@@ -437,9 +445,9 @@ class BaseModelClass(TunableMixin, metaclass=BaseModelMetaClass):
                 "Input AnnData not setup with scvi-tools. "
                 + "attempting to transfer AnnData setup"
             )
-            adata_manager = self.adata_manager.transfer_fields(adata)
-            self._register_manager_for_instance(adata_manager)
-            self.register_manager(adata_manager)
+            self._register_manager_for_instance(
+                self.adata_manager.transfer_fields(adata)
+            )
         else:
             # Case where correct AnnDataManager is found, replay registration as necessary.
             adata_manager.validate()

--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -336,6 +336,7 @@ class BaseModelClass(TunableMixin, metaclass=BaseModelMetaClass):
             _assign_adata_uuid(adata, overwrite=True)
             adata_manager = self.adata_manager.transfer_fields(adata)
             self._register_manager_for_instance(adata_manager)
+            self.regsiter_manager(adata_manager)
 
         return adata_manager
 
@@ -436,9 +437,9 @@ class BaseModelClass(TunableMixin, metaclass=BaseModelMetaClass):
                 "Input AnnData not setup with scvi-tools. "
                 + "attempting to transfer AnnData setup"
             )
-            self._register_manager_for_instance(
-                self.adata_manager.transfer_fields(adata)
-            )
+            adata_manager = self.adata_manager.transfer_fields(adata)
+            self._register_manager_for_instance(adata_manager)
+            self.register_manager(adata_manager)
         else:
             # Case where correct AnnDataManager is found, replay registration as necessary.
             adata_manager.validate()

--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -336,7 +336,7 @@ class BaseModelClass(TunableMixin, metaclass=BaseModelMetaClass):
             _assign_adata_uuid(adata, overwrite=True)
             adata_manager = self.adata_manager.transfer_fields(adata)
             self._register_manager_for_instance(adata_manager)
-            self.regsiter_manager(adata_manager)
+            self.register_manager(adata_manager)
 
         return adata_manager
 

--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -238,23 +238,24 @@ class BaseModelClass(TunableMixin, metaclass=BaseModelMetaClass):
             instance_managers_to_clear = list(instance_manager_store.keys())
             cls_managers_to_clear = list(cls_manager_store.keys())
         else:
+            cls_managers_to_clear = [adata_manager.adata_uuid]
             instance_managers_to_clear = [adata_manager.adata_uuid]
-            if adata_manager.adata_uuid in cls_manager_store:
-                cls_managers_to_clear = [adata_manager.adata_uuid]
-            else:
-                cls_managers_to_clear = []
-
-        for manager_id in instance_managers_to_clear:
-            if adata_manager is None and manager_id == self.adata_manager.adata_uuid:
-                # don't clear the current manager by default
-                continue
-            del instance_manager_store[manager_id]
 
         for manager_id in cls_managers_to_clear:
-            if adata_manager is None and manager_id == self.adata_manager.adata_uuid:
+            if (
+                adata_manager is None and manager_id == self.adata_manager.adata_uuid
+            ) or (manager_id not in cls_manager_store):
                 # don't clear the current manager by default
                 continue
             del cls_manager_store[manager_id]
+
+        for manager_id in instance_managers_to_clear:
+            if (
+                adata_manager is None and manager_id == self.adata_manager.adata_uuid
+            ) or (manager_id not in instance_manager_store):
+                # don't clear the current manager by default
+                continue
+            del instance_manager_store[manager_id]
 
     @classmethod
     def _get_most_recent_anndata_manager(

--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -224,38 +224,41 @@ class BaseModelClass(TunableMixin, metaclass=BaseModelMetaClass):
         instance_manager_store = self._per_instance_manager_store[self.id]
         instance_manager_store[adata_id] = adata_manager
 
-    def deregister_manager(self, adata_manager: Optional[AnnDataManager] = None):
-        """Deregisters an :class:`~scvi.data.AnnDataManager` instance with this model instance and class.
+    def deregister_manager(self, adata: Optional[AnnData] = None):
+        """Deregisters the :class:`~scvi.data.AnnDataManager` instance associated with `adata`.
 
-        If `adata_manager` is `None`, deregisters all :class:`~scvi.data.AnnDataManager` instances
-        in both the class and instance-specific manager stores, except for the current
-        :class:`~scvi.data.AnnDataManager` instance associated with this model instance.
+        If `adata` is `None`, deregisters all :class:`~scvi.data.AnnDataManager` instances
+        in both the class and instance-specific manager stores, except for the one associated
+        with this model instance.
         """
         cls_manager_store = self._setup_adata_manager_store
         instance_manager_store = self._per_instance_manager_store[self.id]
 
-        if adata_manager is None:
+        if adata is None:
             instance_managers_to_clear = list(instance_manager_store.keys())
             cls_managers_to_clear = list(cls_manager_store.keys())
         else:
+            adata_manager = self._get_most_recent_anndata_manager(adata, required=True)
             cls_managers_to_clear = [adata_manager.adata_uuid]
             instance_managers_to_clear = [adata_manager.adata_uuid]
 
-        for manager_id in cls_managers_to_clear:
-            if (
-                adata_manager is None and manager_id == self.adata_manager.adata_uuid
-            ) or (manager_id not in cls_manager_store):
-                # don't clear the current manager by default
+        for adata_id in cls_managers_to_clear:
+            # don't clear the current manager by default
+            is_current_adata = (
+                adata is None and adata_id == self.adata_manager.adata_uuid
+            )
+            if is_current_adata or adata_id not in cls_manager_store:
                 continue
-            del cls_manager_store[manager_id]
+            del cls_manager_store[adata_id]
 
-        for manager_id in instance_managers_to_clear:
-            if (
-                adata_manager is None and manager_id == self.adata_manager.adata_uuid
-            ) or (manager_id not in instance_manager_store):
-                # don't clear the current manager by default
+        for adata_id in instance_managers_to_clear:
+            # don't clear the current manager by default
+            is_current_adata = (
+                adata is None and adata_id == self.adata_manager.adata_uuid
+            )
+            if is_current_adata or adata_id not in instance_manager_store:
                 continue
-            del instance_manager_store[manager_id]
+            del instance_manager_store[adata_id]
 
     @classmethod
     def _get_most_recent_anndata_manager(

--- a/tests/model/base/test_base_model.py
+++ b/tests/model/base/test_base_model.py
@@ -1,0 +1,85 @@
+from typing import List, Optional
+
+from anndata import AnnData
+
+from scvi import REGISTRY_KEYS
+from scvi.data import AnnDataManager, fields, synthetic_iid
+from scvi.data._utils import _get_adata_minify_type
+from scvi.model.base import BaseModelClass
+
+
+class TestModelClass(BaseModelClass):
+    @classmethod
+    def setup_anndata(
+        cls,
+        adata: AnnData,
+        layer: Optional[str] = None,
+        batch_key: Optional[str] = None,
+        labels_key: Optional[str] = None,
+        size_factor_key: Optional[str] = None,
+        categorical_covariate_keys: Optional[List[str]] = None,
+        continuous_covariate_keys: Optional[List[str]] = None,
+        **kwargs,
+    ):
+        setup_method_args = cls._get_setup_method_args(**locals())
+        anndata_fields = [
+            fields.LayerField(REGISTRY_KEYS.X_KEY, layer, is_count_data=True),
+            fields.CategoricalObsField(REGISTRY_KEYS.BATCH_KEY, batch_key),
+            fields.CategoricalObsField(REGISTRY_KEYS.LABELS_KEY, labels_key),
+            fields.NumericalObsField(
+                REGISTRY_KEYS.SIZE_FACTOR_KEY, size_factor_key, required=False
+            ),
+            fields.CategoricalJointObsField(
+                REGISTRY_KEYS.CAT_COVS_KEY, categorical_covariate_keys
+            ),
+            fields.NumericalJointObsField(
+                REGISTRY_KEYS.CONT_COVS_KEY, continuous_covariate_keys
+            ),
+        ]
+        # register new fields if the adata is minified
+        adata_minify_type = _get_adata_minify_type(adata)
+        if adata_minify_type is not None:
+            anndata_fields += cls._get_fields_for_adata_minification(adata_minify_type)
+        adata_manager = AnnDataManager(
+            fields=anndata_fields, setup_method_args=setup_method_args
+        )
+        adata_manager.register_fields(adata, **kwargs)
+        cls.register_manager(adata_manager)
+
+    def train(self):
+        pass
+
+
+def test_deregister_manager():
+    adata = synthetic_iid()
+    bdata = synthetic_iid()
+
+    # default deregister
+    TestModelClass.setup_anndata(adata)
+    TestModelClass.setup_anndata(bdata)
+    model = TestModelClass(adata)
+    adata_manager = model._get_most_recent_anndata_manager(adata)
+    bdata_manager = model._get_most_recent_anndata_manager(bdata)
+
+    model.deregister_manager()
+    instance_manager_store = TestModelClass._per_instance_manager_store[model.id]
+    class_manager_store = model._setup_adata_manager_store
+    assert adata_manager.adata_uuid in instance_manager_store
+    assert adata_manager.adata_uuid in class_manager_store
+    assert bdata_manager.adata_uuid not in class_manager_store
+
+    # deregister with argument
+    TestModelClass.setup_anndata(adata)
+    TestModelClass.setup_anndata(bdata)
+    model = TestModelClass(adata)
+    adata_manager = model._get_most_recent_anndata_manager(adata)
+    bdata_manager = model._get_most_recent_anndata_manager(bdata)
+
+    model.deregister_manager(adata_manager)
+    instance_manager_store = TestModelClass._per_instance_manager_store[model.id]
+    class_manager_store = model._setup_adata_manager_store
+    assert adata_manager.adata_uuid not in instance_manager_store
+    assert adata_manager.adata_uuid not in class_manager_store
+    assert bdata_manager.adata_uuid in class_manager_store
+    model.deregister_manager(bdata_manager)
+    assert bdata_manager.adata_uuid not in class_manager_store

--- a/tests/model/base/test_base_model.py
+++ b/tests/model/base/test_base_model.py
@@ -1,5 +1,6 @@
 from typing import List, Optional
 
+import pytest
 from anndata import AnnData
 
 from scvi import REGISTRY_KEYS
@@ -68,6 +69,9 @@ def test_deregister_manager():
     assert adata_manager.adata_uuid in class_manager_store
     assert bdata_manager.adata_uuid not in class_manager_store
 
+    with pytest.raises(ValueError):
+        model.deregister_manager(bdata)
+
     # deregister with argument
     TestModelClass.setup_anndata(adata)
     TestModelClass.setup_anndata(bdata)
@@ -75,11 +79,16 @@ def test_deregister_manager():
     adata_manager = model._get_most_recent_anndata_manager(adata)
     bdata_manager = model._get_most_recent_anndata_manager(bdata)
 
-    model.deregister_manager(adata_manager)
+    model.deregister_manager(adata)
     instance_manager_store = TestModelClass._per_instance_manager_store[model.id]
     class_manager_store = model._setup_adata_manager_store
     assert adata_manager.adata_uuid not in instance_manager_store
     assert adata_manager.adata_uuid not in class_manager_store
     assert bdata_manager.adata_uuid in class_manager_store
-    model.deregister_manager(bdata_manager)
+    model.deregister_manager(bdata)
     assert bdata_manager.adata_uuid not in class_manager_store
+
+    with pytest.raises(ValueError):
+        model.deregister_manager(adata)
+    with pytest.raises(ValueError):
+        model.deregister_manager(bdata)


### PR DESCRIPTION
Thank you for your contribution to scvi-tools. Feel free to modify or omit any
sections below based on your needs.

---

## General

-   [x] I have read the [contributing guide](https://docs.scvi-tools.org/en/stable/contributing/index.html).
-   [x] I have verified that there are no other pull requests open for the same fix or feature.

## Description

Closes #2053 

Adds `register_manager` calls wherever `_register_manager_for_instance` is called to ensure that the instance manager store is always a subset of the class manager store.

-   [x] I have linked the relevant issue(s) and/or included a description of the changes.
-   [x] If the changes fully address an issue, I have added `Fixes #<issue number>` to the PR description.

## Documentation

-   [x] I have added appropriate comments and documentation where necessary.
-   [x] I have added a description of the changes to the most recent entry in `docs/release_notes/index.md`.

## Testing

-   [x] I have added relevant tests for my changes.
-   [x] All new and existing tests pass locally.

## Development

-   [x] If the changes are patches for a version, I have added the `on-merge: backport to x.x.x` label.
