### PR TITLE
Fix typo in JaxSCVI example

### DIFF
--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -41,6 +41,7 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
 -   Fix {class}`scvi.model.TOTALVI` {class}`scvi.model.MULTIVI` handling of missing protein values {pr}`2009`.
 -   Fix bug in {meth}`scvi.distributions.NegativeBinomialMixture.sample` where `theta` and `mu` arguments were switched around {pr}`2024`.
 -   Fix bug in {meth}`scvi.dataloaders.SemiSupervisedDataLoader.resample_labels` where the labeled dataloader was not being reinitialized on subsample {pr}`2032`.
+-   Fix typo in {class}`scvi.model.JaxSCVI` example snippet {pr}`2075`.
 
 #### Changed
 

--- a/scvi/model/_jaxscvi.py
+++ b/scvi/model/_jaxscvi.py
@@ -43,7 +43,7 @@ class JaxSCVI(JaxTrainingMixin, BaseModelClass):
     --------
     >>> adata = anndata.read_h5ad(path_to_anndata)
     >>> scvi.model.JaxSCVI.setup_anndata(adata, batch_key="batch")
-    >>> vae = scvi.model.SCVI(adata)
+    >>> vae = scvi.model.JaxSCVI(adata)
     >>> vae.train()
     >>> adata.obsm["X_scVI"] = vae.get_latent_representation()
     """


### PR DESCRIPTION
-   [x] Closes #2074 (Replace xxxx with the GitHub issue number)
-   [x] Tests added and passed if fixing a bug or adding a new feature
-   [x] All code checks passed.
-   [x] Added type annotations to new arguments/methods/functions.
-   [x] Added an entry in the latest `docs/release_notes/index.md` file if fixing a bug or adding a new feature.
-   [x] If the changes are patches for a version, I have added the `on-merge: backport to x.x.x` label.
