### PR TITLE
Remove deprecated `Literal` compat class

### DIFF
--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -14,6 +14,7 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
 #### Removed
 
 -   Remove deprecated `use_gpu` in favor of PyTorch Lightning arguments `accelerator` and `devices` {pr}`xxxx`.
+-   Remove deprecated `scvi._compat.Literal` class {pr}`2115`.
 
 ## Version 1.0
 

--- a/scvi/_compat.py
+++ b/scvi/_compat.py
@@ -1,4 +1,0 @@
-class Literal:
-    """Shim Literal."""
-
-    raise DeprecationWarning("This class is deprecated, please import from typing")


### PR DESCRIPTION
-   [x] Closes #xxxx (Replace xxxx with the GitHub issue number)
-   [x] Tests added and passed if fixing a bug or adding a new feature
-   [x] All code checks passed.
-   [x] Added type annotations to new arguments/methods/functions.
-   [x] Added an entry in the latest `docs/release_notes/index.md` file if fixing a bug or adding a new feature.
-   [x] If the changes are patches for a version, I have added the `on-merge: backport to x.x.x` label.
