### PR TITLE
Bump to 1.0.1, add missing release notes

### DIFF
--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -18,6 +18,16 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
 
 ## Version 1.0
 
+### 1.0.1 (2023-07-04)
+
+#### Added
+
+-   Add support for Python 3.11 {pr}`1977`.
+
+#### Changed
+
+-   Upper bound Chex dependency to 0.1.8 due to NumPy installation conflicts {pr}`2132`.
+
 ### 1.0.0 (2023-06-02)
 
 #### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["hatchling"]
 
 [project]
 name = "scvi-tools"
-version = "1.0.0"
+version = "1.0.1"
 description = "Deep probabilistic analysis of single-cell omics data."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -25,6 +25,7 @@ classifiers = [
   "Natural Language :: English",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
   "Operating System :: MacOS :: MacOS X",
   "Operating System :: Microsoft :: Windows",
   "Operating System :: POSIX :: Linux",


### PR DESCRIPTION
-   [x] Closes #xxxx (Replace xxxx with the GitHub issue number)
-   [x] Tests added and passed if fixing a bug or adding a new feature
-   [x] All code checks passed.
-   [x] Added type annotations to new arguments/methods/functions.
-   [x] Added an entry in the latest `docs/release_notes/index.md` file if fixing a bug or adding a new feature.
-   [x] If the changes are patches for a version, I have added the `on-merge: backport to x.x.x` label.
