### PR TITLE
Use training plan arg in pyro

### DIFF
--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -28,6 +28,8 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
 
 ### 1.0.3 (2023-MM-DD)
 
+### Changed
+
 -   Disable the default selection of MPS when `accelerator="auto"` in Lightning {pr}`2167`.
 
 ### Fixed

--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -24,6 +24,13 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
 
 ## Version 1.0
 
+### 1.0.3 (2023-MM-DD)
+
+### Fixed
+
+-   Fix bug in {class}`scvi.model.base.PyroSviTrainMixin` where `training_plan`
+    argument was ignored {pr}`xxxx`.
+
 ### 1.0.2 (2023-07-05)
 
 ### Fixed

--- a/scvi/model/base/_pyromixin.py
+++ b/scvi/model/base/_pyromixin.py
@@ -94,7 +94,7 @@ class PyroSviTrainMixin:
         batch_size: int = 128,
         early_stopping: bool = False,
         lr: Optional[float] = None,
-        training_plan: PyroTrainingPlan = PyroTrainingPlan,
+        training_plan: Optional[PyroTrainingPlan] = None,
         plan_kwargs: Optional[dict] = None,
         **trainer_kwargs,
     ):
@@ -158,7 +158,9 @@ class PyroSviTrainMixin:
                 shuffle_set_split=shuffle_set_split,
                 batch_size=batch_size,
             )
-        training_plan = self._training_plan_cls(self.module, **plan_kwargs)
+
+        if training_plan is None:
+            training_plan = self._training_plan_cls(self.module, **plan_kwargs)
 
         es = "early_stopping"
         trainer_kwargs[es] = (


### PR DESCRIPTION
-   [x] Closes #2159 (Replace xxxx with the GitHub issue number)
-   [ ] Tests added and passed if fixing a bug or adding a new feature
-   [ ] All code checks passed.
-   [x] Added type annotations to new arguments/methods/functions.
-   [x] Added an entry in the latest `docs/release_notes/index.md` file if fixing a bug or adding a new feature.
-   [x] If the changes are patches for a version, I have added the `on-merge: backport to x.x.x` label.
