### PR TITLE
Temporary upper bound on Pydantic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
     "mudata>=0.1.2",
     "sparse>=0.14.0",
     "xarray>=2023.2.0",
+    "pydantic<2.0.0",  # temporary fix until Lightning 2.0.5 is released
 ]
 
 


### PR DESCRIPTION
-   [ ] Closes #xxxx (Replace xxxx with the GitHub issue number)
-   [ ] Tests added and passed if fixing a bug or adding a new feature
-   [ ] All code checks passed.
-   [ ] Added type annotations to new arguments/methods/functions.
-   [ ] Added an entry in the latest `docs/release_notes/index.md` file if fixing a bug or adding a new feature.
-   [ ] If the changes are patches for a version, I have added the `on-merge: backport to x.x.x` label.

TEMPORARY fix for our CI runs until Lightning 2.0.5 is released, which will should fix our issues with Pydantic imports. Must be reverted before the next minor or patch release.
