### PR TITLE
Revert pydantic upper bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ dependencies = [
     "mudata>=0.1.2",
     "sparse>=0.14.0",
     "xarray>=2023.2.0",
-    "pydantic<2.0.0",  # temporary fix until Lightning 2.0.5 is released
 ]
 
 


### PR DESCRIPTION
-   [ ] Closes #xxxx (Replace xxxx with the GitHub issue number)
-   [ ] Tests added and passed if fixing a bug or adding a new feature
-   [ ] All code checks passed.
-   [ ] Added type annotations to new arguments/methods/functions.
-   [ ] Added an entry in the latest `docs/release_notes/index.md` file if fixing a bug or adding a new feature.
-   [ ] If the changes are patches for a version, I have added the `on-merge: backport to x.x.x` label.

Can be reverted because of Lightning 2.0.5 release. See #2177 
