### PR TITLE
Add docstring for scanvi unlabeled category

### DIFF
--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -43,6 +43,8 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
 
 -   Fix bug in {class}`scvi.model.base.PyroSviTrainMixin` where `training_plan`
     argument is ignored {pr}`2162`.
+-   Fix missing docstring for `unlabeled_category` in
+    {class}`scvi.model.SCANVI.setup_anndata` and reorder arguments {pr}`2189`.
 
 ### 1.0.2 (2023-07-05)
 

--- a/scvi/model/_scanvi.py
+++ b/scvi/model/_scanvi.py
@@ -454,9 +454,10 @@ class SCANVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseMinifiedModeModelClass):
         Parameters
         ----------
         %(param_adata)s
+        %(param_labels_key)s
+        %(param_unlabeled_category)s
         %(param_layer)s
         %(param_batch_key)s
-        %(param_labels_key)s
         %(param_size_factor_key)s
         %(param_cat_cov_keys)s
         %(param_cont_cov_keys)s

--- a/scvi/utils/_docstrings.py
+++ b/scvi/utils/_docstrings.py
@@ -179,6 +179,7 @@ setup_anndata_dsp = DocstringProcessor(
     param_cat_cov_keys=param_cat_cov_keys,
     param_cont_cov_keys=param_cont_cov_keys,
     param_size_factor_key=param_size_factor_key,
+    param_unlabeled_category=param_unlabeled_category,
     param_modalities=param_modalities,
     param_copy=param_copy,
     returns=returns,

--- a/scvi/utils/_docstrings.py
+++ b/scvi/utils/_docstrings.py
@@ -145,6 +145,10 @@ continuous_covariate_keys
     (i.e., the model tries to minimize their effects on the latent space). Thus, these should not be used for
     biologically-relevant factors that you do _not_ want to correct for."""
 
+param_unlabeled_category = """\
+unlabeled_category
+    value in `adata.obs[labels_key]` that indicates unlabeled observations."""
+
 param_modalities = """\
 modalities
     Dictionary mapping parameters to modalities."""


### PR DESCRIPTION
-   [x] Closes #2091 
-   [x] Tests added and passed if fixing a bug or adding a new feature
-   [x] All code checks passed.
-   [x] Added type annotations to new arguments/methods/functions.
-   [x] Added an entry in the latest `docs/release_notes/index.md` file if fixing a bug or adding a new feature.
-   [x] If the changes are patches for a version, I have added the `on-merge: backport to x.x.x` label.
