### PR TITLE
Expose `datasplitter_kwargs` in model `train` methods

### DIFF
--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -29,6 +29,7 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
 -   Expose {meth}`torch.save` keyword arguments in {class}`scvi.model.base.BaseModelClass.save`
     and {class}`scvi.external.GIMVI.save` {pr}`2200`.
 -   Add `model_kwargs` and `train_kwargs` arguments to {meth}`scvi.autotune.ModelTuner.fit` {pr}`2203`.
+-   Add `datasplitter_kwargs` to model `train` methods {pr}`2204`.
 
 #### Changed
 

--- a/scvi/external/cellassign/_model.py
+++ b/scvi/external/cellassign/_model.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import logging
-from typing import List, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -129,12 +130,13 @@ class CellAssign(UnsupervisedTrainingMixin, BaseModelClass):
         max_epochs: int = 400,
         lr: float = 3e-3,
         accelerator: str = "auto",
-        devices: Union[int, List[int], str] = "auto",
+        devices: int | list[int] | str = "auto",
         train_size: float = 0.9,
-        validation_size: Optional[float] = None,
+        validation_size: float | None = None,
         shuffle_set_split: bool = True,
         batch_size: int = 1024,
-        plan_kwargs: Optional[dict] = None,
+        datasplitter_kwargs: dict | None = None,
+        plan_kwargs: dict | None = None,
         early_stopping: bool = True,
         early_stopping_patience: int = 15,
         early_stopping_min_delta: float = 0.0,
@@ -160,6 +162,8 @@ class CellAssign(UnsupervisedTrainingMixin, BaseModelClass):
             sequential order of the data according to `validation_size` and `train_size` percentages.
         batch_size
             Minibatch size to use during training.
+        datasplitter_kwargs
+            Additional keyword arguments passed into :class:`~scvi.dataloaders.DataSplitter`.
         plan_kwargs
             Keyword args for :class:`~scvi.train.TrainingPlan`.
         early_stopping
@@ -177,6 +181,8 @@ class CellAssign(UnsupervisedTrainingMixin, BaseModelClass):
             plan_kwargs.update(update_dict)
         else:
             plan_kwargs = update_dict
+
+        datasplitter_kwargs = datasplitter_kwargs or {}
 
         if "callbacks" in kwargs:
             kwargs["callbacks"] += [ClampCallback()]
@@ -209,6 +215,7 @@ class CellAssign(UnsupervisedTrainingMixin, BaseModelClass):
             validation_size=validation_size,
             batch_size=batch_size,
             shuffle_set_split=shuffle_set_split,
+            **datasplitter_kwargs,
         )
         training_plan = TrainingPlan(self.module, **plan_kwargs)
         runner = TrainRunner(
@@ -228,10 +235,10 @@ class CellAssign(UnsupervisedTrainingMixin, BaseModelClass):
         cls,
         adata: AnnData,
         size_factor_key: str,
-        batch_key: Optional[str] = None,
-        categorical_covariate_keys: Optional[List[str]] = None,
-        continuous_covariate_keys: Optional[List[str]] = None,
-        layer: Optional[str] = None,
+        batch_key: str | None = None,
+        categorical_covariate_keys: list[str] | None = None,
+        continuous_covariate_keys: list[str] | None = None,
+        layer: str | None = None,
         **kwargs,
     ):
         """%(summary)s.

--- a/scvi/external/gimvi/_model.py
+++ b/scvi/external/gimvi/_model.py
@@ -169,6 +169,7 @@ class GIMVI(VAEMixin, BaseModelClass):
         validation_size: float | None = None,
         shuffle_set_split: bool = True,
         batch_size: int = 128,
+        datasplitter_kwargs: dict | None = None,
         plan_kwargs: dict | None = None,
         **kwargs,
     ):
@@ -193,6 +194,8 @@ class GIMVI(VAEMixin, BaseModelClass):
             sequential order of the data according to `validation_size` and `train_size` percentages.
         batch_size
             Minibatch size to use during training.
+        datasplitter_kwargs
+            Additional keyword arguments passed into :class:`~scvi.dataloaders.DataSplitter`.
         plan_kwargs
             Keyword args for model-specific Pytorch Lightning task. Keyword arguments passed
             to `train()` will overwrite values present in `plan_kwargs`, when appropriate.
@@ -204,6 +207,7 @@ class GIMVI(VAEMixin, BaseModelClass):
             devices=devices,
             return_device="torch",
         )
+        datasplitter_kwargs = datasplitter_kwargs or {}
 
         self.trainer = Trainer(
             max_epochs=max_epochs,
@@ -220,6 +224,7 @@ class GIMVI(VAEMixin, BaseModelClass):
                 validation_size=validation_size,
                 batch_size=batch_size,
                 shuffle_set_split=shuffle_set_split,
+                **datasplitter_kwargs,
             )
             ds.setup()
             train_dls.append(ds.train_dataloader())

--- a/scvi/external/solo/_model.py
+++ b/scvi/external/solo/_model.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import io
 import logging
 import warnings
 from contextlib import redirect_stdout
-from typing import List, Optional, Sequence, Union
+from typing import Sequence
 
 import anndata
 import numpy as np
@@ -98,8 +100,8 @@ class SOLO(BaseModelClass):
     def from_scvi_model(
         cls,
         scvi_model: SCVI,
-        adata: Optional[AnnData] = None,
-        restrict_to_batch: Optional[str] = None,
+        adata: AnnData | None = None,
+        restrict_to_batch: str | None = None,
         doublet_ratio: int = 2,
         **classifier_kwargs,
     ):
@@ -243,7 +245,7 @@ class SOLO(BaseModelClass):
         cls,
         adata_manager: AnnDataManager,
         doublet_ratio: int,
-        indices: Optional[Sequence[int]] = None,
+        indices: Sequence[int] | None = None,
         seed: int = 1,
     ) -> AnnData:
         """Simulate doublets.
@@ -290,12 +292,13 @@ class SOLO(BaseModelClass):
         max_epochs: int = 400,
         lr: float = 1e-3,
         accelerator: str = "auto",
-        devices: Union[int, List[int], str] = "auto",
+        devices: int | list[int] | str = "auto",
         train_size: float = 0.9,
-        validation_size: Optional[float] = None,
+        validation_size: float | None = None,
         shuffle_set_split: bool = True,
         batch_size: int = 128,
-        plan_kwargs: Optional[dict] = None,
+        datasplitter_kwargs: dict | None = None,
+        plan_kwargs: dict | None = None,
         early_stopping: bool = True,
         early_stopping_patience: int = 30,
         early_stopping_min_delta: float = 0.0,
@@ -321,6 +324,8 @@ class SOLO(BaseModelClass):
             sequential order of the data according to `validation_size` and `train_size` percentages.
         batch_size
             Minibatch size to use during training.
+        datasplitter_kwargs
+            Additional keyword arguments passed into :class:`~scvi.dataloaders.DataSplitter`.
         plan_kwargs
             Keyword args for :class:`~scvi.train.ClassifierTrainingPlan`. Keyword arguments passed to
         early_stopping
@@ -340,6 +345,8 @@ class SOLO(BaseModelClass):
             plan_kwargs.update(update_dict)
         else:
             plan_kwargs = update_dict
+
+        datasplitter_kwargs = datasplitter_kwargs or {}
 
         if early_stopping:
             early_stopping_callback = [
@@ -367,6 +374,7 @@ class SOLO(BaseModelClass):
             validation_size=validation_size,
             shuffle_set_split=shuffle_set_split,
             batch_size=batch_size,
+            **datasplitter_kwargs,
         )
         training_plan = ClassifierTrainingPlan(
             self.module, self.n_labels, **plan_kwargs
@@ -437,8 +445,8 @@ class SOLO(BaseModelClass):
     def setup_anndata(
         cls,
         adata: AnnData,
-        labels_key: Optional[str] = None,
-        layer: Optional[str] = None,
+        labels_key: str | None = None,
+        layer: str | None = None,
         **kwargs,
     ):
         """%(summary)s.

--- a/scvi/external/stereoscope/_model.py
+++ b/scvi/external/stereoscope/_model.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import logging
-from typing import List, Literal, Optional, Tuple, Union
+from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -60,12 +62,13 @@ class RNAStereoscope(UnsupervisedTrainingMixin, BaseModelClass):
         max_epochs: int = 400,
         lr: float = 0.01,
         accelerator: str = "auto",
-        devices: Union[int, List[int], str] = "auto",
+        devices: int | list[int] | str = "auto",
         train_size: float = 1,
-        validation_size: Optional[float] = None,
+        validation_size: float | None = None,
         shuffle_set_split: bool = True,
         batch_size: int = 128,
-        plan_kwargs: Optional[dict] = None,
+        datasplitter_kwargs: dict | None = None,
+        plan_kwargs: dict | None = None,
         **kwargs,
     ):
         """Trains the model using MAP inference.
@@ -88,6 +91,8 @@ class RNAStereoscope(UnsupervisedTrainingMixin, BaseModelClass):
             sequential order of the data according to `validation_size` and `train_size` percentages.
         batch_size
             Minibatch size to use during training.
+        datasplitter_kwargs
+            Additional keyword arguments passed into :class:`~scvi.dataloaders.DataSplitter`.
         plan_kwargs
             Keyword args for :class:`~scvi.train.TrainingPlan`. Keyword arguments passed to
             `train()` will overwrite values present in `plan_kwargs`, when appropriate.
@@ -101,6 +106,7 @@ class RNAStereoscope(UnsupervisedTrainingMixin, BaseModelClass):
             plan_kwargs.update(update_dict)
         else:
             plan_kwargs = update_dict
+
         super().train(
             max_epochs=max_epochs,
             accelerator=accelerator,
@@ -109,6 +115,7 @@ class RNAStereoscope(UnsupervisedTrainingMixin, BaseModelClass):
             validation_size=validation_size,
             shuffle_set_split=shuffle_set_split,
             batch_size=batch_size,
+            datasplitter_kwargs=datasplitter_kwargs,
             plan_kwargs=plan_kwargs,
             **kwargs,
         )
@@ -118,8 +125,8 @@ class RNAStereoscope(UnsupervisedTrainingMixin, BaseModelClass):
     def setup_anndata(
         cls,
         adata: AnnData,
-        labels_key: Optional[str] = None,
-        layer: Optional[str] = None,
+        labels_key: str | None = None,
+        layer: str | None = None,
         **kwargs,
     ):
         """%(summary)s.
@@ -182,7 +189,7 @@ class SpatialStereoscope(UnsupervisedTrainingMixin, BaseModelClass):
     def __init__(
         self,
         st_adata: AnnData,
-        sc_params: Tuple[np.ndarray],
+        sc_params: tuple[np.ndarray],
         cell_type_mapping: np.ndarray,
         prior_weight: Literal["n_obs", "minibatch"] = "n_obs",
         **model_kwargs,
@@ -283,10 +290,11 @@ class SpatialStereoscope(UnsupervisedTrainingMixin, BaseModelClass):
         max_epochs: int = 400,
         lr: float = 0.01,
         accelerator: str = "auto",
-        devices: Union[int, List[int], str] = "auto",
+        devices: int | list[int] | str = "auto",
         shuffle_set_split: bool = True,
         batch_size: int = 128,
-        plan_kwargs: Optional[dict] = None,
+        datasplitter_kwargs: dict | None = None,
+        plan_kwargs: dict | None = None,
         **kwargs,
     ):
         """Trains the model using MAP inference.
@@ -304,6 +312,8 @@ class SpatialStereoscope(UnsupervisedTrainingMixin, BaseModelClass):
             sequential order of the data according to `validation_size` and `train_size` percentages.
         batch_size
             Minibatch size to use during training.
+        datasplitter_kwargs
+            Additional keyword arguments passed into :class:`~scvi.dataloaders.DataSplitter`.
         plan_kwargs
             Keyword args for :class:`~scvi.train.TrainingPlan`. Keyword arguments passed to
             `train()` will overwrite values present in `plan_kwargs`, when appropriate.
@@ -325,6 +335,7 @@ class SpatialStereoscope(UnsupervisedTrainingMixin, BaseModelClass):
             validation_size=None,
             shuffle_set_split=shuffle_set_split,
             batch_size=batch_size,
+            datasplitter_kwargs=datasplitter_kwargs,
             plan_kwargs=plan_kwargs,
             **kwargs,
         )
@@ -334,7 +345,7 @@ class SpatialStereoscope(UnsupervisedTrainingMixin, BaseModelClass):
     def setup_anndata(
         cls,
         adata: AnnData,
-        layer: Optional[str] = None,
+        layer: str | None = None,
         **kwargs,
     ):
         """%(summary)s.

--- a/scvi/model/_condscvi.py
+++ b/scvi/model/_condscvi.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import logging
 import warnings
-from typing import List, Optional, Union
 
 import numpy as np
 import torch
@@ -94,9 +95,7 @@ class CondSCVI(RNASeqMixin, VAEMixin, UnsupervisedTrainingMixin, BaseModelClass)
         self.init_params_ = self._get_init_params(locals())
 
     @torch.inference_mode()
-    def get_vamp_prior(
-        self, adata: Optional[AnnData] = None, p: int = 10
-    ) -> np.ndarray:
+    def get_vamp_prior(self, adata: AnnData | None = None, p: int = 10) -> np.ndarray:
         r"""Return an empirical prior over the cell-type specific latent space (vamp prior) that may be used for deconvolution.
 
         Parameters
@@ -203,12 +202,13 @@ class CondSCVI(RNASeqMixin, VAEMixin, UnsupervisedTrainingMixin, BaseModelClass)
         max_epochs: int = 300,
         lr: float = 0.001,
         accelerator: str = "auto",
-        devices: Union[int, List[int], str] = "auto",
+        devices: int | list[int] | str = "auto",
         train_size: float = 1,
-        validation_size: Optional[float] = None,
+        validation_size: float | None = None,
         shuffle_set_split: bool = True,
         batch_size: int = 128,
-        plan_kwargs: Optional[dict] = None,
+        datasplitter_kwargs: dict | None = None,
+        plan_kwargs: dict | None = None,
         **kwargs,
     ):
         """Trains the model using MAP inference.
@@ -231,6 +231,8 @@ class CondSCVI(RNASeqMixin, VAEMixin, UnsupervisedTrainingMixin, BaseModelClass)
             sequential order of the data according to `validation_size` and `train_size` percentages.
         batch_size
             Minibatch size to use during training.
+        datasplitter_kwargs
+            Additional keyword arguments passed into :class:`~scvi.dataloaders.DataSplitter`.
         plan_kwargs
             Keyword args for :class:`~scvi.train.TrainingPlan`. Keyword arguments passed to
             `train()` will overwrite values present in `plan_kwargs`, when appropriate.
@@ -252,6 +254,7 @@ class CondSCVI(RNASeqMixin, VAEMixin, UnsupervisedTrainingMixin, BaseModelClass)
             validation_size=validation_size,
             shuffle_set_split=shuffle_set_split,
             batch_size=batch_size,
+            datasplitter_kwargs=datasplitter_kwargs,
             plan_kwargs=plan_kwargs,
             **kwargs,
         )
@@ -261,8 +264,8 @@ class CondSCVI(RNASeqMixin, VAEMixin, UnsupervisedTrainingMixin, BaseModelClass)
     def setup_anndata(
         cls,
         adata: AnnData,
-        labels_key: Optional[str] = None,
-        layer: Optional[str] = None,
+        labels_key: str | None = None,
+        layer: str | None = None,
         **kwargs,
     ):
         """%(summary)s.

--- a/scvi/model/_destvi.py
+++ b/scvi/model/_destvi.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import logging
 from collections import OrderedDict
-from typing import Dict, List, Optional, Sequence, Union
+from typing import Sequence
 
 import numpy as np
 import pandas as pd
@@ -157,8 +159,8 @@ class DestVI(UnsupervisedTrainingMixin, BaseModelClass):
     def get_proportions(
         self,
         keep_noise: bool = False,
-        indices: Optional[Sequence[int]] = None,
-        batch_size: Optional[int] = None,
+        indices: Sequence[int] | None = None,
+        batch_size: int | None = None,
     ) -> pd.DataFrame:
         """Returns the estimated cell type proportion for the spatial data.
 
@@ -209,10 +211,10 @@ class DestVI(UnsupervisedTrainingMixin, BaseModelClass):
 
     def get_gamma(
         self,
-        indices: Optional[Sequence[int]] = None,
-        batch_size: Optional[int] = None,
+        indices: Sequence[int] | None = None,
+        batch_size: int | None = None,
         return_numpy: bool = False,
-    ) -> Union[np.ndarray, Dict[str, pd.DataFrame]]:
+    ) -> np.ndarray | dict[str, pd.DataFrame]:
         """Returns the estimated cell-type specific latent space for the spatial data.
 
         Parameters
@@ -262,8 +264,8 @@ class DestVI(UnsupervisedTrainingMixin, BaseModelClass):
     def get_scale_for_ct(
         self,
         label: str,
-        indices: Optional[Sequence[int]] = None,
-        batch_size: Optional[int] = None,
+        indices: Sequence[int] | None = None,
+        batch_size: int | None = None,
     ) -> pd.DataFrame:
         r"""Return the scaled parameter of the NB for every spot in queried cell types.
 
@@ -312,13 +314,14 @@ class DestVI(UnsupervisedTrainingMixin, BaseModelClass):
         max_epochs: int = 2000,
         lr: float = 0.003,
         accelerator: str = "auto",
-        devices: Union[int, List[int], str] = "auto",
+        devices: int | list[int] | str = "auto",
         train_size: float = 1.0,
-        validation_size: Optional[float] = None,
+        validation_size: float | None = None,
         shuffle_set_split: bool = True,
         batch_size: int = 128,
         n_epochs_kl_warmup: int = 200,
-        plan_kwargs: Optional[dict] = None,
+        datasplitter_kwargs: dict | None = None,
+        plan_kwargs: dict | None = None,
         **kwargs,
     ):
         """Trains the model using MAP inference.
@@ -343,6 +346,8 @@ class DestVI(UnsupervisedTrainingMixin, BaseModelClass):
             Minibatch size to use during training.
         n_epochs_kl_warmup
             number of epochs needed to reach unit kl weight in the elbo
+        datasplitter_kwargs
+            Additional keyword arguments passed into :class:`~scvi.dataloaders.DataSplitter`.
         plan_kwargs
             Keyword args for :class:`~scvi.train.TrainingPlan`. Keyword arguments passed to
             `train()` will overwrite values present in `plan_kwargs`, when appropriate.
@@ -365,6 +370,7 @@ class DestVI(UnsupervisedTrainingMixin, BaseModelClass):
             validation_size=validation_size,
             shuffle_set_split=shuffle_set_split,
             batch_size=batch_size,
+            datasplitter_kwargs=datasplitter_kwargs,
             plan_kwargs=plan_kwargs,
             **kwargs,
         )
@@ -374,7 +380,7 @@ class DestVI(UnsupervisedTrainingMixin, BaseModelClass):
     def setup_anndata(
         cls,
         adata: AnnData,
-        layer: Optional[str] = None,
+        layer: str | None = None,
         **kwargs,
     ):
         """%(summary)s.

--- a/scvi/model/_peakvi.py
+++ b/scvi/model/_peakvi.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import logging
 from functools import partial
-from typing import Dict, Iterable, List, Literal, Optional, Sequence, Union
+from typing import Iterable, Literal, Sequence
 
 import numpy as np
 import pandas as pd
@@ -84,8 +86,8 @@ class PEAKVI(ArchesMixin, VAEMixin, UnsupervisedTrainingMixin, BaseModelClass):
     def __init__(
         self,
         adata: AnnData,
-        n_hidden: Optional[int] = None,
-        n_latent: Optional[int] = None,
+        n_hidden: int | None = None,
+        n_latent: int | None = None,
         n_layers_encoder: int = 2,
         n_layers_decoder: int = 2,
         dropout_rate: float = 0.1,
@@ -150,9 +152,9 @@ class PEAKVI(ArchesMixin, VAEMixin, UnsupervisedTrainingMixin, BaseModelClass):
         max_epochs: int = 500,
         lr: float = 1e-4,
         accelerator: str = "auto",
-        devices: Union[int, List[int], str] = "auto",
+        devices: int | list[int] | str = "auto",
         train_size: float = 0.9,
-        validation_size: Optional[float] = None,
+        validation_size: float | None = None,
         shuffle_set_split: bool = True,
         batch_size: int = 128,
         weight_decay: float = 1e-3,
@@ -160,10 +162,11 @@ class PEAKVI(ArchesMixin, VAEMixin, UnsupervisedTrainingMixin, BaseModelClass):
         early_stopping: bool = True,
         early_stopping_patience: int = 50,
         save_best: bool = True,
-        check_val_every_n_epoch: Optional[int] = None,
-        n_steps_kl_warmup: Union[int, None] = None,
-        n_epochs_kl_warmup: Union[int, None] = 50,
-        plan_kwargs: Optional[dict] = None,
+        check_val_every_n_epoch: int | None = None,
+        n_steps_kl_warmup: int | None = None,
+        n_epochs_kl_warmup: int | None = 50,
+        datasplitter_kwargs: dict | None = None,
+        plan_kwargs: dict | None = None,
         **kwargs,
     ):
         """Trains the model using amortized variational inference.
@@ -207,6 +210,8 @@ class PEAKVI(ArchesMixin, VAEMixin, UnsupervisedTrainingMixin, BaseModelClass):
         n_epochs_kl_warmup
             Number of epochs to scale weight on KL divergences from 0 to 1.
             Overrides `n_steps_kl_warmup` when both are not `None`.
+        datasplitter_kwargs
+            Additional keyword arguments passed into :class:`~scvi.dataloaders.DataSplitter`.
         plan_kwargs
             Keyword args for :class:`~scvi.train.TrainingPlan`. Keyword arguments passed to
             `train()` will overwrite values present in `plan_kwargs`, when appropriate.
@@ -242,6 +247,7 @@ class PEAKVI(ArchesMixin, VAEMixin, UnsupervisedTrainingMixin, BaseModelClass):
             early_stopping=early_stopping,
             early_stopping_monitor="reconstruction_loss_validation",
             early_stopping_patience=early_stopping_patience,
+            datasplitter_kwargs=datasplitter_kwargs,
             plan_kwargs=plan_kwargs,
             check_val_every_n_epoch=check_val_every_n_epoch,
             batch_size=batch_size,
@@ -251,10 +257,10 @@ class PEAKVI(ArchesMixin, VAEMixin, UnsupervisedTrainingMixin, BaseModelClass):
     @torch.inference_mode()
     def get_library_size_factors(
         self,
-        adata: Optional[AnnData] = None,
+        adata: AnnData | None = None,
         indices: Sequence[int] = None,
         batch_size: int = 128,
-    ) -> Dict[str, np.ndarray]:
+    ) -> dict[str, np.ndarray]:
         """Return library size factors.
 
         Parameters
@@ -294,18 +300,18 @@ class PEAKVI(ArchesMixin, VAEMixin, UnsupervisedTrainingMixin, BaseModelClass):
     @torch.inference_mode()
     def get_accessibility_estimates(
         self,
-        adata: Optional[AnnData] = None,
+        adata: AnnData | None = None,
         indices: Sequence[int] = None,
-        n_samples_overall: Optional[int] = None,
-        region_list: Optional[Sequence[str]] = None,
-        transform_batch: Optional[Union[str, int]] = None,
+        n_samples_overall: int | None = None,
+        region_list: Sequence[str] | None = None,
+        transform_batch: str | int | None = None,
         use_z_mean: bool = True,
-        threshold: Optional[float] = None,
+        threshold: float | None = None,
         normalize_cells: bool = False,
         normalize_regions: bool = False,
         batch_size: int = 128,
         return_numpy: bool = False,
-    ) -> Union[pd.DataFrame, np.ndarray, csr_matrix]:
+    ) -> pd.DataFrame | np.ndarray | csr_matrix:
         """Impute the full accessibility matrix.
 
         Returns a matrix of accessibility probabilities for each cell and genomic region in the input
@@ -415,19 +421,19 @@ class PEAKVI(ArchesMixin, VAEMixin, UnsupervisedTrainingMixin, BaseModelClass):
     @de_dsp.dedent
     def differential_accessibility(
         self,
-        adata: Optional[AnnData] = None,
-        groupby: Optional[str] = None,
-        group1: Optional[Iterable[str]] = None,
-        group2: Optional[str] = None,
-        idx1: Optional[Union[Sequence[int], Sequence[bool], str]] = None,
-        idx2: Optional[Union[Sequence[int], Sequence[bool], str]] = None,
+        adata: AnnData | None = None,
+        groupby: str | None = None,
+        group1: Iterable[str] | None = None,
+        group2: str | None = None,
+        idx1: Sequence[int] | Sequence[bool] | str | None = None,
+        idx2: Sequence[int] | Sequence[bool] | str | None = None,
         mode: Literal["vanilla", "change"] = "change",
         delta: float = 0.05,
-        batch_size: Optional[int] = None,
+        batch_size: int | None = None,
         all_stats: bool = True,
         batch_correction: bool = False,
-        batchid1: Optional[Iterable[str]] = None,
-        batchid2: Optional[Iterable[str]] = None,
+        batchid1: Iterable[str] | None = None,
+        batchid2: Iterable[str] | None = None,
         fdr_target: float = 0.05,
         silent: bool = False,
         two_sided: bool = True,
@@ -551,11 +557,11 @@ class PEAKVI(ArchesMixin, VAEMixin, UnsupervisedTrainingMixin, BaseModelClass):
     def setup_anndata(
         cls,
         adata: AnnData,
-        batch_key: Optional[str] = None,
-        labels_key: Optional[str] = None,
-        categorical_covariate_keys: Optional[List[str]] = None,
-        continuous_covariate_keys: Optional[List[str]] = None,
-        layer: Optional[str] = None,
+        batch_key: str | None = None,
+        labels_key: str | None = None,
+        categorical_covariate_keys: list[str] | None = None,
+        continuous_covariate_keys: list[str] | None = None,
+        layer: str | None = None,
         **kwargs,
     ):
         """%(summary)s.

--- a/scvi/model/base/_jaxmixin.py
+++ b/scvi/model/base/_jaxmixin.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import logging
 import warnings
-from typing import List, Optional, Union
 
 from scvi.dataloaders import DataSplitter
 from scvi.model._utils import get_max_epochs_heuristic, parse_device_args
@@ -20,14 +21,15 @@ class JaxTrainingMixin:
     @devices_dsp.dedent
     def train(
         self,
-        max_epochs: Optional[int] = None,
+        max_epochs: int | None = None,
         accelerator: str = "auto",
-        devices: Union[int, List[int], str] = "auto",
+        devices: int | list[int] | str = "auto",
         train_size: float = 0.9,
-        validation_size: Optional[float] = None,
+        validation_size: float | None = None,
         shuffle_set_split: bool = True,
         batch_size: int = 128,
-        plan_kwargs: Optional[dict] = None,
+        datasplitter_kwargs: dict | None = None,
+        plan_kwargs: dict | None = None,
         **trainer_kwargs,
     ):
         """Train the model.
@@ -51,6 +53,8 @@ class JaxTrainingMixin:
             Minibatch size to use during training.
         lr
             Learning rate to use during training.
+        datasplitter_kwargs
+            Additional keyword arguments passed into :class:`~scvi.dataloaders.DataSplitter`.
         plan_kwargs
             Keyword args for :class:`~scvi.train.JaxTrainingPlan`. Keyword arguments passed to
             `train()` will overwrite values present in `plan_kwargs`, when appropriate.
@@ -75,6 +79,8 @@ class JaxTrainingMixin:
         except RuntimeError:
             logger.debug("No GPU available to Jax.")
 
+        datasplitter_kwargs = datasplitter_kwargs or {}
+
         data_splitter = self._data_splitter_cls(
             self.adata_manager,
             train_size=train_size,
@@ -82,6 +88,7 @@ class JaxTrainingMixin:
             shuffle_set_split=shuffle_set_split,
             batch_size=batch_size,
             iter_ndarray=True,
+            **datasplitter_kwargs,
         )
         plan_kwargs = plan_kwargs if isinstance(plan_kwargs, dict) else {}
 

--- a/scvi/model/base/_pyromixin.py
+++ b/scvi/model/base/_pyromixin.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import logging
-from typing import Callable, Dict, Optional, Union
+from typing import Callable
 
 import numpy as np
 import torch
@@ -84,17 +86,18 @@ class PyroSviTrainMixin:
     @devices_dsp.dedent
     def train(
         self,
-        max_epochs: Optional[int] = None,
+        max_epochs: int | None = None,
         accelerator: str = "auto",
-        device: Union[int, str] = "auto",
+        device: int | str = "auto",
         train_size: float = 0.9,
-        validation_size: Optional[float] = None,
+        validation_size: float | None = None,
         shuffle_set_split: bool = True,
         batch_size: int = 128,
         early_stopping: bool = False,
-        lr: Optional[float] = None,
-        training_plan: Optional[PyroTrainingPlan] = None,
-        plan_kwargs: Optional[dict] = None,
+        lr: float | None = None,
+        training_plan: PyroTrainingPlan | None = None,
+        datasplitter_kwargs: dict | None = None,
+        plan_kwargs: dict | None = None,
         **trainer_kwargs,
     ):
         """Train the model.
@@ -125,6 +128,8 @@ class PyroSviTrainMixin:
             Specifying optimiser via plan_kwargs overrides this choice of lr.
         training_plan
             Training plan :class:`~scvi.train.PyroTrainingPlan`.
+        datasplitter_kwargs
+            Additional keyword arguments passed into :class:`~scvi.dataloaders.DataSplitter`.
         plan_kwargs
             Keyword args for :class:`~scvi.train.PyroTrainingPlan`. Keyword arguments passed to
             `train()` will overwrite values present in `plan_kwargs`, when appropriate.
@@ -138,6 +143,8 @@ class PyroSviTrainMixin:
         if lr is not None and "optim" not in plan_kwargs.keys():
             plan_kwargs.update({"optim_kwargs": {"lr": lr}})
 
+        datasplitter_kwargs = datasplitter_kwargs or {}
+
         if batch_size is None:
             # use data splitter which moves data to GPU once
             data_splitter = DeviceBackedDataSplitter(
@@ -147,6 +154,7 @@ class PyroSviTrainMixin:
                 batch_size=batch_size,
                 accelerator=accelerator,
                 device=device,
+                **datasplitter_kwargs,
             )
         else:
             data_splitter = self._data_splitter_cls(
@@ -155,6 +163,7 @@ class PyroSviTrainMixin:
                 validation_size=validation_size,
                 shuffle_set_split=shuffle_set_split,
                 batch_size=batch_size,
+                **datasplitter_kwargs,
             )
 
         if training_plan is None:
@@ -192,7 +201,7 @@ class PyroSampleMixin:
         self,
         args,
         kwargs,
-        return_sites: Optional[list] = None,
+        return_sites: list | None = None,
         return_observed: bool = False,
     ):
         """Get one sample from posterior distribution.
@@ -249,7 +258,7 @@ class PyroSampleMixin:
         args,
         kwargs,
         num_samples: int = 1000,
-        return_sites: Optional[list] = None,
+        return_sites: list | None = None,
         return_observed: bool = False,
         show_progress: bool = True,
     ):
@@ -358,8 +367,8 @@ class PyroSampleMixin:
     def _posterior_samples_minibatch(
         self,
         accelerator: str = "auto",
-        device: Union[int, str] = "auto",
-        batch_size: Optional[int] = None,
+        device: int | str = "auto",
+        batch_size: int | None = None,
         **sample_kwargs,
     ):
         """Generate samples of the posterior distribution in minibatches.
@@ -465,13 +474,13 @@ class PyroSampleMixin:
     def sample_posterior(
         self,
         num_samples: int = 1000,
-        return_sites: Optional[list] = None,
+        return_sites: list | None = None,
         accelerator: str = "auto",
-        device: Union[int, str] = "auto",
-        batch_size: Optional[int] = None,
+        device: int | str = "auto",
+        batch_size: int | None = None,
         return_observed: bool = False,
         return_samples: bool = False,
-        summary_fun: Optional[Dict[str, Callable]] = None,
+        summary_fun: dict[str, Callable] | None = None,
     ):
         """Summarise posterior distribution.
 

--- a/scvi/model/base/_training_mixin.py
+++ b/scvi/model/base/_training_mixin.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from __future__ import annotations
 
 from scvi.autotune._types import Tunable
 from scvi.dataloaders import DataSplitter
@@ -17,16 +17,17 @@ class UnsupervisedTrainingMixin:
     @devices_dsp.dedent
     def train(
         self,
-        max_epochs: Optional[int] = None,
+        max_epochs: int | None = None,
         accelerator: str = "auto",
-        devices: Union[int, List[int], str] = "auto",
+        devices: int | list[int] | str = "auto",
         train_size: float = 0.9,
-        validation_size: Optional[float] = None,
+        validation_size: float | None = None,
         shuffle_set_split: bool = True,
         load_sparse_tensor: bool = False,
         batch_size: Tunable[int] = 128,
         early_stopping: bool = False,
-        plan_kwargs: Optional[dict] = None,
+        datasplitter_kwargs: dict | None = None,
+        plan_kwargs: dict | None = None,
         **trainer_kwargs,
     ):
         """Train the model.
@@ -55,6 +56,8 @@ class UnsupervisedTrainingMixin:
         early_stopping
             Perform early stopping. Additional arguments can be passed in `**kwargs`.
             See :class:`~scvi.train.Trainer` for further options.
+        datasplitter_kwargs
+            Additional keyword arguments passed into :class:`~scvi.dataloaders.DataSplitter`.
         plan_kwargs
             Keyword args for :class:`~scvi.train.TrainingPlan`. Keyword arguments passed to
             `train()` will overwrite values present in `plan_kwargs`, when appropriate.
@@ -64,7 +67,8 @@ class UnsupervisedTrainingMixin:
         if max_epochs is None:
             max_epochs = get_max_epochs_heuristic(self.adata.n_obs)
 
-        plan_kwargs = plan_kwargs if isinstance(plan_kwargs, dict) else {}
+        plan_kwargs = plan_kwargs or {}
+        datasplitter_kwargs = datasplitter_kwargs or {}
 
         data_splitter = self._data_splitter_cls(
             self.adata_manager,
@@ -76,6 +80,7 @@ class UnsupervisedTrainingMixin:
                 trainer_kwargs.get("strategy", None)
             ),
             load_sparse_tensor=load_sparse_tensor,
+            **datasplitter_kwargs,
         )
         training_plan = self._training_plan_cls(self.module, **plan_kwargs)
 


### PR DESCRIPTION
-   [ ] Closes #2171 
-   [ ] Tests added and passed if fixing a bug or adding a new feature
-   [ ] All code checks passed.
-   [ ] Added type annotations to new arguments/methods/functions.
-   [ ] Added an entry in the latest `docs/release_notes/index.md` file if fixing a bug or adding a new feature.
-   [ ] If the changes are patches for a version, I have added the `on-merge: backport to x.x.x` label.
