### PR TITLE
Fix legacy convert for pandas 2.0

### DIFF
--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -60,6 +60,8 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
     argument is ignored {pr}`2162`.
 -   Fix missing docstring for `unlabeled_category` in
     {class}`scvi.model.SCANVI.setup_anndata` and reorder arguments {pr}`2189`.
+-   Fix Pandas 2.0 unpickling error in {meth}`scvi.model.base.BaseModelClas.convert_legacy_save`
+    by switching to {func}`pandas.read_pickle` for the setup dictionary {pr}`2212`.
 
 ### 1.0.2 (2023-07-05)
 

--- a/scvi/model/base/_utils.py
+++ b/scvi/model/base/_utils.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import pickle
 import warnings
 from collections.abc import Iterable as IterableClass
 from typing import List, Literal, Optional, Tuple, Union
@@ -36,7 +35,7 @@ def _load_legacy_saved_files(
     var_names = np.genfromtxt(var_names_path, delimiter=",", dtype=str)
 
     with open(setup_dict_path, "rb") as handle:
-        attr_dict = pickle.load(handle)
+        attr_dict = pd.read_pickle(handle)
 
     if load_adata:
         adata_path = os.path.join(dir_path, f"{file_name_prefix}adata.h5ad")


### PR DESCRIPTION
-   [ ] Closes #xxxx (Replace xxxx with the GitHub issue number)
-   [ ] Tests added and passed if fixing a bug or adding a new feature
-   [ ] All code checks passed.
-   [ ] Added type annotations to new arguments/methods/functions.
-   [ ] Added an entry in the latest `docs/release_notes/index.md` file if fixing a bug or adding a new feature.
-   [ ] If the changes are patches for a version, I have added the `on-merge: backport to x.x.x` label.
