### PR TITLE
Add `use_posterior_mean` option to scanvi `predict`

### DIFF
--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -30,6 +30,8 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
     and {class}`scvi.external.GIMVI.save` {pr}`2200`.
 -   Add `model_kwargs` and `train_kwargs` arguments to {meth}`scvi.autotune.ModelTuner.fit` {pr}`2203`.
 -   Add `datasplitter_kwargs` to model `train` methods {pr}`2204`.
+-   Add `use_posterior_mean` argument to {meth}`scvi.model.SCANVI.predict` for
+    stochastic prediction of celltype labels {pr}`2224`.
 
 #### Changed
 

--- a/scvi/model/_scanvi.py
+++ b/scvi/model/_scanvi.py
@@ -306,7 +306,7 @@ class SCANVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseMinifiedModeModelClass):
             Minibatch size for data loading into model. Defaults to `scvi.settings.batch_size`.
         use_posterior_mean
             If ``True``, uses the mean of the posterior distribution to predict celltype
-            labels. Otherwise, uses the sample from the posterior distribution.
+            labels. Otherwise, samples from the posterior distribution.
         """
         adata = self._validate_anndata(adata)
 

--- a/scvi/model/_scanvi.py
+++ b/scvi/model/_scanvi.py
@@ -290,6 +290,7 @@ class SCANVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseMinifiedModeModelClass):
         indices: Sequence[int] | None = None,
         soft: bool = False,
         batch_size: int | None = None,
+        use_posterior_mean: bool = True,
     ) -> np.ndarray | pd.DataFrame:
         """Return cell label predictions.
 
@@ -303,6 +304,9 @@ class SCANVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseMinifiedModeModelClass):
             If True, returns per class probabilities
         batch_size
             Minibatch size for data loading into model. Defaults to `scvi.settings.batch_size`.
+        use_posterior_mean
+            If ``True``, uses the mean of the posterior distribution to predict celltype
+            labels. Otherwise, uses the sample from the posterior distribution.
         """
         adata = self._validate_anndata(adata)
 
@@ -326,7 +330,11 @@ class SCANVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseMinifiedModeModelClass):
             cat_covs = tensors[cat_key] if cat_key in tensors.keys() else None
 
             pred = self.module.classify(
-                x, batch_index=batch, cat_covs=cat_covs, cont_covs=cont_covs
+                x,
+                batch_index=batch,
+                cat_covs=cat_covs,
+                cont_covs=cont_covs,
+                use_posterior_mean=use_posterior_mean,
             )
             if not soft:
                 pred = pred.argmax(dim=1)

--- a/scvi/model/_scanvi.py
+++ b/scvi/model/_scanvi.py
@@ -306,7 +306,8 @@ class SCANVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseMinifiedModeModelClass):
             Minibatch size for data loading into model. Defaults to `scvi.settings.batch_size`.
         use_posterior_mean
             If ``True``, uses the mean of the posterior distribution to predict celltype
-            labels. Otherwise, samples from the posterior distribution.
+            labels. Otherwise, uses a sample from the posterior distribution - this
+            means that the predictions will be stochastic.
         """
         adata = self._validate_anndata(adata)
 

--- a/scvi/module/_scanvae.py
+++ b/scvi/module/_scanvae.py
@@ -202,7 +202,7 @@ class SCANVAE(VAE):
         batch_index: Optional[torch.Tensor] = None,
         cont_covs: Optional[torch.Tensor] = None,
         cat_covs: Optional[torch.Tensor] = None,
-        use_posterior_mean: bool = False,
+        use_posterior_mean: bool = True,
     ) -> torch.Tensor:
         """Classify cells into cell types."""
         if self.log_variational:

--- a/scvi/module/_scanvae.py
+++ b/scvi/module/_scanvae.py
@@ -202,6 +202,7 @@ class SCANVAE(VAE):
         batch_index: Optional[torch.Tensor] = None,
         cont_covs: Optional[torch.Tensor] = None,
         cat_covs: Optional[torch.Tensor] = None,
+        use_posterior_mean: bool = False,
     ) -> torch.Tensor:
         """Classify cells into cell types."""
         if self.log_variational:
@@ -217,8 +218,8 @@ class SCANVAE(VAE):
             categorical_input = ()
 
         qz, z = self.z_encoder(encoder_input, batch_index, *categorical_input)
-        # We classify using the inferred mean parameter of z_1 in the latent space
-        z = qz.loc
+        z = qz.loc if use_posterior_mean else z
+
         if self.use_labels_groups:
             w_g = self.classifier_groups(z)
             unw_y = self.classifier(z)

--- a/scvi/module/_scanvae.py
+++ b/scvi/module/_scanvae.py
@@ -206,7 +206,7 @@ class SCANVAE(VAE):
     ) -> torch.Tensor:
         """Classify cells into cell types."""
         if self.log_variational:
-            x = torch.log(1 + x)
+            x = torch.log1p(x)
 
         if cont_covs is not None and self.encode_covariates:
             encoder_input = torch.cat((x, cont_covs), dim=-1)

--- a/tests/model/test_scanvi.py
+++ b/tests/model/test_scanvi.py
@@ -1,0 +1,14 @@
+import scvi
+
+
+def test_scanvi_predict_use_posterior_mean():
+    adata = scvi.data.synthetic_iid()
+    scvi.model.SCANVI.setup_anndata(
+        adata, labels_key="labels", unlabeled_category="label_0"
+    )
+
+    model = scvi.model.SCANVI(adata)
+    model.train(max_epochs=1)
+
+    _ = model.predict(use_posterior_mean=True)
+    _ = model.predict(use_posterior_mean=False)


### PR DESCRIPTION
-   [x] Closes #1587 (Replace xxxx with the GitHub issue number)
-   [x] Tests added and passed if fixing a bug or adding a new feature
-   [x] All code checks passed.
-   [x] Added type annotations to new arguments/methods/functions.
-   [x] Added an entry in the latest `docs/release_notes/index.md` file if fixing a bug or adding a new feature.
-   [x] If the changes are patches for a version, I have added the `on-merge: backport to x.x.x` label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Feature**
- Added a new argument `use_posterior_mean` to the `predict` method in the `SCANVI` class. This allows for stochastic prediction of cell type labels.

**Bug Fix**
- Replaced `torch.log` with `torch.log1p` in `_scanvae.py` to avoid numerical instability.

**Test**
- Introduced a new test function `test_scanvi_predict_use_posterior_mean()` to validate the functionality of the new feature.

> 🎉 Here's to the code that's ever so lean,  
> With `use_posterior_mean`, predictions are keen.  
> No more instability, thanks to `log1p`,  
> Our tests ensure we don't miss a blip! 🚀
<!-- end of auto-generated comment: release notes by coderabbit.ai -->