### PR TITLE
Pass in `n_hidden` to `Encoder` in `AmortizedLDA`

### DIFF
--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -33,6 +33,11 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
 -   Add `use_posterior_mean` argument to {meth}`scvi.model.SCANVI.predict` for
     stochastic prediction of celltype labels {pr}`2224`.
 
+#### Fixed
+
+-   Fix bug where `n_hidden` was not being passed into {class}`scvi.nn.Encoder` in {class}`scvi.model.AmortizedLDA`
+    {pr}`2229`
+
 #### Changed
 
 -   Replace `sparse` with `sparse_format` argument in {meth}`scvi.data.synthetic_iid`

--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -39,6 +39,7 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
     method {pr}`2173`. `metrics["diff_exp"]` is now a dictionary where the `summary`
     stores the summary dataframe, and the `lfc_per_model_per_group` key stores the
     per-group LFC.
+-   `n_hidden` is taking effect in AmortizedLDA.
 
 #### Removed
 

--- a/scvi/module/_amortizedlda.py
+++ b/scvi/module/_amortizedlda.py
@@ -163,7 +163,9 @@ class AmortizedLDAPyroGuide(PyroModule):
         # Populated by PyroTrainingPlan.
         self.n_obs = None
 
-        self.encoder = Encoder(n_input, n_topics, distribution="ln", return_dist=True, n_hidden=n_hidden)
+        self.encoder = Encoder(
+            n_input, n_topics, distribution="ln", return_dist=True, n_hidden=n_hidden
+        )
         (
             topic_feature_posterior_mu,
             topic_feature_posterior_sigma,

--- a/scvi/module/_amortizedlda.py
+++ b/scvi/module/_amortizedlda.py
@@ -163,7 +163,7 @@ class AmortizedLDAPyroGuide(PyroModule):
         # Populated by PyroTrainingPlan.
         self.n_obs = None
 
-        self.encoder = Encoder(n_input, n_topics, distribution="ln", return_dist=True)
+        self.encoder = Encoder(n_input, n_topics, distribution="ln", return_dist=True, n_hidden=n_hidden)
         (
             topic_feature_posterior_mu,
             topic_feature_posterior_sigma,


### PR DESCRIPTION
n_hidden was without effect in AmortizedLDA.

-   X Closes #xxxx (Replace xxxx with the GitHub issue number)
-   X Tests added and passed if fixing a bug or adding a new feature
-   [X] All code checks passed.
-   [X] Added type annotations to new arguments/methods/functions.
-   [x] Added an entry in the latest `docs/release_notes/index.md` file if fixing a bug or adding a new feature.
-   [X ] If the changes are patches for a version, I have added the `on-merge: backport to x.x.x` label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Release Notes:**

- **New Feature:** The `n_hidden` parameter is now effective in the `AmortizedLDA` model. This enhancement allows users to specify the number of hidden layers in the model, providing more flexibility and control over the model's complexity.

> 🎉 Here's to the code that's ever evolving,
> With each new feature, it's complexity solving.
> Now with `n_hidden` in our stride,
> In `AmortizedLDA`, it takes pride.
> More control, more power, we're revolving! 🚀
<!-- end of auto-generated comment: release notes by coderabbit.ai -->