### PR TITLE
Fix tunable detection for new type annotation

### DIFF
--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -32,6 +32,7 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
 -   Add `datasplitter_kwargs` to model `train` methods {pr}`2204`.
 -   Add `use_posterior_mean` argument to {meth}`scvi.model.SCANVI.predict` for
     stochastic prediction of celltype labels {pr}`2224`.
+-   Add support for Python 3.10+ type annotations in {class}`scvi.autotune.ModelTuner` {pr}`2239`.
 
 #### Fixed
 


### PR DESCRIPTION
-   [ ] Closes #xxxx (Replace xxxx with the GitHub issue number)
-   [ ] Tests added and passed if fixing a bug or adding a new feature
-   [ ] All code checks passed.
-   [x] Added type annotations to new arguments/methods/functions.
-   [x] Added an entry in the latest `docs/release_notes/index.md` file if fixing a bug or adding a new feature.
-   [ ] If the changes are patches for a version, I have added the `on-merge: backport to x.x.x` label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

```
- New Feature: Enhanced support for Python 3.10+ type annotations in `scvi.autotune.ModelTuner` class. The `_parse_func_params` function now handles both old and new type annotations for tunable parameters, improving the overall handling of these parameters.

> 🎉🐇
> 
> "In the land of code, where logic intertwines,
> A rabbit hops, leaving traces of fine lines.
> With Python 3.10, we dance and cheer,
> For better annotation support is finally here! 🥳"
```
<!-- end of auto-generated comment: release notes by coderabbit.ai -->