### PR TITLE
Log learning rate when `reduce_lr_on_plateau=True`

### DIFF
--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -38,7 +38,7 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
 -   Add option to pass in a random seed to {meth}`scvi.autotune.ModelTuner.fit`
     with argument `seed` {pr}`2260`.
 -   Log the learning rate when `reduce_lr_on_plateau` is `True` in
-    {class}`scvi.train.TrainingPlan` {pr}`xxxx`.
+    {class}`scvi.train.TrainingPlan` {pr}`2270`.
 
 #### Fixed
 

--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -37,6 +37,8 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
     with argument `monitor_device_stats` {pr}`2260`.
 -   Add option to pass in a random seed to {meth}`scvi.autotune.ModelTuner.fit`
     with argument `seed` {pr}`2260`.
+-   Log the learning rate when `reduce_lr_on_plateau` is `True` in
+    {class}`scvi.train.TrainingPlan` {pr}`xxxx`.
 
 #### Fixed
 

--- a/scvi/train/_trainingplans.py
+++ b/scvi/train/_trainingplans.py
@@ -325,12 +325,22 @@ class TrainingPlan(TunableMixin, pl.LightningModule):
         )
 
         if mode == "train" and self.reduce_lr_on_plateau:
-            self.log(
-                "lr",
-                self.optimizers().param_groups[0]["lr"],
-                on_step=False,
-                on_epoch=True,
-            )
+            optimizers = self.optimizers()
+            if isinstance(optimizers, list):
+                for i, opt in enumerate(optimizers):
+                    self.log(
+                        f"lr_{i}",
+                        opt.param_groups[0]["lr"],
+                        on_step=False,
+                        on_epoch=True,
+                    )
+            else:
+                self.log(
+                    "lr",
+                    self.optimizers().param_groups[0]["lr"],
+                    on_step=False,
+                    on_epoch=True,
+                )
 
         # accumlate extra metrics passed to loss recorder
         for key in loss_output.extra_metrics_keys:

--- a/scvi/train/_trainingplans.py
+++ b/scvi/train/_trainingplans.py
@@ -324,6 +324,14 @@ class TrainingPlan(TunableMixin, pl.LightningModule):
             sync_dist=self.use_sync_dist,
         )
 
+        if mode == "train" and self.reduce_lr_on_plateau:
+            self.log(
+                "lr",
+                self.optimizers().param_groups[0]["lr"],
+                on_step=False,
+                on_epoch=True,
+            )
+
         # accumlate extra metrics passed to loss recorder
         for key in loss_output.extra_metrics_keys:
             met = loss_output.extra_metrics[key]


### PR DESCRIPTION
-   [ ] Closes #xxxx (Replace xxxx with the GitHub issue number)
-   [ ] Tests added and passed if fixing a bug or adding a new feature
-   [ ] All code checks passed.
-   [x] Added type annotations to new arguments/methods/functions.
-   [x] Added an entry in the latest `docs/release_notes/index.md` file if fixing a bug or adding a new feature.
-   [ ] If the changes are patches for a version, I have added the `on-merge: backport to x.x.x` label.
