### PR TITLE
Make `mde()` consistent with docstring for `device` argument

### DIFF
--- a/scvi/model/utils/_mde.py
+++ b/scvi/model/utils/_mde.py
@@ -57,8 +57,12 @@ def mde(
 
     if isinstance(data, pd.DataFrame):
         data = data.values
-
-    device = "cpu" if not torch.cuda.is_available() else "cuda"
+        
+    if device not in ["cpu", "cuda", None]:
+        raise ValueError("`device` must be 'cpu' or 'cuda'")
+    
+    if device is None:
+        device = "cpu" if not torch.cuda.is_available() else "cuda"
 
     _kwargs = {
         "embedding_dim": 2,

--- a/scvi/model/utils/_mde.py
+++ b/scvi/model/utils/_mde.py
@@ -57,10 +57,10 @@ def mde(
 
     if isinstance(data, pd.DataFrame):
         data = data.values
-        
+
     if device not in ["cpu", "cuda", None]:
         raise ValueError("`device` must be 'cpu' or 'cuda'")
-    
+
     if device is None:
         device = "cpu" if not torch.cuda.is_available() else "cuda"
 


### PR DESCRIPTION
`device` always defaults to "cuda" if a GPU is available, even if "cpu" is explicitly indicated

-   [ ] Closes #xxxx (Replace xxxx with the GitHub issue number)
-   [ ] Tests added and passed if fixing a bug or adding a new feature
-   [ ] All code checks passed.
-   [ ] Added type annotations to new arguments/methods/functions.
-   [ ] Added an entry in the latest `docs/release_notes/index.md` file if fixing a bug or adding a new feature.
-   [ ] If the changes are patches for a version, I have added the `on-merge: backport to x.x.x` label.
