### PR TITLE
Allow for other registry keys in dtype conversion

### DIFF
--- a/scvi/data/_utils.py
+++ b/scvi/data/_utils.py
@@ -46,25 +46,14 @@ ScipySparse = Union[
 def registry_key_to_default_dtype(key: str) -> type:
     """Returns the default dtype for a given registry key."""
     if key in [
-        REGISTRY_KEYS.X_KEY,
-        REGISTRY_KEYS.PROTEIN_EXP_KEY,
-        REGISTRY_KEYS.CONT_COVS_KEY,
-        REGISTRY_KEYS.SIZE_FACTOR_KEY,
-        REGISTRY_KEYS.MINIFY_TYPE_KEY,
-        REGISTRY_KEYS.LATENT_QZM_KEY,
-        REGISTRY_KEYS.LATENT_QZV_KEY,
-        REGISTRY_KEYS.OBSERVED_LIB_SIZE,
-    ]:
-        return np.float32
-    elif key in [
         REGISTRY_KEYS.BATCH_KEY,
         REGISTRY_KEYS.LABELS_KEY,
         REGISTRY_KEYS.CAT_COVS_KEY,
         REGISTRY_KEYS.INDICES_KEY,
     ]:
         return np.int64
-    else:
-        raise KeyError(f"Invalid registry key: {key}")
+
+    return np.float32
 
 
 def scipy_to_torch_sparse(x: ScipySparse) -> torch.Tensor:


### PR DESCRIPTION
-   [ ] Closes #xxxx (Replace xxxx with the GitHub issue number)
-   [ ] Tests added and passed if fixing a bug or adding a new feature
-   [ ] All code checks passed.
-   [ ] Added type annotations to new arguments/methods/functions.
-   [ ] Added an entry in the latest `docs/release_notes/index.md` file if fixing a bug or adding a new feature.
-   [ ] If the changes are patches for a version, I have added the `on-merge: backport to x.x.x` label.
