### PR TITLE
Pin Pandas to not 2.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "jaxlib>=0.4.3",
     "optax",
     "numpy>=1.21.0",
-    "pandas>=1.0",
+    "pandas>=1.0,!=2.1.2",
     "scipy",
     "scikit-learn>=0.21.2",
     "rich>=12.0.0",


### PR DESCRIPTION
Pandas 2.1.2 currently causes a `RecursionError` during tests (see [here](https://github.com/scverse/scvi-tools/actions/runs/6696369392/job/18194152332#step:6:3358) and [here](https://github.com/scverse/anndata/issues/1210)), and pinning to `!= 2.1.2` fixes this for now until https://github.com/pandas-dev/pandas/pull/55764 merges.
