### PR TITLE
Move chex to test dep

### DIFF
--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -41,6 +41,8 @@ is available in the [commit logs](https://github.com/YosefLab/scvi-tools/commits
     training plans {pr}`2280`.
 -   {class}`scvi.train.SemiSupervisedTrainingPlan` now logs the classifier
     calibration error {pr}`2299`.
+-   Change `chex` to a tests-only dependency. Use `flax.struct.dataclass` in place of
+    `chex.dataclass` {pr}`2319`.
 
 #### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ classifiers = [
 ]
 dependencies = [
     "anndata>=0.7.5",
-    "chex<=0.1.8",  # see https://github.com/scverse/scvi-tools/pull/2187
     "docrep>=0.3.2",
     "flax",
     "jax>=0.4.4",
@@ -63,6 +62,7 @@ dependencies = [
 tests = [
     "pytest",
     "pytest-cov",
+    "chex<=0.1.8",  # see https://github.com/scverse/scvi-tools/pull/2187
     "scvi-tools[optional]"
 ]  # dependencies for running the test suite
 editing = [

--- a/scvi/autotune/_manager.py
+++ b/scvi/autotune/_manager.py
@@ -10,9 +10,9 @@ from collections import OrderedDict
 from datetime import datetime
 from typing import Any, Callable
 
+import flax
 import lightning.pytorch as pl
 import rich
-from chex import dataclass
 
 try:
     import ray
@@ -36,7 +36,7 @@ from ._utils import in_notebook
 logger = logging.getLogger(__name__)
 
 
-@dataclass
+@flax.struct.dataclass
 class TuneAnalysis:
     """Dataclass for storing results from a tuning experiment."""
 

--- a/scvi/module/base/_base_module.py
+++ b/scvi/module/base/_base_module.py
@@ -5,7 +5,6 @@ from collections.abc import Iterable
 from dataclasses import field
 from typing import Any, Callable
 
-import chex
 import flax
 import jax
 import jax.numpy as jnp
@@ -29,7 +28,7 @@ from ._decorators import auto_move_data
 from ._pyro import AutoMoveDataPredictive
 
 
-@chex.dataclass
+@flax.struct.dataclass
 class LossOutput:
     """Loss signature for models.
 


### PR DESCRIPTION
Move chex out to test dependencies. Aims to reduce issues between torch and jax implementations. Can close #2318 for now.

-   [ ] All code checks passed.
-   [x] Added an entry in the latest `docs/release_notes/index.md` file if fixing a bug or adding a new feature.