### PR TITLE
Fix release template formatting

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -7,26 +7,13 @@ assignees: ""
 ---
 
 -   [ ] Bump version in `pyproject.toml`.
--   [ ] If patch release, backport version bump PR into the appropriate branch.
-        Else, create a new branch off `main` with the appropriate rules.
--   [ ] Create a new GitHub draft release targeting the release branch with the
-        same body as the previous release (don't release yet).
--   [ ] Trigger a Docker image build in
-        [`scvi-tools-docker`](https://github.com/YosefLab/scvi-tools-docker)
-        targeting the release branch.
--   [ ] After image builds and pushes to the registry, run the
-        [tutorials](https://github.com/scverse/scvi-tutorials) using the new
-        image.
--   [ ] Publish a new release on the tutorials repo off `main` after all
-        tutorials changes have been merged.
--   [ ] Create a new branch off `main` in the main repo and run
-        `git submodule update --remote`, and then merge the PR, with an
-        appropriate backport as needed.
--   [ ] Double check everything and then publish the draft release on the main
-        repo.
--   [ ] Check that the
-        [feedstock repo](https://github.com/conda-forge/scvi-tools-feedstock)
-        updates correctly.
--   [ ] Check that the version updates correctly on
-        [PyPI](https://pypi.org/project/scvi-tools/).
+-   [ ] If patch release, backport version bump PR into the appropriate branch. Else, create a new branch off `main` with the appropriate rules.
+-   [ ] Create a new GitHub draft release targeting the release branch with the same body as the previous release (don't release yet).
+-   [ ] Trigger a Docker image build in [`scvi-tools-docker`](https://github.com/YosefLab/scvi-tools-docker) targeting the release branch.
+-   [ ] After image builds and pushes to the registry, run the [tutorials](https://github.com/scverse/scvi-tutorials) using the new image.
+-   [ ] Publish a new release on the tutorials repo off `main` after all tutorials changes have been merged.
+-   [ ] Create a new branch off `main` in the main repo and run `git submodule update --remote`, and then merge the PR, with an appropriate backport as needed.
+-   [ ] Double check everything and then publish the draft release on the main repo.
+-   [ ] Check that the [feedstock repo](https://github.com/conda-forge/scvi-tools-feedstock) updates correctly.
+-   [ ] Check that the version updates correctly on [PyPI](https://pypi.org/project/scvi-tools/).
 -   [ ] (Optional) Post threads on Discourse and Twitter!

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 -   [ ] Closes #xxxx (Replace xxxx with the GitHub issue number)
 -   [ ] Tests added and passed if fixing a bug or adding a new feature
--   [ ] All code checks passed.
--   [ ] Added type annotations to new arguments/methods/functions.
--   [ ] Added an entry in the latest `docs/release_notes/index.md` file if fixing a bug or adding a new feature.
--   [ ] If the changes are patches for a version, I have added the `on-merge: backport to x.x.x` label.
+-   [ ] All code checks passed
+-   [ ] Added type annotations to new arguments/methods/functions
+-   [ ] Added an entry in the latest `docs/release_notes/index.md` file if fixing a bug or adding a new feature
+-   [ ] If the changes are patches for a version, I have added the `on-merge: backport to x.x.x` label


### PR DESCRIPTION
-   [ ] Closes #xxxx (Replace xxxx with the GitHub issue number)
-   [ ] Tests added and passed if fixing a bug or adding a new feature
-   [ ] All code checks passed.
-   [ ] Added type annotations to new arguments/methods/functions.
-   [ ] Added an entry in the latest `docs/release_notes/index.md` file if fixing a bug or adding a new feature.
-   [ ] If the changes are patches for a version, I have added the `on-merge: backport to x.x.x` label.
