### PR TITLE
Format timestamps for compatibility with new `fsspec`

### DIFF
--- a/scvi/autotune/_manager.py
+++ b/scvi/autotune/_manager.py
@@ -491,7 +491,7 @@ class TunerManager:
         self, experiment_name: str | None, logging_dir: str | None
     ) -> tuple[str, str]:
         if experiment_name is None:
-            experiment_name = datetime.now().strftime("%Y-%m-%d-%H:%M:%S")
+            experiment_name = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
             experiment_name += f"_{self._model_cls.__name__.lower()}"
         if logging_dir is None:
             logging_dir = os.path.join(settings.logging_dir, "autotune")

--- a/scvi/train/_callbacks.py
+++ b/scvi/train/_callbacks.py
@@ -4,7 +4,6 @@ import os
 import warnings
 from copy import deepcopy
 from datetime import datetime
-from pathlib import Path
 from shutil import rmtree
 from typing import Callable
 
@@ -72,7 +71,6 @@ class SaveCheckpoint(ModelCheckpoint):
                 datetime.now().strftime("%Y-%m-%d_%H-%M-%S"),
             )
             dirpath += f"_{monitor}"
-            Path(dirpath).mkdir(parents=True, exist_ok=True)
 
         if filename is None:
             filename = "{epoch}-{step}-{" + monitor + "}"
@@ -91,10 +89,6 @@ class SaveCheckpoint(ModelCheckpoint):
                 stacklevel=settings.warnings_stacklevel,
             )
             kwargs.pop("save_last")
-
-        print("$$$$$$$$$$")
-        print(dirpath)
-        print(os.listdir(settings.logging_dir))
 
         super().__init__(
             dirpath=dirpath,

--- a/scvi/train/_callbacks.py
+++ b/scvi/train/_callbacks.py
@@ -4,6 +4,7 @@ import os
 import warnings
 from copy import deepcopy
 from datetime import datetime
+from pathlib import Path
 from shutil import rmtree
 from typing import Callable
 
@@ -68,9 +69,10 @@ class SaveCheckpoint(ModelCheckpoint):
         if dirpath is None:
             dirpath = os.path.join(
                 settings.logging_dir,
-                datetime.now().strftime("%Y-%m-%d-%H:%M:%S"),
+                datetime.now().strftime("%Y-%m-%d_%H-%M-%S"),
             )
-            dirpath += f"-{monitor}"
+            dirpath += f"_{monitor}"
+            Path(dirpath).mkdir(parents=True, exist_ok=True)
 
         if filename is None:
             filename = "{epoch}-{step}-{" + monitor + "}"
@@ -89,6 +91,10 @@ class SaveCheckpoint(ModelCheckpoint):
                 stacklevel=settings.warnings_stacklevel,
             )
             kwargs.pop("save_last")
+
+        print("$$$$$$$$$$")
+        print(dirpath)
+        print(os.listdir(settings.logging_dir))
 
         super().__init__(
             dirpath=dirpath,

--- a/tests/autotune/test_tuner.py
+++ b/tests/autotune/test_tuner.py
@@ -1,14 +1,15 @@
 import scvi
+from scvi.autotune import ModelTuner
 
 
 def test_model_tuner_init():
     model_cls = scvi.model.SCVI
-    scvi.autotune.ModelTuner(model_cls)
+    ModelTuner(model_cls)
 
 
-def test_model_tuner_fit(save_path):
+def test_model_tuner_fit(save_path: str):
     model_cls = scvi.model.SCVI
-    tuner = scvi.autotune.ModelTuner(model_cls)
+    tuner = ModelTuner(model_cls)
 
     adata = scvi.data.synthetic_iid()
     model_cls.setup_anndata(adata)
@@ -24,6 +25,6 @@ def test_model_tuner_fit(save_path):
 
 def test_model_tuner_info():
     model_cls = scvi.model.SCVI
-    tuner = scvi.autotune.ModelTuner(model_cls)
+    tuner = ModelTuner(model_cls)
 
     tuner.info()

--- a/tests/train/test_callbacks.py
+++ b/tests/train/test_callbacks.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 
 import pytest
 
@@ -27,9 +26,7 @@ def test_modelcheckpoint_callback(save_path: str):
         assert checkpoint.is_trained_
 
     def test_model_cls(model_cls, adata):
-        logging_dir = os.path.join(save_path, model_cls.__name__)
-        Path(logging_dir).mkdir(parents=True, exist_ok=True)
-        scvi.settings.logging_dir = logging_dir
+        scvi.settings.logging_dir = os.path.join(save_path, model_cls.__name__)
 
         # enable_checkpointing=True, default monitor
         model = model_cls(adata)

--- a/tests/train/test_callbacks.py
+++ b/tests/train/test_callbacks.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import pytest
 
@@ -26,7 +27,9 @@ def test_modelcheckpoint_callback(save_path: str):
         assert checkpoint.is_trained_
 
     def test_model_cls(model_cls, adata):
-        scvi.settings.logging_dir = os.path.join(save_path, model_cls.__name__)
+        logging_dir = os.path.join(save_path, model_cls.__name__)
+        Path(logging_dir).mkdir(parents=True, exist_ok=True)
+        scvi.settings.logging_dir = logging_dir
 
         # enable_checkpointing=True, default monitor
         model = model_cls(adata)


### PR DESCRIPTION
Logging directory formatting in `SaveCheckpoint` and `ModelTuner` was causing [errors](https://github.com/scverse/scvi-tools/actions/runs/7076214573/job/19259213548) since we use `-` and `:` for dates. Replacing these with `_` fixes the issue.

Looks like this was caused by `fsspec==2023.12.0` since [pinning](https://github.com/scverse/scvi-tools/pull/2344) to `2023.10.0` also fixes the issue. Not sure exactly what's in the new release that's causing this, but probably best to change the formatting. This is backwards compatible as auto-formatting of logging directories in `SaveCheckpoint` and `ModelTuner` were set to be released in 1.1. 
