### PR TITLE
Switch from `optax.additive_weight_decay` to `optax.add_decayed_weights`

### DIFF
--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -54,7 +54,7 @@ is available in the [commit logs](https://github.com/scverse/scvi-tools/commits/
 -   Add `seed` argument to {func}`scvi.model.utils.mde` for reproducibility {pr}`2373`.
 -   Add {meth}`scvi.hub.HubModel.save` and {meth}`scvi.hub.HubMetadata.save` {pr}`2382`.
 -   Add support for Optax 0.1.8 by renaming instances of {func}`optax.additive_weight_decay` to
-    {func}`optax.add_weight_decay` {pr}`xxxx`.
+    {func}`optax.add_weight_decay` {pr}`2396`.
 
 #### Fixed
 

--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -53,6 +53,8 @@ is available in the [commit logs](https://github.com/scverse/scvi-tools/commits/
     metrics on a subset of the data {pr}`2361`.
 -   Add `seed` argument to {func}`scvi.model.utils.mde` for reproducibility {pr}`2373`.
 -   Add {meth}`scvi.hub.HubModel.save` and {meth}`scvi.hub.HubMetadata.save` {pr}`2382`.
+-   Add support for Optax 0.1.8 by renaming instances of {func}`optax.additive_weight_decay` to
+    {func}`optax.add_weight_decay` {pr}`xxxx`.
 
 #### Fixed
 

--- a/scvi/train/_trainingplans.py
+++ b/scvi/train/_trainingplans.py
@@ -1242,7 +1242,7 @@ class JaxTrainingPlan(TrainingPlan):
             # Replicates PyTorch Adam defaults
             optim = optax.chain(
                 clip_by,
-                optax.additive_weight_decay(weight_decay=self.weight_decay),
+                optax.add_decayed_weights(weight_decay=self.weight_decay),
                 optax.adam(self.lr, eps=self.eps),
             )
         elif self.optimizer_name == "AdamW":


### PR DESCRIPTION
Fixes #2394. 

See discussion detailing that both functions are equivalent, just that one has been deprecated and removed: https://github.com/google-deepmind/optax/issues/307