### PR TITLE
Remove pypi token from workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Upload release to PyPI
 
 on:
     push:
@@ -28,5 +28,3 @@ jobs:
 
             - name: Publish a Python distribution to PyPI
               uses: pypa/gh-action-pypi-publish@release/v1
-              with:
-                  password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
-   [ ] Closes #xxxx (Replace xxxx with the GitHub issue number)
-   [ ] Tests added and passed if fixing a bug or adding a new feature
-   [ ] All code checks passed
-   [ ] Added type annotations to new arguments/methods/functions
-   [ ] Added an entry in the latest `docs/release_notes/index.md` file if fixing a bug or adding a new feature
-   [ ] If the changes are patches for a version, I have added the `on-merge: backport to x.x.x` label
