### PR TITLE
Fix reinitialization error in GIMVI

### DIFF
--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -76,6 +76,7 @@ is available in the [commit logs](https://github.com/scverse/scvi-tools/commits/
 -   Fix initialization of {class}`scvi.distributions.NegativeBinomial` and
     {class}`scvi.distributions.ZeroInflatedNegativeBinomial` when `validate_args=True` and
     optional parameters not passed in {pr}`2395`.
+-   Fix error when re-initializing {class}`scvi.external.GIMVI` with the same datasets {pr}`2446`.
 
 #### Changed
 

--- a/scvi/external/gimvi/_model.py
+++ b/scvi/external/gimvi/_model.py
@@ -121,7 +121,19 @@ class GIMVI(VAEMixin, BaseModelClass):
 
         # since we are combining datasets, we need to increment the batch_idx
         # of one of the datasets
-        self.n_seq_batch = sum_stats[0]["n_batch"]
+        adata_seq_n_batches = sum_stats[0]["n_batch"]
+        adata_spatial_batch = adata_spatial.obs[
+            self.adata_managers["spatial"]
+            .data_registry[REGISTRY_KEYS.BATCH_KEY]
+            .attr_key
+        ]
+        if np.min(adata_spatial_batch) == 0:
+            # see #2446
+            adata_spatial.obs[
+                self.adata_managers["spatial"]
+                .data_registry[REGISTRY_KEYS.BATCH_KEY]
+                .attr_key
+            ] += adata_seq_n_batches
 
         n_batches = sum(s["n_batch"] for s in sum_stats)
 
@@ -212,7 +224,6 @@ class GIMVI(VAEMixin, BaseModelClass):
         )
         self.train_indices_, self.test_indices_, self.validation_indices_ = [], [], []
         train_dls, test_dls, val_dls = [], [], []
-        # seq and then spatial
         for i, adm in enumerate(self.adata_managers.values()):
             ds = DataSplitter(
                 adm,
@@ -238,7 +249,6 @@ class GIMVI(VAEMixin, BaseModelClass):
             self.module,
             adversarial_classifier=True,
             scale_adversarial_loss=kappa,
-            n_seq_batch=self.n_seq_batch,
             **plan_kwargs,
         )
 

--- a/scvi/external/gimvi/_model.py
+++ b/scvi/external/gimvi/_model.py
@@ -121,12 +121,7 @@ class GIMVI(VAEMixin, BaseModelClass):
 
         # since we are combining datasets, we need to increment the batch_idx
         # of one of the datasets
-        adata_seq_n_batches = sum_stats[0]["n_batch"]
-        adata_spatial.obs[
-            self.adata_managers["spatial"]
-            .data_registry[REGISTRY_KEYS.BATCH_KEY]
-            .attr_key
-        ] += adata_seq_n_batches
+        self.n_seq_batch = sum_stats[0]["n_batch"]
 
         n_batches = sum(s["n_batch"] for s in sum_stats)
 
@@ -217,6 +212,7 @@ class GIMVI(VAEMixin, BaseModelClass):
         )
         self.train_indices_, self.test_indices_, self.validation_indices_ = [], [], []
         train_dls, test_dls, val_dls = [], [], []
+        # seq and then spatial
         for i, adm in enumerate(self.adata_managers.values()):
             ds = DataSplitter(
                 adm,
@@ -242,6 +238,7 @@ class GIMVI(VAEMixin, BaseModelClass):
             self.module,
             adversarial_classifier=True,
             scale_adversarial_loss=kappa,
+            n_seq_batch=self.n_seq_batch,
             **plan_kwargs,
         )
 

--- a/scvi/external/gimvi/_model.py
+++ b/scvi/external/gimvi/_model.py
@@ -119,8 +119,6 @@ class GIMVI(VAEMixin, BaseModelClass):
 
         total_genes = n_inputs[0]
 
-        # since we are combining datasets, we need to increment the batch_idx
-        # of one of the datasets
         adata_seq_n_batches = sum_stats[0]["n_batch"]
         adata_spatial_batch = adata_spatial.obs[
             self.adata_managers["spatial"]
@@ -129,6 +127,8 @@ class GIMVI(VAEMixin, BaseModelClass):
         ]
         if np.min(adata_spatial_batch) == 0:
             # see #2446
+            # since we are combining datasets, we need to increment the batch_idx of one of the
+            # datasets. we only need to do this once so we check if the min is 0
             adata_spatial.obs[
                 self.adata_managers["spatial"]
                 .data_registry[REGISTRY_KEYS.BATCH_KEY]

--- a/scvi/external/gimvi/_task.py
+++ b/scvi/external/gimvi/_task.py
@@ -8,7 +8,7 @@ from scvi.train import AdversarialTrainingPlan
 class GIMVITrainingPlan(AdversarialTrainingPlan):
     """gimVI training plan."""
 
-    def __init__(self, *args, n_seq_batch: int = 0, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if kwargs["adversarial_classifier"] is True:
             self.n_output_classifier = 2
@@ -23,8 +23,6 @@ class GIMVITrainingPlan(AdversarialTrainingPlan):
             self.adversarial_classifier = kwargs["adversarial_classifier"]
         self.automatic_optimization = False
         self.validation_step_outputs = []
-
-        self.n_seq_batch = n_seq_batch
 
     def training_step(self, batch, batch_idx):
         """Training step."""
@@ -45,10 +43,6 @@ class GIMVITrainingPlan(AdversarialTrainingPlan):
         zs = []
         for i, tensors in enumerate(batch):
             n_obs += tensors[REGISTRY_KEYS.X_KEY].shape[0]
-            if i == 1:  # spatial
-                # since we are combining datasets, we need to increment the batch_idx
-                # of one of the datasets
-                tensors[REGISTRY_KEYS.BATCH_KEY] += self.n_seq_batch
             self.loss_kwargs.update({"kl_weight": self.kl_weight, "mode": i})
             inference_kwargs = {"mode": i}
             generative_kwargs = {"mode": i}

--- a/scvi/external/gimvi/_task.py
+++ b/scvi/external/gimvi/_task.py
@@ -8,7 +8,7 @@ from scvi.train import AdversarialTrainingPlan
 class GIMVITrainingPlan(AdversarialTrainingPlan):
     """gimVI training plan."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, n_seq_batch: int = 0, **kwargs):
         super().__init__(*args, **kwargs)
         if kwargs["adversarial_classifier"] is True:
             self.n_output_classifier = 2
@@ -23,6 +23,8 @@ class GIMVITrainingPlan(AdversarialTrainingPlan):
             self.adversarial_classifier = kwargs["adversarial_classifier"]
         self.automatic_optimization = False
         self.validation_step_outputs = []
+
+        self.n_seq_batch = n_seq_batch
 
     def training_step(self, batch, batch_idx):
         """Training step."""
@@ -43,6 +45,10 @@ class GIMVITrainingPlan(AdversarialTrainingPlan):
         zs = []
         for i, tensors in enumerate(batch):
             n_obs += tensors[REGISTRY_KEYS.X_KEY].shape[0]
+            if i == 1:  # spatial
+                # since we are combining datasets, we need to increment the batch_idx
+                # of one of the datasets
+                tensors[REGISTRY_KEYS.BATCH_KEY] += self.n_seq_batch
             self.loss_kwargs.update({"kl_weight": self.kl_weight, "mode": i})
             inference_kwargs = {"mode": i}
             generative_kwargs = {"mode": i}

--- a/tests/external/gimvi/test_gimvi.py
+++ b/tests/external/gimvi/test_gimvi.py
@@ -169,3 +169,22 @@ def test_gimvi_model_library_size():
     model.train(1, check_val_every_n_epoch=1, train_size=0.5)
     model.get_latent_representation()
     model.get_imputed_values()
+
+
+def test_gimvi_reinit():
+    adata_seq = synthetic_iid()
+    adata_spatial = synthetic_iid()
+    GIMVI.setup_anndata(
+        adata_seq,
+        batch_key="batch",
+        labels_key="labels",
+    )
+    GIMVI.setup_anndata(
+        adata_spatial,
+        batch_key="batch",
+        labels_key="labels",
+    )
+    model = GIMVI(adata_seq, adata_spatial)
+    model.train(max_epochs=1)
+    model = GIMVI(adata_seq, adata_spatial)
+    model.train(max_epochs=1)

--- a/tests/external/gimvi/test_gimvi.py
+++ b/tests/external/gimvi/test_gimvi.py
@@ -172,6 +172,7 @@ def test_gimvi_model_library_size():
 
 
 def test_gimvi_reinit():
+    # see #2446
     adata_seq = synthetic_iid()
     adata_spatial = synthetic_iid()
     GIMVI.setup_anndata(


### PR DESCRIPTION
Fixes #2273. Error occurs when re-initializing GIMVI with the same spatial dataset due to the following code in `GIMVI.__init__` that in-place modified an `.obs` column:
```
adata_seq_n_batches = sum_stats[0]["n_batch"]
adata_spatial.obs[
    self.adata_managers["spatial"]
    .data_registry[REGISTRY_KEYS.BATCH_KEY]
    .attr_key
] += adata_seq_n_batches
```
This was necessary as the spatial batches and GEX batches were 0-indexed, but we wanted to distinguish between them. The fix checks whether the obs column's minimum is 0, and if so, we add the offset. Otherwise, we don't, since that means the column was updated before within the same session.