### PR TITLE
Add API for custom dataloaders in `SCVI`

### DIFF
--- a/docs/api/developer.md
+++ b/docs/api/developer.md
@@ -287,6 +287,7 @@ Utility functions used by scvi-tools.
    utils.track
    utils.setup_anndata_dsp
    utils.attrdict
+   model.get_max_epochs_heuristic
 ```
 
 [ray tune]: https://docs.ray.io/en/latest/tune/index.html

--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -59,6 +59,9 @@ is available in the [commit logs](https://github.com/scverse/scvi-tools/commits/
     {meth}`scvi.hub.HubModel.pull_from_s3` and {meth}`scvi.hub.HubModel.push_to_s3` {pr}`2378`.
 -   Add clearer error message for {func}`scvi.data.poisson_gene_selection` when input data does not
     contain raw counts {pr}`2422`.
+-   Add API for using custom dataloaders with {class}`scvi.model.SCVI` by making `adata` argument
+    optional on initialization and adding optional argument `data_module` to
+    {meth}`scvi.model.base.UnsupervisedTrainingMixin.train` {pr}`2467`.
 
 #### Fixed
 

--- a/scvi/model/__init__.py
+++ b/scvi/model/__init__.py
@@ -10,6 +10,7 @@ from ._peakvi import PEAKVI
 from ._scanvi import SCANVI
 from ._scvi import SCVI
 from ._totalvi import TOTALVI
+from ._utils import get_max_epochs_heuristic
 
 __all__ = [
     "SCVI",

--- a/scvi/model/_scvi.py
+++ b/scvi/model/_scvi.py
@@ -127,12 +127,12 @@ class SCVI(
             "latent_distribution": latent_distribution,
             **kwargs,
         }
-        self._model_summary_string = f"""
-        SCVI model with the following parameters: \n
-        n_hidden: {n_hidden}, n_latent: {n_latent}, n_layers: {n_layers},
-        dropout_rate: {dropout_rate}, dispersion: {dispersion},
-        gene_likelihood: {gene_likelihood}, latent_distribution: {latent_distribution}.
-        """
+        self._model_summary_string = (
+            "SCVI model with the following parameters: \n"
+            f"n_hidden: {n_hidden}, n_latent: {n_latent}, n_layers: {n_layers}, "
+            f"dropout_rate: {dropout_rate}, dispersion: {dispersion}, "
+            f"gene_likelihood: {gene_likelihood}, latent_distribution: {latent_distribution}."
+        )
 
         if self._module_init_on_train:
             self.module = None

--- a/scvi/model/_scvi.py
+++ b/scvi/model/_scvi.py
@@ -51,7 +51,7 @@ class SCVI(
     adata
         AnnData object that has been registered via :meth:`~scvi.model.SCVI.setup_anndata`. If
         ``None``, then the underlying module will not be initialized until training, and a
-        :class:`~lightning.LightningDataModule` must be passed in during training
+        :class:`~lightning.pytorch.core.LightningDataModule` must be passed in during training
         (``EXPERIMENTAL``).
     n_hidden
         Number of nodes per hidden layer.

--- a/scvi/model/_scvi.py
+++ b/scvi/model/_scvi.py
@@ -137,8 +137,8 @@ class SCVI(
         if self._module_init_on_train:
             self.module = None
             warnings.warn(
-                "Model was initialized without `adata`. The module will be initialized during "
-                "training. This behavior is experimental and may change in the future.",
+                "Model was initialized without `adata`. The module will be initialized when "
+                "calling `train`. This behavior is experimental and may change in the future.",
                 UserWarning,
                 stacklevel=settings.warnings_stacklevel,
             )

--- a/scvi/model/_scvi.py
+++ b/scvi/model/_scvi.py
@@ -51,7 +51,7 @@ class SCVI(
     adata
         AnnData object that has been registered via :meth:`~scvi.model.SCVI.setup_anndata`. If
         ``None``, then the underlying module will not be initialized until training, and a
-        :class:`~lightning.pytorch.LightningDataModule` must be passed in during training
+        :class:`~lightning.LightningDataModule` must be passed in during training
         (``EXPERIMENTAL``).
     n_hidden
         Number of nodes per hidden layer.

--- a/scvi/model/_scvi.py
+++ b/scvi/model/_scvi.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
+
 import logging
-from typing import Literal, Optional
+import warnings
+from typing import Literal
 
 import numpy as np
 from anndata import AnnData
 
-from scvi import REGISTRY_KEYS
+from scvi import REGISTRY_KEYS, settings
 from scvi._types import MinifiedDataType
 from scvi.data import AnnDataManager
 from scvi.data._constants import _ADATA_MINIFY_TYPE_UNS_KEY, ADATA_MINIFY_TYPE
@@ -46,7 +49,10 @@ class SCVI(
     Parameters
     ----------
     adata
-        AnnData object that has been registered via :meth:`~scvi.model.SCVI.setup_anndata`.
+        AnnData object that has been registered via :meth:`~scvi.model.SCVI.setup_anndata`. If
+        ``None``, then the underlying module will not be initialized until training, and a
+        :class:`~lightning.pytorch.LightningDataModule` must be passed in during training
+        (``EXPERIMENTAL``).
     n_hidden
         Number of nodes per hidden layer.
     n_latent
@@ -73,8 +79,8 @@ class SCVI(
 
         * ``'normal'`` - Normal distribution
         * ``'ln'`` - Logistic normal distribution (Normal(0, I) transformed by softmax)
-    **model_kwargs
-        Keyword args for :class:`~scvi.module.VAE`
+    **kwargs
+        Additional keyword arguments for :class:`~scvi.module.VAE`.
 
     Examples
     --------
@@ -99,7 +105,7 @@ class SCVI(
 
     def __init__(
         self,
-        adata: AnnData,
+        adata: AnnData | None = None,
         n_hidden: int = 128,
         n_latent: int = 10,
         n_layers: int = 1,
@@ -107,58 +113,72 @@ class SCVI(
         dispersion: Literal["gene", "gene-batch", "gene-label", "gene-cell"] = "gene",
         gene_likelihood: Literal["zinb", "nb", "poisson"] = "zinb",
         latent_distribution: Literal["normal", "ln"] = "normal",
-        **model_kwargs,
+        **kwargs,
     ):
         super().__init__(adata)
 
-        n_cats_per_cov = (
-            self.adata_manager.get_state_registry(
-                REGISTRY_KEYS.CAT_COVS_KEY
-            ).n_cats_per_key
-            if REGISTRY_KEYS.CAT_COVS_KEY in self.adata_manager.data_registry
-            else None
-        )
-        n_batch = self.summary_stats.n_batch
-        use_size_factor_key = (
-            REGISTRY_KEYS.SIZE_FACTOR_KEY in self.adata_manager.data_registry
-        )
-        library_log_means, library_log_vars = None, None
-        if not use_size_factor_key and self.minified_data_type is None:
-            library_log_means, library_log_vars = _init_library_size(
-                self.adata_manager, n_batch
-            )
+        self._module_kwargs = {
+            "n_hidden": n_hidden,
+            "n_latent": n_latent,
+            "n_layers": n_layers,
+            "dropout_rate": dropout_rate,
+            "dispersion": dispersion,
+            "gene_likelihood": gene_likelihood,
+            "latent_distribution": latent_distribution,
+            **kwargs,
+        }
+        self._model_summary_string = f"""
+        SCVI model with the following parameters: \n
+        n_hidden: {n_hidden}, n_latent: {n_latent}, n_layers: {n_layers},
+        dropout_rate: {dropout_rate}, dispersion: {dispersion},
+        gene_likelihood: {gene_likelihood}, latent_distribution: {latent_distribution}.
+        """
 
-        self.module = self._module_cls(
-            n_input=self.summary_stats.n_vars,
-            n_batch=n_batch,
-            n_labels=self.summary_stats.n_labels,
-            n_continuous_cov=self.summary_stats.get("n_extra_continuous_covs", 0),
-            n_cats_per_cov=n_cats_per_cov,
-            n_hidden=n_hidden,
-            n_latent=n_latent,
-            n_layers=n_layers,
-            dropout_rate=dropout_rate,
-            dispersion=dispersion,
-            gene_likelihood=gene_likelihood,
-            latent_distribution=latent_distribution,
-            use_size_factor_key=use_size_factor_key,
-            library_log_means=library_log_means,
-            library_log_vars=library_log_vars,
-            **model_kwargs,
-        )
-        self.module.minified_data_type = self.minified_data_type
-        self._model_summary_string = (
-            "SCVI Model with the following params: \nn_hidden: {}, n_latent: {}, n_layers: {}, dropout_rate: "
-            "{}, dispersion: {}, gene_likelihood: {}, latent_distribution: {}"
-        ).format(
-            n_hidden,
-            n_latent,
-            n_layers,
-            dropout_rate,
-            dispersion,
-            gene_likelihood,
-            latent_distribution,
-        )
+        if self._module_init_on_train:
+            self.module = None
+            warnings.warn(
+                "Model was initialized without `adata`. The module will be initialized during "
+                "training. This behavior is experimental and may change in the future.",
+                UserWarning,
+                stacklevel=settings.warnings_stacklevel,
+            )
+        else:
+            n_cats_per_cov = (
+                self.adata_manager.get_state_registry(
+                    REGISTRY_KEYS.CAT_COVS_KEY
+                ).n_cats_per_key
+                if REGISTRY_KEYS.CAT_COVS_KEY in self.adata_manager.data_registry
+                else None
+            )
+            n_batch = self.summary_stats.n_batch
+            use_size_factor_key = (
+                REGISTRY_KEYS.SIZE_FACTOR_KEY in self.adata_manager.data_registry
+            )
+            library_log_means, library_log_vars = None, None
+            if not use_size_factor_key and self.minified_data_type is None:
+                library_log_means, library_log_vars = _init_library_size(
+                    self.adata_manager, n_batch
+                )
+            self.module = self._module_cls(
+                n_input=self.summary_stats.n_vars,
+                n_batch=n_batch,
+                n_labels=self.summary_stats.n_labels,
+                n_continuous_cov=self.summary_stats.get("n_extra_continuous_covs", 0),
+                n_cats_per_cov=n_cats_per_cov,
+                n_hidden=n_hidden,
+                n_latent=n_latent,
+                n_layers=n_layers,
+                dropout_rate=dropout_rate,
+                dispersion=dispersion,
+                gene_likelihood=gene_likelihood,
+                latent_distribution=latent_distribution,
+                use_size_factor_key=use_size_factor_key,
+                library_log_means=library_log_means,
+                library_log_vars=library_log_vars,
+                **kwargs,
+            )
+            self.module.minified_data_type = self.minified_data_type
+
         self.init_params_ = self._get_init_params(locals())
 
     @classmethod
@@ -166,12 +186,12 @@ class SCVI(
     def setup_anndata(
         cls,
         adata: AnnData,
-        layer: Optional[str] = None,
-        batch_key: Optional[str] = None,
-        labels_key: Optional[str] = None,
-        size_factor_key: Optional[str] = None,
-        categorical_covariate_keys: Optional[list[str]] = None,
-        continuous_covariate_keys: Optional[list[str]] = None,
+        layer: str | None = None,
+        batch_key: str | None = None,
+        labels_key: str | None = None,
+        size_factor_key: str | None = None,
+        categorical_covariate_keys: list[str] | None = None,
+        continuous_covariate_keys: list[str] | None = None,
         **kwargs,
     ):
         """%(summary)s.

--- a/scvi/model/_utils.py
+++ b/scvi/model/_utils.py
@@ -34,13 +34,14 @@ def use_distributed_sampler(strategy: Union[str, Strategy]) -> bool:
 
 
 def get_max_epochs_heuristic(
-    n_obs: int, epochs_cap: int = 400, decay_at_n_obs: int = 20000
+    n_obs: int, epochs_cap: int = 400, decay_at_n_obs: int = 20_000
 ) -> int:
     """Compute a heuristic for the default number of maximum epochs.
 
-    If `n_obs <= decay_at_n_obs`, the number of maximum epochs is set to
-    `epochs_cap`. Otherwise, the number of maximum epochs decays according to
-    `(decay_at_n_obs / n_obs) * epochs_cap`, with a minimum of 1.
+    If ``n_obs <= decay_at_n_obs``, the number of maximum epochs is set to
+    ``epochs_cap``. Otherwise, the number of maximum epochs decays according to
+    ``(decay_at_n_obs / n_obs) * epochs_cap``, with a minimum of 1. Raises a
+    warning if the number of maximum epochs is set to 1.
 
     Parameters
     ----------
@@ -53,8 +54,7 @@ def get_max_epochs_heuristic(
 
     Returns
     -------
-    `int`
-        A heuristic for the default number of maximum epochs.
+    A heuristic for the number of maximum training epochs.
     """
     max_epochs = min(round((decay_at_n_obs / n_obs) * epochs_cap), epochs_cap)
     max_epochs = max(max_epochs, 1)

--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -98,6 +98,7 @@ class BaseModelClass(TunableMixin, metaclass=BaseModelMetaClass):
             self.registry_ = self._adata_manager.registry
             self.summary_stats = self._adata_manager.summary_stats
 
+        self._module_init_on_train = adata is None
         self.is_trained_ = False
         self._model_summary_string = ""
         self.train_indices_ = None

--- a/scvi/model/base/_training_mixin.py
+++ b/scvi/model/base/_training_mixin.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from lightning.pytorch import LightningDataModule
+from lightning import LightningDataModule
 
 from scvi._types import Tunable
 from scvi.dataloaders import DataSplitter
@@ -70,9 +70,8 @@ class UnsupervisedTrainingMixin:
             Keyword args for :class:`~scvi.train.TrainingPlan`. Keyword arguments passed to
             `train()` will overwrite values present in `plan_kwargs`, when appropriate.
         data_module
-            ``EXPERIMENTAL`` A :class:`~lightning.pytorch.LightningDataModule` instance to use for
-            training. Can only be passed in if the model was not initialized with
-            :class:`~anndata.AnnData`.
+            ``EXPERIMENTAL`` A :class:`~lightning.LightningDataModule` instance to use for training.
+            Can only be passed in if the model was not initialized with :class:`~anndata.AnnData`.
         **trainer_kwargs
             Other keyword args for :class:`~scvi.train.Trainer`.
         """

--- a/scvi/model/base/_training_mixin.py
+++ b/scvi/model/base/_training_mixin.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from lightning.pytorch import LightningDataModule
+
 from scvi._types import Tunable
 from scvi.dataloaders import DataSplitter
 from scvi.model._utils import get_max_epochs_heuristic, use_distributed_sampler
@@ -28,6 +30,7 @@ class UnsupervisedTrainingMixin:
         early_stopping: bool = False,
         datasplitter_kwargs: dict | None = None,
         plan_kwargs: dict | None = None,
+        data_module: LightningDataModule | None = None,
         **trainer_kwargs,
     ):
         """Train the model.
@@ -35,53 +38,91 @@ class UnsupervisedTrainingMixin:
         Parameters
         ----------
         max_epochs
-            Number of passes through the dataset. If `None`, defaults to
-            `np.min([round((20000 / n_cells) * 400), 400])`
+            Number of passes through the dataset. If ``None``, defaults to
+            `np.min([round((20000 / n_cells) * 400), 400])`. Must be passed if ``data_module`` is
+            passed in and does not have ``n_obs`` attribute.
         %(param_accelerator)s
         %(param_devices)s
         train_size
-            Size of training set in the range [0.0, 1.0].
+            Size of training set in the range ``[0.0, 1.0]``. Not used if ``data_module`` is passed
+            in.
         validation_size
-            Size of the test set. If `None`, defaults to 1 - `train_size`. If
-            `train_size + validation_size < 1`, the remaining cells belong to a test set.
+            Size of the test set. If ``None``, defaults to ``1 - train_size``. If
+            ``train_size + validation_size < 1``, the remaining cells belong to a test set. Not used
+            if ``data_module`` is passed in.
         shuffle_set_split
-            Whether to shuffle indices before splitting. If `False`, the val, train, and test set are split in the
-            sequential order of the data according to `validation_size` and `train_size` percentages.
+            Whether to shuffle indices before splitting. If ``False``, the val, train, and test set
+            are split in the sequential order of the data according to ``validation_size`` and
+            ``train_size`` percentages. Not used if ``data_module`` is passed in.
         load_sparse_tensor
             ``EXPERIMENTAL`` If ``True``, loads data with sparse CSR or CSC layout as a
             :class:`~torch.Tensor` with the same layout. Can lead to speedups in data transfers to
-            GPUs, depending on the sparsity of the data.
+            GPUs, depending on the sparsity of the data. Not used if ``data_module`` is passed in.
         batch_size
-            Minibatch size to use during training.
+            Minibatch size to use during training. Not used if ``data_module`` is passed in.
         early_stopping
             Perform early stopping. Additional arguments can be passed in `**kwargs`.
             See :class:`~scvi.train.Trainer` for further options.
         datasplitter_kwargs
-            Additional keyword arguments passed into :class:`~scvi.dataloaders.DataSplitter`.
+            Additional keyword arguments passed into :class:`~scvi.dataloaders.DataSplitter`. Not
+            used if ``data_module`` is passed in.
         plan_kwargs
             Keyword args for :class:`~scvi.train.TrainingPlan`. Keyword arguments passed to
             `train()` will overwrite values present in `plan_kwargs`, when appropriate.
+        data_module
+            ``EXPERIMENTAL`` A :class:`~lightning.pytorch.LightningDataModule` instance to use for
+            training. Can only be passed in if the model was not initialized with
+            :class:`~anndata.AnnData`.
         **trainer_kwargs
             Other keyword args for :class:`~scvi.train.Trainer`.
         """
-        if max_epochs is None:
+        if data_module is not None and not self._module_init_on_train:
+            raise ValueError(
+                "Cannot pass in `data_module` if the model was initialized with `adata`."
+            )
+        elif data_module is None and self._module_init_on_train:
+            raise ValueError(
+                "If the model was not initialized with `adata`, a `data_module` must be passed in."
+            )
+
+        if max_epochs is None and data_module is None:
             max_epochs = get_max_epochs_heuristic(self.adata.n_obs)
+        elif (
+            max_epochs is None
+            and data_module is not None
+            and hasattr(data_module, "n_obs")
+        ):
+            max_epochs = get_max_epochs_heuristic(data_module.n_obs)
+        elif max_epochs is None and data_module is not None:
+            raise ValueError(
+                "If `data_module` does not have `n_obs` attribute, `max_epochs` must be passed in."
+            )
 
         plan_kwargs = plan_kwargs or {}
         datasplitter_kwargs = datasplitter_kwargs or {}
 
-        data_splitter = self._data_splitter_cls(
-            self.adata_manager,
-            train_size=train_size,
-            validation_size=validation_size,
-            batch_size=batch_size,
-            shuffle_set_split=shuffle_set_split,
-            distributed_sampler=use_distributed_sampler(
-                trainer_kwargs.get("strategy", None)
-            ),
-            load_sparse_tensor=load_sparse_tensor,
-            **datasplitter_kwargs,
-        )
+        if data_module is None:
+            data_module = self._data_splitter_cls(
+                self.adata_manager,
+                train_size=train_size,
+                validation_size=validation_size,
+                batch_size=batch_size,
+                shuffle_set_split=shuffle_set_split,
+                distributed_sampler=use_distributed_sampler(
+                    trainer_kwargs.get("strategy", None)
+                ),
+                load_sparse_tensor=load_sparse_tensor,
+                **datasplitter_kwargs,
+            )
+        else:
+            self.module = self._module_cls(
+                data_module.n_vars,
+                n_batch=data_module.n_batch,
+                n_labels=getattr(data_module, "n_labels", 1),
+                n_continuous_cov=getattr(data_module, "n_continuous_cov", 0),
+                n_cats_per_cov=getattr(data_module, "n_cats_per_cov", None),
+                **self._module_kwargs,
+            )
         training_plan = self._training_plan_cls(self.module, **plan_kwargs)
 
         es = "early_stopping"
@@ -91,7 +132,7 @@ class UnsupervisedTrainingMixin:
         runner = self._train_runner_cls(
             self,
             training_plan=training_plan,
-            data_splitter=data_splitter,
+            data_splitter=data_module,
             max_epochs=max_epochs,
             accelerator=accelerator,
             devices=devices,

--- a/scvi/model/base/_training_mixin.py
+++ b/scvi/model/base/_training_mixin.py
@@ -38,42 +38,49 @@ class UnsupervisedTrainingMixin:
         Parameters
         ----------
         max_epochs
-            Number of passes through the dataset. If ``None``, defaults to
-            `np.min([round((20000 / n_cells) * 400), 400])`. Must be passed if ``data_module`` is
-            passed in and does not have ``n_obs`` attribute.
+            The maximum number of epochs to train the model. The actual number of epochs may be
+            less if early stopping is enabled. If ``None``, defaults to a heuristic based on
+            :func:`~scvi.model.get_max_epochs_heuristic`. Must be passed in if ``data_module`` is
+            passed in, and it does not have an ``n_obs`` attribute.
         %(param_accelerator)s
         %(param_devices)s
         train_size
-            Size of training set in the range ``[0.0, 1.0]``. Not used if ``data_module`` is passed
-            in.
+            Size of training set in the range ``[0.0, 1.0]``. Passed into
+            :class:`~scvi.dataloaders.DataSplitter`. Not used if ``data_module`` is passed in.
         validation_size
             Size of the test set. If ``None``, defaults to ``1 - train_size``. If
-            ``train_size + validation_size < 1``, the remaining cells belong to a test set. Not used
-            if ``data_module`` is passed in.
+            ``train_size + validation_size < 1``, the remaining cells belong to a test set. Passed
+            into :class:`~scvi.dataloaders.DataSplitter`. Not used if ``data_module`` is passed in.
         shuffle_set_split
             Whether to shuffle indices before splitting. If ``False``, the val, train, and test set
             are split in the sequential order of the data according to ``validation_size`` and
-            ``train_size`` percentages. Not used if ``data_module`` is passed in.
+            ``train_size`` percentages. Passed into :class:`~scvi.dataloaders.DataSplitter`. Not
+            used if ``data_module`` is passed in.
         load_sparse_tensor
             ``EXPERIMENTAL`` If ``True``, loads data with sparse CSR or CSC layout as a
             :class:`~torch.Tensor` with the same layout. Can lead to speedups in data transfers to
-            GPUs, depending on the sparsity of the data. Not used if ``data_module`` is passed in.
+            GPUs, depending on the sparsity of the data. Passed into
+            :class:`~scvi.dataloaders.DataSplitter`. Not used if ``data_module`` is passed in.
         batch_size
-            Minibatch size to use during training. Not used if ``data_module`` is passed in.
+            Minibatch size to use during training. Passed into
+            :class:`~scvi.dataloaders.DataSplitter`. Not used if ``data_module`` is passed in.
         early_stopping
-            Perform early stopping. Additional arguments can be passed in `**kwargs`.
+            Perform early stopping. Additional arguments can be passed in through ``**kwargs``.
             See :class:`~scvi.train.Trainer` for further options.
         datasplitter_kwargs
-            Additional keyword arguments passed into :class:`~scvi.dataloaders.DataSplitter`. Not
-            used if ``data_module`` is passed in.
+            Additional keyword arguments passed into :class:`~scvi.dataloaders.DataSplitter`. Values
+            in this argument can be overwritten by arguments directly passed into this method, when
+            appropriate. Not used if ``data_module`` is passed in.
         plan_kwargs
-            Keyword args for :class:`~scvi.train.TrainingPlan`. Keyword arguments passed to
-            `train()` will overwrite values present in `plan_kwargs`, when appropriate.
+            Additional keyword arguments passed into :class:`~scvi.train.TrainingPlan`. Values in
+            this argument can be overwritten by arguments directly passed into this method, when
+            appropriate.
         data_module
-            ``EXPERIMENTAL`` A :class:`~lightning.LightningDataModule` instance to use for training.
-            Can only be passed in if the model was not initialized with :class:`~anndata.AnnData`.
-        **trainer_kwargs
-            Other keyword args for :class:`~scvi.train.Trainer`.
+            ``EXPERIMENTAL`` A :class:`~lightning.LightningDataModule` instance to use for training
+            in place of the default :class:`~scvi.dataloaders.DataSplitter`. Can only be passed in
+            if the model was not initialized with :class:`~anndata.AnnData`.
+        **kwargs
+           Additional keyword arguments passed into :class:`~scvi.train.Trainer`.
         """
         if data_module is not None and not self._module_init_on_train:
             raise ValueError(
@@ -84,23 +91,19 @@ class UnsupervisedTrainingMixin:
                 "If the model was not initialized with `adata`, a `data_module` must be passed in."
             )
 
-        if max_epochs is None and data_module is None:
-            max_epochs = get_max_epochs_heuristic(self.adata.n_obs)
-        elif (
-            max_epochs is None
-            and data_module is not None
-            and hasattr(data_module, "n_obs")
-        ):
-            max_epochs = get_max_epochs_heuristic(data_module.n_obs)
-        elif max_epochs is None and data_module is not None:
-            raise ValueError(
-                "If `data_module` does not have `n_obs` attribute, `max_epochs` must be passed in."
-            )
-
-        plan_kwargs = plan_kwargs or {}
-        datasplitter_kwargs = datasplitter_kwargs or {}
+        if max_epochs is None:
+            if data_module is None:
+                max_epochs = get_max_epochs_heuristic(self.adata.n_obs)
+            elif hasattr(data_module, "n_obs"):
+                max_epochs = get_max_epochs_heuristic(data_module.n_obs)
+            else:
+                raise ValueError(
+                    "If `data_module` does not have `n_obs` attribute, `max_epochs` must be passed "
+                    "in."
+                )
 
         if data_module is None:
+            datasplitter_kwargs = datasplitter_kwargs or {}
             data_module = self._data_splitter_cls(
                 self.adata_manager,
                 train_size=train_size,
@@ -122,6 +125,8 @@ class UnsupervisedTrainingMixin:
                 n_cats_per_cov=getattr(data_module, "n_cats_per_cov", None),
                 **self._module_kwargs,
             )
+
+        plan_kwargs = plan_kwargs or {}
         training_plan = self._training_plan_cls(self.module, **plan_kwargs)
 
         es = "early_stopping"

--- a/scvi/model/base/_training_mixin.py
+++ b/scvi/model/base/_training_mixin.py
@@ -76,9 +76,9 @@ class UnsupervisedTrainingMixin:
             this argument can be overwritten by arguments directly passed into this method, when
             appropriate.
         data_module
-            ``EXPERIMENTAL`` A :class:`~lightning.LightningDataModule` instance to use for training
-            in place of the default :class:`~scvi.dataloaders.DataSplitter`. Can only be passed in
-            if the model was not initialized with :class:`~anndata.AnnData`.
+            ``EXPERIMENTAL`` A :class:`~lightning.pytorch.core.LightningDataModule` instance to use
+            for training in place of the default :class:`~scvi.dataloaders.DataSplitter`. Can only
+            be passed in if the model was not initialized with :class:`~anndata.AnnData`.
         **kwargs
            Additional keyword arguments passed into :class:`~scvi.train.Trainer`.
         """

--- a/scvi/model/base/_training_mixin.py
+++ b/scvi/model/base/_training_mixin.py
@@ -116,7 +116,7 @@ class UnsupervisedTrainingMixin:
                 load_sparse_tensor=load_sparse_tensor,
                 **datasplitter_kwargs,
             )
-        else:
+        elif self.module is None:
             self.module = self._module_cls(
                 data_module.n_vars,
                 n_batch=data_module.n_batch,

--- a/tests/hub/test_hub_metadata.py
+++ b/tests/hub/test_hub_metadata.py
@@ -87,7 +87,7 @@ def test_hub_modelcardhelper(request, save_path):
     assert hmch.license_info == "cc-by-4.0"
     assert hmch.model_cls_name == "SCVI"
     assert hmch.model_init_params == {
-        "kwargs": {"model_kwargs": {}},
+        "kwargs": {"kwargs": {}},
         "non_kwargs": {
             "n_hidden": 128,
             "n_latent": 10,


### PR DESCRIPTION
This commit enables users to bypass the default workflow of setting up an `AnnData` and initializing a model with it in order to train, and instead being able to train a model directly with a custom dataloader.

- Make `adata` argument optional in `SCVI`, which sets a `_module_init_on_train` flag (through `BaseModelClass`) if no `adata` is passed in
- This causes the module init to be delayed until train time since we won't have access to certain arguments (*e.g.* `n_input` and `n_batch`) that must be inferred from the data
- Add an optional `data_module` argument to `UnsupervisedTrainingMixin.train` that must be a `LightningDataModule` and must be passed in if the model was not initialized with `adata`

Set as an experimental feature for now. Will expand to models other than `SCVI` when the implementation and API stabilize.