### PR TITLE
Make xarray and sparse optional deps, remove chex dep, remove Pandas pin, support newest Ray, temp remove cellxgene dep

### DIFF
--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -59,6 +59,7 @@ is available in the [commit logs](https://github.com/scverse/scvi-tools/commits/
     {meth}`scvi.hub.HubModel.pull_from_s3` and {meth}`scvi.hub.HubModel.push_to_s3` {pr}`2378`.
 -   Add clearer error message for {func}`scvi.data.poisson_gene_selection` when input data does not
     contain raw counts {pr}`2422`.
+-   Add support for `ray[tune]>=2.8` in {class}`scvi.autotune.ModelTuner` {pr}`2472`.
 
 #### Fixed
 
@@ -102,12 +103,18 @@ is available in the [commit logs](https://github.com/scverse/scvi-tools/commits/
     computations to use `"micro"` reduction rather than `"macro"` {pr}`2339`.
 -   Internal refactoring of {meth}`scvi.module.VAE.sample` and
     {meth}`scvi.model.base.RNASeqMixin.posterior_predictive_sample` {pr}`2377`.
+-   Change `xarray` and `sparse` from mandatory to optional dependencies {pr}`2472`.
+-   Change {class}`scvi.autotune.TuneAnalysis` to inherit from {class}`dataclassses.dataclass`
+    instead of {class}`chex.dataclass` for compatibility {pr}`2472`.
+-   Change {class}`scvi.module.base.LossOutput` to inherit from {class}`flax.struct.dataclass`
+    instead of {class}`chex.dataclass` for compatibility {pr}`2472`.
 
 #### Removed
 
 -   Remove deprecated `use_gpu argument in favor of PyTorch Lightning arguments
 `accelerator`and`devices` {pr}`2114`.
 -   Remove deprecated `scvi._compat.Literal` class {pr}`2115`.
+-   Remove `chex` as mandatory dependency {pr}`2472`.
 
 ## Version 1.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "jaxlib>=0.4.3",
     "optax",
     "numpy>=1.21.0",
-    "pandas>=1.0,!=2.1.2",
+    "pandas>=1.0",
     "scipy",
     "scikit-learn>=0.21.2",
     "rich>=12.0.0",
@@ -53,8 +53,6 @@ dependencies = [
     "numpyro>=0.12.1",
     "ml-collections>=0.1.1",
     "mudata>=0.1.2",
-    "sparse>=0.14.0",
-    "xarray>=2023.2.0",
 ]
 
 
@@ -97,13 +95,14 @@ autotune = [
 ]  # scvi.autotune
 aws = ["boto3"] # scvi.hub.HubModel.pull_from_s3
 census = ["cellxgene-census"]  # scvi.data.cellxgene
+criticism = ["xarray>=2023.2.0", "sparse>=0.14.0"]  # scvi.criticism
 hub = ["huggingface_hub"]  # scvi.hub dependencies
 pymde = ["pymde"]  # scvi.model.utils.mde dependencies
 regseq = ["biopython>=1.81", "genomepy"]  # scvi.data.add_dna_sequence
 loompy = ["loompy>=3.0.6"]  # read loom
 scanpy = ["scanpy>=1.6"]  # scvi.criticism and read 10x
 optional = [
-    "scvi-tools[autotune,aws,census,hub,loompy,pymde,regseq,scanpy]"
+    "scvi-tools[autotune,aws,census,criticism,hub,loompy,pymde,regseq,scanpy]"
 ]  # all optional user functionality
 
 tutorials = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ regseq = ["biopython>=1.81", "genomepy"]  # scvi.data.add_dna_sequence
 loompy = ["loompy>=3.0.6"]  # read loom
 scanpy = ["scanpy>=1.6"]  # scvi.criticism and read 10x
 optional = [
-    "scvi-tools[autotune,aws,census,criticism,hub,loompy,pymde,regseq,scanpy]"
+    "scvi-tools[autotune,aws,criticism,hub,loompy,pymde,regseq,scanpy]"
 ]  # all optional user functionality
 
 tutorials = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 dependencies = [
     "anndata>=0.7.5",
-    "chex<=0.1.8",  # see https://github.com/scverse/scvi-tools/pull/2187
+    "chex",
     "docrep>=0.3.2",
     "flax",
     "jax>=0.4.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ docsbuild = ["scvi-tools[docs,optional]"]  # docs build dependencies
 
 autotune = [
     "hyperopt>=0.2",
-    "ray[tune]>=2.5.0,<2.8.0",
+    "ray[tune]>=2.5.0,<2.10.0",
     "ipython",
     "scib-metrics>=0.4.1",
     "tensorboard",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ classifiers = [
 ]
 dependencies = [
     "anndata>=0.7.5",
-    "chex",
     "docrep>=0.3.2",
     "flax",
     "jax>=0.4.4",

--- a/scvi/autotune/_manager.py
+++ b/scvi/autotune/_manager.py
@@ -9,6 +9,7 @@ import warnings
 from collections import OrderedDict
 from dataclasses import dataclass
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Callable
 
 import lightning.pytorch as pl
@@ -446,7 +447,8 @@ class TunerManager:
             callbacks = [callback_cls(metric, on="validation_end")]
 
             logs_dir = os.path.join(logging_dir, experiment_name)
-            trial_name = air.session.get_trial_name() + "_lightning"
+            Path(logs_dir).mkdir(parents=True, exist_ok=True)
+            trial_name = ray.train.get_context().get_trial_name() + "_lightning"
             logger = pl.loggers.TensorBoardLogger(logs_dir, name=trial_name)
 
             if monitor_device_stats:

--- a/scvi/autotune/_manager.py
+++ b/scvi/autotune/_manager.py
@@ -7,13 +7,13 @@ import math
 import os
 import warnings
 from collections import OrderedDict
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Callable
 
 import lightning.pytorch as pl
 import ray
 import rich
-from chex import dataclass
 from ray import air, tune
 from ray.tune.integration.pytorch_lightning import TuneReportCallback
 

--- a/scvi/criticism/__init__.py
+++ b/scvi/criticism/__init__.py
@@ -1,3 +1,8 @@
-from ._ppc import PosteriorPredictiveCheck
+from scvi.utils import error_on_missing_dependencies
+
+error_on_missing_dependencies("xarray", "sparse")
+
+
+from ._ppc import PosteriorPredictiveCheck  # noqa
 
 __all__ = ["PosteriorPredictiveCheck"]

--- a/scvi/external/tangram/_module.py
+++ b/scvi/external/tangram/_module.py
@@ -1,6 +1,5 @@
 from typing import NamedTuple, Optional
 
-import chex
 import jax
 import jax.numpy as jnp
 
@@ -111,7 +110,6 @@ class TangramMapper(JaxBaseModuleClass):
             sc = sc * filter
 
         g_pred = mapper.transpose() @ sc
-        chex.assert_equal_shape([sp, g_pred])
 
         # Expression term
         if self.lambda_g1 > 0:

--- a/scvi/module/base/_base_module.py
+++ b/scvi/module/base/_base_module.py
@@ -83,12 +83,12 @@ class LossOutput:
     true_labels: Tensor | None = None
     extra_metrics: dict[str, Tensor] | None = field(default_factory=dict)
     n_obs_minibatch: int | None = None
-    reconstruction_loss_sum: Tensor = field(default=None, init=False)
-    kl_local_sum: Tensor = field(default=None, init=False)
-    kl_global_sum: Tensor = field(default=None, init=False)
+    reconstruction_loss_sum: Tensor = field(default=None)
+    kl_local_sum: Tensor = field(default=None)
+    kl_global_sum: Tensor = field(default=None)
 
     def __post_init__(self):
-        self.loss = self.dict_sum(self.loss)
+        object.__setattr__(self, "loss", self.dict_sum(self.loss))
 
         if self.n_obs_minibatch is None and self.reconstruction_loss is None:
             raise ValueError(
@@ -97,21 +97,30 @@ class LossOutput:
 
         default = 0 * self.loss
         if self.reconstruction_loss is None:
-            self.reconstruction_loss = default
+            object.__setattr__(self, "reconstruction_loss", default)
         if self.kl_local is None:
-            self.kl_local = default
+            object.__setattr__(self, "kl_local", default)
         if self.kl_global is None:
-            self.kl_global = default
-        self.reconstruction_loss = self._as_dict("reconstruction_loss")
-        self.kl_local = self._as_dict("kl_local")
-        self.kl_global = self._as_dict("kl_global")
-        self.reconstruction_loss_sum = self.dict_sum(self.reconstruction_loss).sum()
-        self.kl_local_sum = self.dict_sum(self.kl_local).sum()
-        self.kl_global_sum = self.dict_sum(self.kl_global)
+            object.__setattr__(self, "kl_global", default)
+
+        object.__setattr__(
+            self, "reconstruction_loss", self._as_dict("reconstruction_loss")
+        )
+        object.__setattr__(self, "kl_local", self._as_dict("kl_local"))
+        object.__setattr__(self, "kl_global", self._as_dict("kl_global"))
+        object.__setattr__(
+            self,
+            "reconstruction_loss_sum",
+            self.dict_sum(self.reconstruction_loss).sum(),
+        )
+        object.__setattr__(self, "kl_local_sum", self.dict_sum(self.kl_local).sum())
+        object.__setattr__(self, "kl_global_sum", self.dict_sum(self.kl_global))
 
         if self.reconstruction_loss is not None and self.n_obs_minibatch is None:
             rec_loss = self.reconstruction_loss
-            self.n_obs_minibatch = list(rec_loss.values())[0].shape[0]
+            object.__setattr__(
+                self, "n_obs_minibatch", list(rec_loss.values())[0].shape[0]
+            )
 
         if self.classification_loss is not None and (
             self.logits is None or self.true_labels is None

--- a/scvi/module/base/_base_module.py
+++ b/scvi/module/base/_base_module.py
@@ -5,7 +5,6 @@ from collections.abc import Iterable
 from dataclasses import field
 from typing import Any, Callable
 
-import chex
 import flax
 import jax
 import jax.numpy as jnp
@@ -28,7 +27,7 @@ from ._decorators import auto_move_data
 from ._pyro import AutoMoveDataPredictive
 
 
-@chex.dataclass
+@flax.struct.dataclass
 class LossOutput:
     """Loss signature for models.
 


### PR DESCRIPTION
- Change `xarray` and `sparse` to optional dependencies as they're only used for `RNAMixin.posterior_predictive_sample` and `PPC`
- Remove `chex` dependency (planning on adding this back as a test dependency once we have a better JAX testing framework) by changing `TuneAnalysis` to the standard dataclass and `LossOutput` as a `flax.struct.dataclass`
- Remove pin on Pandas as #2308 is resolved now
- Temporarily remove cellxgene-census dep
- Update autotune for new ray API

Need to find a cleaner way to modify `LossOutput` attributes post init.