### PR TITLE
Add token to codecov action

### DIFF
--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -58,3 +58,5 @@ jobs:
           coverage report
       - name: Upload coverage
         uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test_linux_cuda.yml
+++ b/.github/workflows/test_linux_cuda.yml
@@ -62,3 +62,5 @@ jobs:
           coverage report
       - name: Upload coverage
         uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test_linux_pre.yml
+++ b/.github/workflows/test_linux_pre.yml
@@ -68,3 +68,5 @@ jobs:
           coverage report
       - name: Upload coverage
         uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test_linux_private.yml
+++ b/.github/workflows/test_linux_private.yml
@@ -81,3 +81,5 @@ jobs:
           coverage report
       - name: Upload coverage
         uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -57,3 +57,5 @@ jobs:
           coverage report
       - name: Upload coverage
         uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test_macos_m1.yml
+++ b/.github/workflows/test_macos_m1.yml
@@ -57,3 +57,5 @@ jobs:
           coverage report
       - name: Upload coverage
         uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -57,3 +57,5 @@ jobs:
           coverage report
       - name: Upload coverage
         uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
As of v4 of codecov-action, it requires a token for uploading.