### PR TITLE
Add changes for tracking scib-metrics in autotune

### DIFF
--- a/scvi/module/_vae.py
+++ b/scvi/module/_vae.py
@@ -468,7 +468,13 @@ class VAE(BaseMinifiedModeModuleClass):
             "kl_divergence_l": kl_divergence_l,
             "kl_divergence_z": kl_divergence_z,
         }
-        return LossOutput(loss=loss, reconstruction_loss=reconst_loss, kl_local=kl_local)
+        return (
+            LossOutput(loss=loss, reconstruction_loss=reconst_loss, kl_local=kl_local),
+            x,
+            inference_outputs["z"],
+            tensors[REGISTRY_KEYS.BATCH_KEY],
+            tensors[REGISTRY_KEYS.LABELS_KEY],
+        )
 
     @torch.inference_mode()
     def sample(

--- a/scvi/train/_scib_callback.py
+++ b/scvi/train/_scib_callback.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Literal
+
+import lightning.pytorch as pl
+from anndata import AnnData
+from lightning.pytorch.callbacks import Callback
+from scib_metrics.benchmark import BatchCorrection, Benchmarker, BioConservation
+
+
+class ScibCallback(Callback):
+    def __init__(
+        self,
+        bio_conservation_metrics: BioConservation | None = None,
+        batch_correction_metrics: BatchCorrection | None = None,
+        stage: Literal["training", "validation", "both"] = "both",
+    ):
+        super().__init__()
+
+        self.bio_conservation_metrics = bio_conservation_metrics
+        self.batch_correction_metrics = batch_correction_metrics
+        self.stage = stage
+
+    def compute_metrics(
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+        stage: Literal["training", "validation"],
+    ):
+        if stage == "training" and self.stage not in ["training", "both"]:
+            return
+        elif stage == "validation" and self.stage not in ["validation", "both"]:
+            return
+
+        if not hasattr(pl_module, f"_{stage}_epoch_outputs"):
+            raise ValueError(f"The training plan must have a `_{stage}_epoch_outputs` attribute.")
+
+        outputs = getattr(pl_module, f"_{stage}_epoch_outputs")
+        x = outputs["x"].numpy()
+        z = outputs["z"].numpy()
+        batch = outputs["batch"].numpy()
+        labels = outputs["labels"].numpy()
+
+        adata = AnnData(X=x, obs={"batch": batch, "labels": labels}, obsm={"z": z})
+        benchmarker = Benchmarker(
+            adata,
+            batch_key="batch",
+            label_key="labels",
+            embedding_obsm_keys=["z"],
+            bio_conservation_metrics=self.bio_conservation_metrics,
+            batch_correction_metrics=self.batch_correction_metrics,
+        )
+        benchmarker.prepare()
+        benchmarker.benchmark()
+        results = benchmarker.get_results(min_max_scale=False).to_dict()
+        metrics = {f"training {metric}": results[metric]["z"] for metric in results}
+        pl_module.logger.log_metrics(metrics, trainer.global_step)
+
+        delattr(pl_module, f"_{stage}_epoch_outputs")
+
+    def on_train_epoch_end(self, trainer: pl.Trainer, pl_module: pl.LightningModule):
+        self.compute_metrics(trainer, pl_module, "training")
+
+    def on_validation_epoch_end(self, trainer: pl.Trainer, pl_module: pl.LightningModule):
+        self.compute_metrics(trainer, pl_module, "validation")


### PR DESCRIPTION
Here's an example code snippet for how this works with SCVI:
```
import scvi
from scvi.autotune import ModelTuner
from scvi.train._scib_callback import ScibCallback

adata = scvi.data.synthetic_iid()
model_cls = scvi.model.SCVI
model_cls.setup_anndata(adata, batch_key="batch", labels_key="labels")

tuner = ModelTuner(model_cls)
tuner.fit(
    adata,
    use_defaults=True,
    metric="validation Batch correction",  # necessary
    train_kwargs={"callbacks": [ScibCallback(stage="validation")]},  # necessary
    validate_metrics=False,  # necessary
)
```
Code is not nice yet as the `TrainingPlan` has to accumulate and store the raw counts, latent representation, batches, and labels for this to work. 