### PR TITLE
Address AnnData 0.10 deprecations

### DIFF
--- a/scvi/data/_anntorchdataset.py
+++ b/scvi/data/_anntorchdataset.py
@@ -9,12 +9,12 @@ import pandas as pd
 import torch
 
 try:
-    from anndata._core.sparse_dataset import SparseDataset
-except ImportError:
-    # anndata >= 0.10.0
+    # anndata >= 0.10
     from anndata.experimental import CSCDataset, CSRDataset
 
     SparseDataset = (CSRDataset, CSCDataset)
+except ImportError:
+    from anndata._core.sparse_dataset import SparseDataset
 
 from scipy.sparse import issparse
 from torch.utils.data import Dataset

--- a/scvi/data/_built_in_data/_pbmc.py
+++ b/scvi/data/_built_in_data/_pbmc.py
@@ -16,7 +16,7 @@ def _load_purified_pbmc_dataset(
     save_fn = "PurifiedPBMCDataset.h5ad"
     _download(url, save_path, save_fn)
     path_to_file = os.path.join(save_path, save_fn)
-    adata = anndata.read(path_to_file)
+    adata = anndata.read_h5ad(path_to_file)
 
     dataset_names = [
         "cd4_t_helper",

--- a/scvi/data/_utils.py
+++ b/scvi/data/_utils.py
@@ -13,12 +13,12 @@ import torch
 from anndata import AnnData
 
 try:
-    from anndata._core.sparse_dataset import SparseDataset
-except ImportError:
-    # anndata >= 0.10.0
+    # anndata >= 0.10
     from anndata.experimental import CSCDataset, CSRDataset
 
     SparseDataset = (CSRDataset, CSCDataset)
+except ImportError:
+    from anndata._core.sparse_dataset import SparseDataset
 
 # TODO use the experimental api once we lower bound to anndata 0.8
 try:

--- a/scvi/model/base/_utils.py
+++ b/scvi/model/base/_utils.py
@@ -83,7 +83,7 @@ def _load_saved_files(
             if is_mudata:
                 adata = mudata.read(adata_path)
             else:
-                adata = anndata.read(adata_path)
+                adata = anndata.read_h5ad(adata_path)
         else:
             raise ValueError("Save path contains no saved anndata and no adata was passed.")
     else:


### PR DESCRIPTION
- Try importing `anndata.experimental.CSCDataset/CSRDataset` instead of `anndata._core.sparse_dataset.SparseDataset`
- Replace instances of `anndata.read` with `anndata.read_h5ad`