### PR TITLE
[misc] use module constants, clean up typing and docs in `VAE`

### DIFF
--- a/docs/api/developer.md
+++ b/docs/api/developer.md
@@ -93,6 +93,7 @@ Parameterizable probability distributions.
    :toctree: reference/
    :nosignatures:
 
+   distributions.Poisson
    distributions.NegativeBinomial
    distributions.NegativeBinomialMixture
    distributions.ZeroInflatedNegativeBinomial
@@ -221,6 +222,7 @@ Basic neural network building blocks.
    nn.FCLayers
    nn.Encoder
    nn.Decoder
+   nn.DecoderSCVI
    nn.one_hot
    nn.Embedding
 

--- a/scvi/__init__.py
+++ b/scvi/__init__.py
@@ -4,7 +4,7 @@
 import logging
 import warnings
 
-from ._constants import METRIC_KEYS, REGISTRY_KEYS
+from ._constants import REGISTRY_KEYS
 from ._settings import settings
 
 # this import needs to come after prior imports to prevent circular import
@@ -25,7 +25,6 @@ scvi_logger.propagate = False
 __all__ = [
     "settings",
     "REGISTRY_KEYS",
-    "METRIC_KEYS",
     "data",
     "model",
     "external",

--- a/scvi/_constants.py
+++ b/scvi/_constants.py
@@ -16,18 +16,4 @@ class _REGISTRY_KEYS_NT(NamedTuple):
     OBSERVED_LIB_SIZE: str = "observed_lib_size"
 
 
-class _METRIC_KEYS_NT(NamedTuple):
-    TRAINING_KEY: str = "training"
-    VALIDATION_KEY: str = "validation"
-    # classification
-    ACCURACY_KEY: str = "accuracy"
-    F1_SCORE_KEY: str = "f1_score"
-    CALIBRATION_ERROR_KEY: str = "calibration_error"
-    AUROC_KEY: str = "auroc"
-    CLASSIFICATION_LOSS_KEY: str = "classification_loss"
-    TRUE_LABELS_KEY: str = "true_labels"
-    LOGITS_KEY: str = "logits"
-
-
 REGISTRY_KEYS = _REGISTRY_KEYS_NT()
-METRIC_KEYS = _METRIC_KEYS_NT()

--- a/scvi/model/_scvi.py
+++ b/scvi/model/_scvi.py
@@ -100,6 +100,10 @@ class SCVI(
     2. :doc:`/tutorials/notebooks/scrna/harmonization`
     3. :doc:`/tutorials/notebooks/scrna/scarches_scvi_tools`
     4. :doc:`/tutorials/notebooks/scrna/scvi_in_R`
+
+    See Also
+    --------
+    :class:`~scvi.module.VAE`
     """
 
     _module_cls = VAE

--- a/scvi/model/base/_vaemixin.py
+++ b/scvi/model/base/_vaemixin.py
@@ -171,6 +171,8 @@ class VAEMixin:
         -------
         Low-dimensional representation for each cell or a tuple containing its mean and variance.
         """
+        from scvi.module._constants import MODULE_KEYS
+
         self._check_if_trained(warn=False)
 
         adata = self._validate_anndata(adata)
@@ -181,10 +183,10 @@ class VAEMixin:
         for tensors in scdl:
             inference_inputs = self.module._get_inference_input(tensors)
             outputs = self.module.inference(**inference_inputs)
-            if "qz" in outputs:
-                qz = outputs["qz"]
+            if MODULE_KEYS.QZ_KEY in outputs:
+                qz = outputs[MODULE_KEYS.QZ_KEY]
             else:
-                qz_m, qz_v = outputs["qz_m"], outputs["qz_v"]
+                qz_m, qz_v = outputs[MODULE_KEYS.QZM_KEY], outputs[MODULE_KEYS.QZV_KEY]
                 qz = torch.distributions.Normal(qz_m, qz_v.sqrt())
             if give_mean:
                 # does each model need to have this latent distribution param?
@@ -195,7 +197,7 @@ class VAEMixin:
                 else:
                     z = qz.loc
             else:
-                z = outputs["z"]
+                z = outputs[MODULE_KEYS.Z_KEY]
 
             latent += [z.cpu()]
             latent_qzm += [qz.loc.cpu()]

--- a/scvi/module/_constants.py
+++ b/scvi/module/_constants.py
@@ -6,8 +6,8 @@ class _MODULE_KEYS(NamedTuple):
     # inference
     Z_KEY: str = "z"
     QZ_KEY: str = "qz"
-    QZM_KEY: str = "qz_m"
-    QZV_KEY: str = "qz_v"
+    QZM_KEY: str = "qzm"
+    QZV_KEY: str = "qzv"
     LIBRARY_KEY: str = "library"
     QL_KEY: str = "ql"
     BATCH_INDEX_KEY: str = "batch_index"

--- a/scvi/module/_constants.py
+++ b/scvi/module/_constants.py
@@ -1,0 +1,23 @@
+from typing import NamedTuple
+
+
+class _MODULE_KEYS(NamedTuple):
+    Z_KEY: str = "z"
+    QZ_KEY: str = "qz"
+    QZM_KEY: str = "qz_m"
+    QZV_KEY: str = "qz_v"
+    LIBRARY_KEY: str = "library"
+    QL_KEY: str = "ql"
+    BATCH_INDEX_KEY: str = "batch_index"
+    Y_KEY: str = "y"
+    CONT_COVS_KEY: str = "cont_covs"
+    CAT_COVS_KEY: str = "cat_covs"
+    SIZE_FACTOR_KEY: str = "size_factor"
+    PX_KEY: str = "px"
+    PL_KEY: str = "pl"
+    PZ_KEY: str = "pz"
+    KL_L_KEY: str = "kl_divergence_l"
+    KL_Z_KEY: str = "kl_divergence_z"
+
+
+MODULE_KEYS = _MODULE_KEYS()

--- a/scvi/module/_constants.py
+++ b/scvi/module/_constants.py
@@ -2,6 +2,8 @@ from typing import NamedTuple
 
 
 class _MODULE_KEYS(NamedTuple):
+    X_KEY: str = "x"
+    # inference
     Z_KEY: str = "z"
     QZ_KEY: str = "qz"
     QZM_KEY: str = "qz_m"
@@ -13,9 +15,11 @@ class _MODULE_KEYS(NamedTuple):
     CONT_COVS_KEY: str = "cont_covs"
     CAT_COVS_KEY: str = "cat_covs"
     SIZE_FACTOR_KEY: str = "size_factor"
+    # generative
     PX_KEY: str = "px"
     PL_KEY: str = "pl"
     PZ_KEY: str = "pz"
+    # loss
     KL_L_KEY: str = "kl_divergence_l"
     KL_Z_KEY: str = "kl_divergence_z"
 

--- a/scvi/module/_vae.py
+++ b/scvi/module/_vae.py
@@ -265,7 +265,7 @@ class VAE(EmbeddingModuleMixin, BaseMinifiedModeModuleClass):
     ) -> dict[str, torch.Tensor | None]:
         if self.minified_data_type is None:
             return {
-                REGISTRY_KEYS.X_KEY: tensors[REGISTRY_KEYS.X_KEY],
+                MODULE_KEYS.X_KEY: tensors[REGISTRY_KEYS.X_KEY],
                 MODULE_KEYS.BATCH_INDEX_KEY: tensors[REGISTRY_KEYS.BATCH_KEY],
                 MODULE_KEYS.CONT_COVS_KEY: tensors.get(REGISTRY_KEYS.CONT_COVS_KEY, None),
                 MODULE_KEYS.CAT_COVS_KEY: tensors.get(REGISTRY_KEYS.CAT_COVS_KEY, None),

--- a/scvi/module/_vae.py
+++ b/scvi/module/_vae.py
@@ -579,7 +579,7 @@ class VAE(EmbeddingModuleMixin, BaseMinifiedModeModuleClass):
             Number of Monte Carlo samples to draw from the distribution for each observation.
         max_poisson_rate
             The maximum value to which to clip the ``rate`` parameter of
-            :class:`~torch.distributions.Poisson`. Avoids numerical sampling issues when the
+            :class:`~scvi.distributions.Poisson`. Avoids numerical sampling issues when the
             parameter is very large due to the variance of the distribution.
 
         Returns
@@ -587,6 +587,8 @@ class VAE(EmbeddingModuleMixin, BaseMinifiedModeModuleClass):
         Tensor on CPU with shape ``(n_obs, n_vars)`` if ``n_samples == 1``, else
         ``(n_obs, n_vars,)``.
         """
+        from scvi.distributions import Poisson
+
         inference_kwargs = {"n_samples": n_samples}
         _, generative_outputs = self.forward(
             tensors, inference_kwargs=inference_kwargs, compute_loss=False
@@ -594,7 +596,7 @@ class VAE(EmbeddingModuleMixin, BaseMinifiedModeModuleClass):
 
         dist = generative_outputs[MODULE_KEYS.PX_KEY]
         if self.gene_likelihood == "poisson":
-            dist = torch.distributions.Poisson(torch.clamp(dist.rate, max=max_poisson_rate))
+            dist = Poisson(torch.clamp(dist.rate, max=max_poisson_rate))
 
         # (n_obs, n_vars) if n_samples == 1, else (n_samples, n_obs, n_vars)
         samples = dist.sample()

--- a/scvi/module/_vae.py
+++ b/scvi/module/_vae.py
@@ -50,10 +50,10 @@ class VAE(EmbeddingModuleMixin, BaseMinifiedModeModuleClass):
         Flexibility of the dispersion parameter when ``gene_likelihood`` is either ``"nb"`` or
         ``"zinb"``. One of the following:
 
-        * ``"gene"``: dispersion parameter of NB is constant per gene across cells.
-        * ``"gene-batch"``: dispersion can differ between different batches.
-        * ``"gene-label"``: dispersion can differ between different labels.
-        * ``"gene-cell"``: dispersion can differ for every gene in every cell.
+        * ``"gene"``: parameter is constant per gene across cells.
+        * ``"gene-batch"``: parameter is constant per gene per batch.
+        * ``"gene-label"``: parameter is constant per gene per label.
+        * ``"gene-cell"``: parameter is constant per gene per cell.
     log_variational
         If ``True``, use :func:`~torch.log1p` on input data before encoding for numerical stability
         (not normalization).
@@ -168,18 +168,18 @@ class VAE(EmbeddingModuleMixin, BaseMinifiedModeModuleClass):
         from scvi.nn import DecoderSCVI, Encoder
 
         super().__init__()
+
         self.dispersion = dispersion
         self.n_latent = n_latent
         self.log_variational = log_variational
         self.gene_likelihood = gene_likelihood
-        # Automatically deactivate if useless
         self.n_batch = n_batch
         self.n_labels = n_labels
         self.latent_distribution = latent_distribution
         self.encode_covariates = encode_covariates
-
         self.use_size_factor_key = use_size_factor_key
         self.use_observed_lib_size = use_size_factor_key or use_observed_lib_size
+
         if not self.use_observed_lib_size:
             if library_log_means is None or library_log_vars is None:
                 raise ValueError(

--- a/scvi/module/_vae.py
+++ b/scvi/module/_vae.py
@@ -18,7 +18,6 @@ from scvi.module.base import (
 )
 from scvi.nn import one_hot
 
-torch.backends.cudnn.benchmark = True
 logger = logging.getLogger(__name__)
 
 
@@ -194,9 +193,7 @@ class VAE(EmbeddingModuleMixin, BaseMinifiedModeModuleClass):
             pass
         else:
             raise ValueError(
-                "dispersion must be one of ['gene', 'gene-batch',"
-                " 'gene-label', 'gene-cell'], but input was "
-                "{}.format(self.dispersion)"
+                "`dispersion` must be one of 'gene', 'gene-batch', 'gene-label', 'gene-cell'."
             )
 
         self.batch_representation = batch_representation
@@ -211,14 +208,9 @@ class VAE(EmbeddingModuleMixin, BaseMinifiedModeModuleClass):
         use_layer_norm_encoder = use_layer_norm == "encoder" or use_layer_norm == "both"
         use_layer_norm_decoder = use_layer_norm == "decoder" or use_layer_norm == "both"
 
-        # z encoder goes from the n_input-dimensional data to an n_latent-d
-        # latent space representation
         n_input_encoder = n_input + n_continuous_cov * encode_covariates
-
         if self.batch_representation == "embedding":
-            # batch embeddings are concatenated to the input of the encoder
             n_input_encoder += batch_dim * encode_covariates
-            # don't pass in batch index if using embeddings
             cat_list = list([] if n_cats_per_cov is None else n_cats_per_cov)
         else:
             cat_list = [n_batch] + list([] if n_cats_per_cov is None else n_cats_per_cov)
@@ -255,10 +247,8 @@ class VAE(EmbeddingModuleMixin, BaseMinifiedModeModuleClass):
             return_dist=True,
             **_extra_encoder_kwargs,
         )
-        # decoder goes from n_latent-dimensional space to n_input-d data
         n_input_decoder = n_latent + n_continuous_cov
         if self.batch_representation == "embedding":
-            # batch embeddings are concatenated to the input of the decoder
             n_input_decoder += batch_dim
 
         _extra_decoder_kwargs = extra_decoder_kwargs or {}

--- a/scvi/train/__init__.py
+++ b/scvi/train/__init__.py
@@ -1,4 +1,5 @@
 from ._callbacks import JaxModuleInit, LoudEarlyStopping, SaveBestState, SaveCheckpoint
+from ._constants import METRIC_KEYS
 from ._trainer import Trainer
 from ._trainingplans import (
     AdversarialTrainingPlan,
@@ -25,4 +26,5 @@ __all__ = [
     "SaveCheckpoint",
     "JaxModuleInit",
     "JaxTrainingPlan",
+    "METRIC_KEYS",
 ]

--- a/scvi/train/_constants.py
+++ b/scvi/train/_constants.py
@@ -1,0 +1,17 @@
+from typing import NamedTuple
+
+
+class _METRIC_KEYS_NT(NamedTuple):
+    TRAINING_KEY: str = "training"
+    VALIDATION_KEY: str = "validation"
+    # classification
+    ACCURACY_KEY: str = "accuracy"
+    F1_SCORE_KEY: str = "f1_score"
+    CALIBRATION_ERROR_KEY: str = "calibration_error"
+    AUROC_KEY: str = "auroc"
+    CLASSIFICATION_LOSS_KEY: str = "classification_loss"
+    TRUE_LABELS_KEY: str = "true_labels"
+    LOGITS_KEY: str = "logits"
+
+
+METRIC_KEYS = _METRIC_KEYS_NT()

--- a/scvi/train/_trainingplans.py
+++ b/scvi/train/_trainingplans.py
@@ -16,7 +16,7 @@ from lightning.pytorch.strategies.ddp import DDPStrategy
 from pyro.nn import PyroModule
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 
-from scvi import METRIC_KEYS, REGISTRY_KEYS
+from scvi import REGISTRY_KEYS
 from scvi.module import Classifier
 from scvi.module.base import (
     BaseModuleClass,
@@ -26,6 +26,7 @@ from scvi.module.base import (
     TrainStateWithState,
 )
 from scvi.nn import one_hot
+from scvi.train._constants import METRIC_KEYS
 
 from ._metrics import ElboMetric
 

--- a/tests/model/test_scvi.py
+++ b/tests/model/test_scvi.py
@@ -378,6 +378,8 @@ def test_scvi(n_latent: int = 5):
 
 
 def test_scvi_get_latent_rep_backwards_compat(n_latent: int = 5):
+    from scvi.module._constants import MODULE_KEYS
+
     adata = synthetic_iid()
     SCVI.setup_anndata(
         adata,
@@ -391,8 +393,8 @@ def test_scvi_get_latent_rep_backwards_compat(n_latent: int = 5):
 
     def old_inference(*args, **kwargs):
         inf_outs = vae.inference(*args, **kwargs)
-        qz = inf_outs.pop("qz")
-        inf_outs["qz_m"], inf_outs["qz_v"] = qz.loc, qz.scale**2
+        qz = inf_outs.pop(MODULE_KEYS.QZ_KEY)
+        inf_outs[MODULE_KEYS.QZM_KEY], inf_outs[MODULE_KEYS.QZV_KEY] = qz.loc, qz.scale**2
         return inf_outs
 
     vae_mock.inference.side_effect = old_inference
@@ -402,6 +404,8 @@ def test_scvi_get_latent_rep_backwards_compat(n_latent: int = 5):
 
 
 def test_scvi_get_feature_corr_backwards_compat(n_latent: int = 5):
+    from scvi.module._constants import MODULE_KEYS
+
     adata = synthetic_iid()
     SCVI.setup_anndata(
         adata,
@@ -415,9 +419,9 @@ def test_scvi_get_feature_corr_backwards_compat(n_latent: int = 5):
 
     def old_forward(*args, **kwargs):
         inf_outs, gen_outs = vae.forward(*args, **kwargs)
-        qz = inf_outs.pop("qz")
-        inf_outs["qz_m"], inf_outs["qz_v"] = qz.loc, qz.scale**2
-        px = gen_outs.pop("px")
+        qz = inf_outs.pop(MODULE_KEYS.QZ_KEY)
+        inf_outs[MODULE_KEYS.QZM_KEY], inf_outs[MODULE_KEYS.QZV_KEY] = qz.loc, qz.scale**2
+        px = gen_outs.pop(MODULE_KEYS.PX_KEY)
         gen_outs["px_scale"], gen_outs["px_r"] = px.scale, px.theta
         return inf_outs, gen_outs
 

--- a/tests/train/test_trainingplans.py
+++ b/tests/train/test_trainingplans.py
@@ -1,10 +1,10 @@
 import pytest
 
 import scvi
-from scvi import METRIC_KEYS
 from scvi.data import synthetic_iid
 from scvi.model import SCVI, JaxSCVI
 from scvi.train import JaxTrainingPlan, TrainingPlan
+from scvi.train._constants import METRIC_KEYS
 from scvi.train._trainingplans import _compute_kl_weight
 
 


### PR DESCRIPTION
- move `METRIC_KEYS` in `scvi._constants` to `scvi.train._constants` since it's only used there
- add `MODULE_KEYS` to `scvi.module._constants`, use them in `VAE`