### PR TITLE
feat(hub): add unsigned arg to hubmodel s3 pull

### DIFF
--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -27,6 +27,8 @@ is available in the [commit logs](https://github.com/scverse/scvi-tools/commits/
     in {func}`scvi.autotune.run_autotune` {pr}`2605`.
 -   Add {class}`scvi.external.VELOVI` for RNA velocity estimation using variational inference
     {pr}`2611`.
+-   Add `unsigned` argument to {meth}`scvi.hub.HubModel.pull_from_s3` to allow for unsigned
+    downloads of models from AWS S3 {pr}`2615`.
 
 #### Changed
 

--- a/scvi/hub/_model.py
+++ b/scvi/hub/_model.py
@@ -294,6 +294,7 @@ class HubModel:
         s3_path: str,
         pull_anndata: bool = True,
         cache_dir: str | None = None,
+        unsigned: bool = False,
         **kwargs,
     ) -> HubModel:
         """Download a :class:`~scvi.hub.HubModel` from an S3 bucket.
@@ -312,6 +313,9 @@ class HubModel:
         cache_dir
             The directory where the downloaded model files will be cached. Defaults to a temporary
             directory created with :func:`tempfile.mkdtemp`.
+        unsigned
+            Whether to use unsigned requests. If ``True`` and ``config`` is passed in ``kwargs``,
+            ``config`` will be overwritten.
         **kwargs
             Keyword arguments passed into :func:`~boto3.client`.
 
@@ -320,7 +324,10 @@ class HubModel:
         The pretrained model specified by the given S3 bucket and path.
         """
         from boto3 import client
+        from botocore import UNSIGNED, config
 
+        if unsigned:
+            kwargs["config"] = config.Config(signature_version=UNSIGNED)
         cache_dir = cache_dir or tempfile.mkdtemp()
         s3 = client("s3", **kwargs)
 


### PR DESCRIPTION
feature only added to `pull_from_s3` as users should authenticate if pushing to a bucket