### PR TITLE
feat(ci): set up cirun for gpu tests

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -1,9 +1,9 @@
 runners:
-  - name: aws-gpu-runner
-    cloud: aws
-    instance_type: g5.xlarge
-    region: us-west-2
-    image: ami-081fd1f021bc275c4 # ubuntu 20.04 nvidia drivers
+  - name: "aws-gpu-runner"
+    cloud: "aws"
+    instance_type: "g5.xlarge"
+    region: "us-west-2"
+    machine_image: "ami-081fd1f021bc275c4" # ubuntu 20.04 nvidia drivers
     preemptible: true
     labels:
       - "cirun-aws-gpu"

--- a/.cirun.yml
+++ b/.cirun.yml
@@ -1,0 +1,8 @@
+runners:
+  - name: aws-gpu-runner
+    cloud: aws
+    instance_type: g5.xlarge
+    region: us-west-2
+    image: ami-081fd1f021bc275c4 # ubuntu 20.04 nvidia drivers
+    labels:
+      - "cirun-aws-gpu"

--- a/.cirun.yml
+++ b/.cirun.yml
@@ -3,7 +3,7 @@ runners:
     cloud: "aws"
     instance_type: "g5.xlarge"
     region: "us-west-2"
-    machine_image: "ami-081fd1f021bc275c4" # ubuntu 20.04 nvidia drivers
+    machine_image: "ami-080f83501083a6167" # ubuntu 20.04 nvidia drivers
     preemptible: true
     labels:
       - "cirun-aws-gpu"

--- a/.cirun.yml
+++ b/.cirun.yml
@@ -1,7 +1,10 @@
 runners:
   - name: "aws-gpu-runner"
     cloud: "aws"
-    instance_type: "g5.xlarge"
+    instance_type:
+      - "g5.xlarge"
+      - "g5.2xlarge"
+      - "g5.4xlarge"
     region: "us-west-2"
     machine_image: "ami-080f83501083a6167" # ubuntu 20.04 nvidia drivers
     preemptible: true

--- a/.cirun.yml
+++ b/.cirun.yml
@@ -4,5 +4,6 @@ runners:
     instance_type: g5.xlarge
     region: us-west-2
     image: ami-081fd1f021bc275c4 # ubuntu 20.04 nvidia drivers
+    preemptible: true
     labels:
       - "cirun-aws-gpu"

--- a/.github/workflows/test_linux_cuda.yml
+++ b/.github/workflows/test_linux_cuda.yml
@@ -22,7 +22,9 @@ jobs:
         contains(github.event_name, 'schedule') ||
         contains(github.event_name, 'workflow_dispatch')
       )
-    runs-on: [self-hosted, Linux, X64, CUDA]
+    runs-on: "cirun-aws-gpu--${{ github.run_id }}"
+    timeout-minutes: 30
+
     defaults:
       run:
         shell: bash -e {0} # -e to fail on error


### PR DESCRIPTION
adds a cirun configuration for GPU tests. given that certain instances may not be available during testing time as well as initialization taking a while, I think it only makes sense to use cirun/aws for multi-gpu tests and keep single-gpu ones on self-hosted.