### PR TITLE
chore(external): add note and warning for solo predict breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,8 +60,8 @@ is available in the [commit logs](https://github.com/scverse/scvi-tools/commits/
 
 #### Fixed
 
--   Fix {meth}`scvi.external.SOLO.predict` to correctly return probabiities instead of logits
-    when passing in `soft=True` {pr}`2689`.
+-   Breaking change: Fix {meth}`scvi.external.SOLO.predict` to correctly return probabiities
+    instead of logits when passing in `soft=True` {pr}`2689`.
 
 ### 1.1.2 (2024-03-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ is available in the [commit logs](https://github.com/scverse/scvi-tools/commits/
 #### Fixed
 
 -   Breaking change: Fix {meth}`scvi.external.SOLO.predict` to correctly return probabiities
-    instead of logits when passing in `soft=True` {pr}`2689`.
+    instead of logits when passing in `soft=True` (the default option) {pr}`2689`.
 
 ### 1.1.2 (2024-03-01)
 

--- a/scvi/external/solo/_model.py
+++ b/scvi/external/solo/_model.py
@@ -400,6 +400,14 @@ class SOLO(BaseModelClass):
         -------
         DataFrame with prediction, index corresponding to cell barcode.
         """
+        warnings.warn(
+            "Prior to scvi-tools 1.1.3, `SOLO.predict` with `soft=True` (the default option) "
+            "returned logits instead of probabilities. This behavior has since been corrected to "
+            "return probabiltiies.",
+            UserWarning,
+            stacklevel=settings.warnings_stacklevel,
+        )
+
         adata = self._validate_anndata(None)
         scdl = self._make_data_loader(adata=adata)
 


### PR DESCRIPTION
amends #2689 to add a note in the changelog as well as a warning noting that it is a breaking change.