### PR TITLE
docs: remove velovi preprocess from api

### DIFF
--- a/docs/api/user.md
+++ b/docs/api/user.md
@@ -103,8 +103,6 @@ Here we maintain a few package specific utilities for feature selection, etc.
    data.organize_multiome_anndatas
    data.add_dna_sequence
    data.reads_to_fragments
-   external.velovi.get_permutation_scores
-   external.velovi.preprocess_data
 ```
 
 ```{eval-rst}


### PR DESCRIPTION
amends #2637 by also removing the velovi preprocess functions from the api reference