### PR TITLE
refactor(model): move base model utils to new files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,20 @@ to [Semantic Versioning]. Full commit history is available in the
     {meth}`scvi.model.MULTIVI.train`, to be removed in v1.3. Please pass in `enable_checkpointing`
     or specify a custom checkpointing procedure with {class}`scvi.train.SaveCheckpoint` instead
     {pr}`2673`.
+- Move {func}`scvi.model.base._utils._load_legacy_saved_files` to
+    {func}`scvi.model.base._save_load._load_legacy_saved_files` {pr}`xxxx`.
+- Move {func}`scvi.model.base._utils._load_saved_files` to
+    {func}`scvi.model.base._save_load._load_saved_files` {pr}`xxxx`.
+- Move {func}`scvi.model.base._utils._initialize_model` to
+    {func}`scvi.model.base._save_load._initialize_model` {pr}`xxxx`.
+- Move {func}`scvi.model.base._utils._validate_var_names` to
+    {func}`scvi.model.base._save_load._validate_var_names` {pr}`xxxx`.
+- Move {func}`scvi.model.base._utils._prepare_obs` to
+    {func}`scvi.model.base._de_core._prepare_obs` {pr}`xxxx`.
+- Move {func}`scvi.model.base._utils._de_core` to
+    {func}`scvi.model.base._de_core._de_core` {pr}`xxxx`.
+- Move {func}`scvi.model.base._utils._fdr_de_prediction` to
+    {func}`scvi.model.base._de_core_._fdr_de_prediction` {pr}`xxxx`.
 
 #### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,19 +47,19 @@ to [Semantic Versioning]. Full commit history is available in the
     or specify a custom checkpointing procedure with {class}`scvi.train.SaveCheckpoint` instead
     {pr}`2673`.
 - Move {func}`scvi.model.base._utils._load_legacy_saved_files` to
-    {func}`scvi.model.base._save_load._load_legacy_saved_files` {pr}`xxxx`.
+    {func}`scvi.model.base._save_load._load_legacy_saved_files` {pr}`2731`.
 - Move {func}`scvi.model.base._utils._load_saved_files` to
-    {func}`scvi.model.base._save_load._load_saved_files` {pr}`xxxx`.
+    {func}`scvi.model.base._save_load._load_saved_files` {pr}`2731`.
 - Move {func}`scvi.model.base._utils._initialize_model` to
-    {func}`scvi.model.base._save_load._initialize_model` {pr}`xxxx`.
+    {func}`scvi.model.base._save_load._initialize_model` {pr}`2731`.
 - Move {func}`scvi.model.base._utils._validate_var_names` to
-    {func}`scvi.model.base._save_load._validate_var_names` {pr}`xxxx`.
+    {func}`scvi.model.base._save_load._validate_var_names` {pr}`2731`.
 - Move {func}`scvi.model.base._utils._prepare_obs` to
-    {func}`scvi.model.base._de_core._prepare_obs` {pr}`xxxx`.
+    {func}`scvi.model.base._de_core._prepare_obs` {pr}`2731`.
 - Move {func}`scvi.model.base._utils._de_core` to
-    {func}`scvi.model.base._de_core._de_core` {pr}`xxxx`.
+    {func}`scvi.model.base._de_core._de_core` {pr}`2731`.
 - Move {func}`scvi.model.base._utils._fdr_de_prediction` to
-    {func}`scvi.model.base._de_core_._fdr_de_prediction` {pr}`xxxx`.
+    {func}`scvi.model.base._de_core_._fdr_de_prediction` {pr}`2731`.
 
 #### Removed
 

--- a/src/scvi/external/contrastivevi/_model.py
+++ b/src/scvi/external/contrastivevi/_model.py
@@ -31,7 +31,7 @@ from scvi.model._utils import (
     use_distributed_sampler,
 )
 from scvi.model.base import BaseModelClass
-from scvi.model.base._utils import _de_core
+from scvi.model.base._de_core import _de_core
 from scvi.train import TrainingPlan, TrainRunner
 from scvi.utils import setup_anndata_dsp
 from scvi.utils._docstrings import devices_dsp

--- a/src/scvi/external/poissonvi/_model.py
+++ b/src/scvi/external/poissonvi/_model.py
@@ -24,9 +24,7 @@ from scvi.model._utils import _init_library_size, scatac_raw_counts_properties
 from scvi.model.base import (
     RNASeqMixin,
 )
-from scvi.model.base._utils import (
-    _de_core,
-)
+from scvi.model.base._de_core import _de_core
 from scvi.module import VAE
 from scvi.utils import setup_anndata_dsp
 from scvi.utils._docstrings import de_dsp

--- a/src/scvi/hub/_metadata.py
+++ b/src/scvi/hub/_metadata.py
@@ -9,7 +9,7 @@ from huggingface_hub import ModelCard, ModelCardData
 
 from scvi.data import AnnDataManager
 from scvi.data._utils import _is_minified
-from scvi.model.base._utils import _load_saved_files
+from scvi.model.base._save_load import _load_saved_files
 
 from ._constants import _SCVI_HUB
 from ._template import template

--- a/src/scvi/model/_multivi.py
+++ b/src/scvi/model/_multivi.py
@@ -36,12 +36,11 @@ from scvi.model.base import (
     UnsupervisedTrainingMixin,
     VAEMixin,
 )
+from scvi.model.base._de_core import _de_core
 from scvi.module import MULTIVAE
 from scvi.train import AdversarialTrainingPlan
 from scvi.train._callbacks import SaveBestState
 from scvi.utils._docstrings import de_dsp, devices_dsp, setup_anndata_dsp
-
-from .base._utils import _de_core
 
 logger = logging.getLogger(__name__)
 

--- a/src/scvi/model/_peakvi.py
+++ b/src/scvi/model/_peakvi.py
@@ -26,12 +26,12 @@ from scvi.model._utils import (
     scatac_raw_counts_properties,
 )
 from scvi.model.base import UnsupervisedTrainingMixin
+from scvi.model.base._de_core import _de_core
 from scvi.module import PEAKVAE
 from scvi.train._callbacks import SaveBestState
 from scvi.utils._docstrings import de_dsp, devices_dsp, setup_anndata_dsp
 
 from .base import ArchesMixin, BaseModelClass, VAEMixin
-from .base._utils import _de_core
 
 logger = logging.getLogger(__name__)
 

--- a/src/scvi/model/_totalvi.py
+++ b/src/scvi/model/_totalvi.py
@@ -25,7 +25,7 @@ from scvi.model._utils import (
     cite_seq_raw_counts_properties,
     get_max_epochs_heuristic,
 )
-from scvi.model.base._utils import _de_core
+from scvi.model.base._de_core import _de_core
 from scvi.module import TOTALVAE
 from scvi.train import AdversarialTrainingPlan, TrainRunner
 from scvi.utils._docstrings import de_dsp, devices_dsp, setup_anndata_dsp

--- a/src/scvi/model/base/_archesmixin.py
+++ b/src/scvi/model/base/_archesmixin.py
@@ -14,11 +14,11 @@ from scvi import REGISTRY_KEYS, settings
 from scvi.data import _constants
 from scvi.data._constants import _MODEL_NAME_KEY, _SETUP_ARGS_KEY
 from scvi.model._utils import parse_device_args
+from scvi.model.base._save_load import _initialize_model, _load_saved_files, _validate_var_names
 from scvi.nn import FCLayers
 from scvi.utils._docstrings import devices_dsp
 
 from ._base_model import BaseModelClass
-from ._utils import _initialize_model, _load_saved_files, _validate_var_names
 
 logger = logging.getLogger(__name__)
 

--- a/src/scvi/model/base/_base_model.py
+++ b/src/scvi/model/base/_base_model.py
@@ -27,11 +27,14 @@ from scvi.data._constants import (
 from scvi.data._utils import _assign_adata_uuid, _check_if_view, _get_adata_minify_type
 from scvi.dataloaders import AnnDataLoader
 from scvi.model._utils import parse_device_args
-from scvi.model.base._utils import _load_legacy_saved_files
+from scvi.model.base._save_load import (
+    _initialize_model,
+    _load_legacy_saved_files,
+    _load_saved_files,
+    _validate_var_names,
+)
 from scvi.utils import attrdict, setup_anndata_dsp
 from scvi.utils._docstrings import devices_dsp
-
-from ._utils import _initialize_model, _load_saved_files, _validate_var_names
 
 logger = logging.getLogger(__name__)
 

--- a/src/scvi/model/base/_de_core.py
+++ b/src/scvi/model/base/_de_core.py
@@ -1,145 +1,16 @@
 import logging
-import os
-import warnings
 from collections.abc import Iterable as IterableClass
-from typing import Literal, Optional, Union
+from typing import Union
 
 import anndata
-import mudata
 import numpy as np
 import pandas as pd
-import torch
-from anndata import AnnData, read_h5ad
 
-from scvi import settings
-from scvi.data._constants import _SETUP_METHOD_NAME
-from scvi.data._download import _download
 from scvi.utils import track
 
 from ._differential import DifferentialComputation
 
 logger = logging.getLogger(__name__)
-
-
-def _load_legacy_saved_files(
-    dir_path: str,
-    file_name_prefix: str,
-    load_adata: bool,
-) -> tuple[dict, np.ndarray, dict, Optional[AnnData]]:
-    model_path = os.path.join(dir_path, f"{file_name_prefix}model_params.pt")
-    var_names_path = os.path.join(dir_path, f"{file_name_prefix}var_names.csv")
-    setup_dict_path = os.path.join(dir_path, f"{file_name_prefix}attr.pkl")
-
-    model_state_dict = torch.load(model_path, map_location="cpu")
-
-    var_names = np.genfromtxt(var_names_path, delimiter=",", dtype=str)
-
-    with open(setup_dict_path, "rb") as handle:
-        attr_dict = pd.read_pickle(handle)
-
-    if load_adata:
-        adata_path = os.path.join(dir_path, f"{file_name_prefix}adata.h5ad")
-        if os.path.exists(adata_path):
-            adata = read_h5ad(adata_path)
-        elif not os.path.exists(adata_path):
-            raise ValueError("Save path contains no saved anndata and no adata was passed.")
-    else:
-        adata = None
-
-    return model_state_dict, var_names, attr_dict, adata
-
-
-def _load_saved_files(
-    dir_path: str,
-    load_adata: bool,
-    prefix: Optional[str] = None,
-    map_location: Optional[Literal["cpu", "cuda"]] = None,
-    backup_url: Optional[str] = None,
-) -> tuple[dict, np.ndarray, dict, AnnData]:
-    """Helper to load saved files."""
-    file_name_prefix = prefix or ""
-
-    model_file_name = f"{file_name_prefix}model.pt"
-    model_path = os.path.join(dir_path, model_file_name)
-    try:
-        _download(backup_url, dir_path, model_file_name)
-        model = torch.load(model_path, map_location=map_location)
-    except FileNotFoundError as exc:
-        raise ValueError(
-            f"Failed to load model file at {model_path}. "
-            "If attempting to load a saved model from <v0.15.0, please use the util function "
-            "`convert_legacy_save` to convert to an updated format."
-        ) from exc
-
-    model_state_dict = model["model_state_dict"]
-    var_names = model["var_names"]
-    attr_dict = model["attr_dict"]
-
-    if load_adata:
-        is_mudata = attr_dict["registry_"].get(_SETUP_METHOD_NAME) == "setup_mudata"
-        file_suffix = "adata.h5ad" if is_mudata is False else "mdata.h5mu"
-        adata_path = os.path.join(dir_path, f"{file_name_prefix}{file_suffix}")
-        if os.path.exists(adata_path):
-            if is_mudata:
-                adata = mudata.read(adata_path)
-            else:
-                adata = anndata.read_h5ad(adata_path)
-        else:
-            raise ValueError("Save path contains no saved anndata and no adata was passed.")
-    else:
-        adata = None
-
-    return attr_dict, var_names, model_state_dict, adata
-
-
-def _initialize_model(cls, adata, attr_dict):
-    """Helper to initialize a model."""
-    if "init_params_" not in attr_dict.keys():
-        raise ValueError(
-            "No init_params_ were saved by the model. Check out the "
-            "developers guide if creating custom models."
-        )
-    # get the parameters for the class init signature
-    init_params = attr_dict.pop("init_params_")
-
-    # new saving and loading, enable backwards compatibility
-    if "non_kwargs" in init_params.keys():
-        # grab all the parameters except for kwargs (is a dict)
-        non_kwargs = init_params["non_kwargs"]
-        kwargs = init_params["kwargs"]
-
-        # expand out kwargs
-        kwargs = {k: v for (i, j) in kwargs.items() for (k, v) in j.items()}
-    else:
-        # grab all the parameters except for kwargs (is a dict)
-        non_kwargs = {k: v for k, v in init_params.items() if not isinstance(v, dict)}
-        kwargs = {k: v for k, v in init_params.items() if isinstance(v, dict)}
-        kwargs = {k: v for (i, j) in kwargs.items() for (k, v) in j.items()}
-        non_kwargs.pop("use_cuda")
-
-    # backwards compat for scANVI
-    if "unlabeled_category" in non_kwargs.keys():
-        non_kwargs.pop("unlabeled_category")
-    if "pretrained_model" in non_kwargs.keys():
-        non_kwargs.pop("pretrained_model")
-
-    model = cls(adata, **non_kwargs, **kwargs)
-    for attr, val in attr_dict.items():
-        setattr(model, attr, val)
-
-    return model
-
-
-def _validate_var_names(adata, source_var_names):
-    user_var_names = adata.var_names.astype(str)
-    if not np.array_equal(source_var_names, user_var_names):
-        warnings.warn(
-            "var_names for adata passed in does not match var_names of adata used to "
-            "train the model. For valid results, the vars need to be the same and in "
-            "the same order as the adata used to train the model.",
-            UserWarning,
-            stacklevel=settings.warnings_stacklevel,
-        )
 
 
 def _prepare_obs(

--- a/src/scvi/model/base/_rnamixin.py
+++ b/src/scvi/model/base/_rnamixin.py
@@ -17,10 +17,9 @@ from scvi import REGISTRY_KEYS, settings
 from scvi._types import Number
 from scvi.distributions._utils import DistributionConcatenator, subset_distribution
 from scvi.model._utils import _get_batch_code_from_category, scrna_raw_counts_properties
+from scvi.model.base._de_core import _de_core
 from scvi.module.base._decorators import _move_data_to_device
 from scvi.utils import de_dsp, dependencies, unsupported_if_adata_minified
-
-from ._utils import _de_core
 
 try:
     from sparse import GCXS

--- a/src/scvi/model/base/_save_load.py
+++ b/src/scvi/model/base/_save_load.py
@@ -1,0 +1,290 @@
+import logging
+import os
+import warnings
+from collections.abc import Iterable as IterableClass
+from typing import Literal, Optional, Union
+
+import anndata
+import mudata
+import numpy as np
+import pandas as pd
+import torch
+from anndata import AnnData, read_h5ad
+
+from scvi import settings
+from scvi.data._constants import _SETUP_METHOD_NAME
+from scvi.data._download import _download
+from scvi.utils import track
+
+from ._differential import DifferentialComputation
+
+logger = logging.getLogger(__name__)
+
+
+def _load_legacy_saved_files(
+    dir_path: str,
+    file_name_prefix: str,
+    load_adata: bool,
+) -> tuple[dict, np.ndarray, dict, Optional[AnnData]]:
+    model_path = os.path.join(dir_path, f"{file_name_prefix}model_params.pt")
+    var_names_path = os.path.join(dir_path, f"{file_name_prefix}var_names.csv")
+    setup_dict_path = os.path.join(dir_path, f"{file_name_prefix}attr.pkl")
+
+    model_state_dict = torch.load(model_path, map_location="cpu")
+
+    var_names = np.genfromtxt(var_names_path, delimiter=",", dtype=str)
+
+    with open(setup_dict_path, "rb") as handle:
+        attr_dict = pd.read_pickle(handle)
+
+    if load_adata:
+        adata_path = os.path.join(dir_path, f"{file_name_prefix}adata.h5ad")
+        if os.path.exists(adata_path):
+            adata = read_h5ad(adata_path)
+        elif not os.path.exists(adata_path):
+            raise ValueError("Save path contains no saved anndata and no adata was passed.")
+    else:
+        adata = None
+
+    return model_state_dict, var_names, attr_dict, adata
+
+
+def _load_saved_files(
+    dir_path: str,
+    load_adata: bool,
+    prefix: Optional[str] = None,
+    map_location: Optional[Literal["cpu", "cuda"]] = None,
+    backup_url: Optional[str] = None,
+) -> tuple[dict, np.ndarray, dict, AnnData]:
+    """Helper to load saved files."""
+    file_name_prefix = prefix or ""
+
+    model_file_name = f"{file_name_prefix}model.pt"
+    model_path = os.path.join(dir_path, model_file_name)
+    try:
+        _download(backup_url, dir_path, model_file_name)
+        model = torch.load(model_path, map_location=map_location)
+    except FileNotFoundError as exc:
+        raise ValueError(
+            f"Failed to load model file at {model_path}. "
+            "If attempting to load a saved model from <v0.15.0, please use the util function "
+            "`convert_legacy_save` to convert to an updated format."
+        ) from exc
+
+    model_state_dict = model["model_state_dict"]
+    var_names = model["var_names"]
+    attr_dict = model["attr_dict"]
+
+    if load_adata:
+        is_mudata = attr_dict["registry_"].get(_SETUP_METHOD_NAME) == "setup_mudata"
+        file_suffix = "adata.h5ad" if is_mudata is False else "mdata.h5mu"
+        adata_path = os.path.join(dir_path, f"{file_name_prefix}{file_suffix}")
+        if os.path.exists(adata_path):
+            if is_mudata:
+                adata = mudata.read(adata_path)
+            else:
+                adata = anndata.read_h5ad(adata_path)
+        else:
+            raise ValueError("Save path contains no saved anndata and no adata was passed.")
+    else:
+        adata = None
+
+    return attr_dict, var_names, model_state_dict, adata
+
+
+def _initialize_model(cls, adata, attr_dict):
+    """Helper to initialize a model."""
+    if "init_params_" not in attr_dict.keys():
+        raise ValueError(
+            "No init_params_ were saved by the model. Check out the "
+            "developers guide if creating custom models."
+        )
+    # get the parameters for the class init signature
+    init_params = attr_dict.pop("init_params_")
+
+    # new saving and loading, enable backwards compatibility
+    if "non_kwargs" in init_params.keys():
+        # grab all the parameters except for kwargs (is a dict)
+        non_kwargs = init_params["non_kwargs"]
+        kwargs = init_params["kwargs"]
+
+        # expand out kwargs
+        kwargs = {k: v for (i, j) in kwargs.items() for (k, v) in j.items()}
+    else:
+        # grab all the parameters except for kwargs (is a dict)
+        non_kwargs = {k: v for k, v in init_params.items() if not isinstance(v, dict)}
+        kwargs = {k: v for k, v in init_params.items() if isinstance(v, dict)}
+        kwargs = {k: v for (i, j) in kwargs.items() for (k, v) in j.items()}
+        non_kwargs.pop("use_cuda")
+
+    # backwards compat for scANVI
+    if "unlabeled_category" in non_kwargs.keys():
+        non_kwargs.pop("unlabeled_category")
+    if "pretrained_model" in non_kwargs.keys():
+        non_kwargs.pop("pretrained_model")
+
+    model = cls(adata, **non_kwargs, **kwargs)
+    for attr, val in attr_dict.items():
+        setattr(model, attr, val)
+
+    return model
+
+
+def _validate_var_names(adata, source_var_names):
+    user_var_names = adata.var_names.astype(str)
+    if not np.array_equal(source_var_names, user_var_names):
+        warnings.warn(
+            "var_names for adata passed in does not match var_names of adata used to "
+            "train the model. For valid results, the vars need to be the same and in "
+            "the same order as the adata used to train the model.",
+            UserWarning,
+            stacklevel=settings.warnings_stacklevel,
+        )
+
+
+def _prepare_obs(
+    idx1: Union[list[bool], np.ndarray, str],
+    idx2: Union[list[bool], np.ndarray, str],
+    adata: anndata.AnnData,
+):
+    """Construct an array used for masking.
+
+    Given population identifiers `idx1` and potentially `idx2`,
+    this function creates an array `obs_col` that identifies both populations
+    for observations contained in `adata`.
+    In particular, `obs_col` will take values `group1` (resp. `group2`)
+    for `idx1` (resp `idx2`).
+
+    Parameters
+    ----------
+    idx1
+        Can be of three types. First, it can corresponds to a boolean mask that
+        has the same shape as adata. It can also corresponds to a list of indices.
+        Last, it can correspond to string query of adata.obs columns.
+    idx2
+        Same as above
+    adata
+        Anndata
+    """
+
+    def ravel_idx(my_idx, obs_df):
+        return (
+            obs_df.index.isin(obs_df.query(my_idx).index)
+            if isinstance(my_idx, str)
+            else np.asarray(my_idx).ravel()
+        )
+
+    obs_df = adata.obs
+    idx1 = ravel_idx(idx1, obs_df)
+    g1_key = "one"
+    obs_col = np.array(["None"] * adata.shape[0], dtype=str)
+    obs_col[idx1] = g1_key
+    group1 = [g1_key]
+    group2 = None if idx2 is None else "two"
+    if idx2 is not None:
+        idx2 = ravel_idx(idx2, obs_df)
+        obs_col[idx2] = group2
+    if (obs_col[idx1].shape[0] == 0) or (obs_col[idx2].shape[0] == 0):
+        raise ValueError("One of idx1 or idx2 has size zero.")
+    return obs_col, group1, group2
+
+
+def _de_core(
+    adata_manager,
+    model_fn,
+    representation_fn,
+    groupby,
+    group1,
+    group2,
+    idx1,
+    idx2,
+    all_stats,
+    all_stats_fn,
+    col_names,
+    mode,
+    batchid1,
+    batchid2,
+    delta,
+    batch_correction,
+    fdr,
+    silent,
+    **kwargs,
+):
+    """Internal function for DE interface."""
+    adata = adata_manager.adata
+    if group1 is None and idx1 is None:
+        group1 = adata.obs[groupby].astype("category").cat.categories.tolist()
+        if len(group1) == 1:
+            raise ValueError("Only a single group in the data. Can't run DE on a single group.")
+
+    if not isinstance(group1, IterableClass) or isinstance(group1, str):
+        group1 = [group1]
+
+    # make a temp obs key using indices
+    temp_key = None
+    if idx1 is not None:
+        obs_col, group1, group2 = _prepare_obs(idx1, idx2, adata)
+        temp_key = "_scvi_temp_de"
+        adata.obs[temp_key] = obs_col
+        groupby = temp_key
+
+    df_results = []
+    dc = DifferentialComputation(model_fn, representation_fn, adata_manager)
+    for g1 in track(
+        group1,
+        description="DE...",
+        disable=silent,
+    ):
+        cell_idx1 = (adata.obs[groupby] == g1).to_numpy().ravel()
+        if group2 is None:
+            cell_idx2 = ~cell_idx1
+        else:
+            cell_idx2 = (adata.obs[groupby] == group2).to_numpy().ravel()
+
+        all_info = dc.get_bayes_factors(
+            cell_idx1,
+            cell_idx2,
+            mode=mode,
+            delta=delta,
+            batchid1=batchid1,
+            batchid2=batchid2,
+            use_observed_batches=not batch_correction,
+            **kwargs,
+        )
+
+        if all_stats is True:
+            genes_properties_dict = all_stats_fn(adata_manager, cell_idx1, cell_idx2)
+            all_info = {**all_info, **genes_properties_dict}
+
+        res = pd.DataFrame(all_info, index=col_names)
+        sort_key = "proba_de" if mode == "change" else "bayes_factor"
+        res = res.sort_values(by=sort_key, ascending=False)
+        if mode == "change":
+            res[f"is_de_fdr_{fdr}"] = _fdr_de_prediction(res["proba_de"], fdr=fdr)
+        if idx1 is None:
+            g2 = "Rest" if group2 is None else group2
+            res["comparison"] = f"{g1} vs {g2}"
+            res["group1"] = g1
+            res["group2"] = g2
+        df_results.append(res)
+
+    if temp_key is not None:
+        del adata.obs[temp_key]
+
+    result = pd.concat(df_results, axis=0)
+
+    return result
+
+
+def _fdr_de_prediction(posterior_probas: pd.Series, fdr: float = 0.05) -> pd.Series:
+    """Compute posterior expected FDR and tag features as DE."""
+    if not posterior_probas.ndim == 1:
+        raise ValueError("posterior_probas should be 1-dimensional")
+    original_index = posterior_probas.index
+    sorted_pgs = posterior_probas.sort_values(ascending=False)
+    cumulative_fdr = (1.0 - sorted_pgs).cumsum() / (1.0 + np.arange(len(sorted_pgs)))
+    d = (cumulative_fdr <= fdr).sum()
+    is_pred_de = pd.Series(np.zeros_like(cumulative_fdr).astype(bool), index=sorted_pgs.index)
+    is_pred_de.iloc[:d] = True
+    is_pred_de = is_pred_de.loc[original_index]
+    return is_pred_de

--- a/src/scvi/model/base/_save_load.py
+++ b/src/scvi/model/base/_save_load.py
@@ -1,8 +1,7 @@
 import logging
 import os
 import warnings
-from collections.abc import Iterable as IterableClass
-from typing import Literal, Optional, Union
+from typing import Literal, Optional
 
 import anndata
 import mudata
@@ -14,9 +13,6 @@ from anndata import AnnData, read_h5ad
 from scvi import settings
 from scvi.data._constants import _SETUP_METHOD_NAME
 from scvi.data._download import _download
-from scvi.utils import track
-
-from ._differential import DifferentialComputation
 
 logger = logging.getLogger(__name__)
 
@@ -140,151 +136,3 @@ def _validate_var_names(adata, source_var_names):
             UserWarning,
             stacklevel=settings.warnings_stacklevel,
         )
-
-
-def _prepare_obs(
-    idx1: Union[list[bool], np.ndarray, str],
-    idx2: Union[list[bool], np.ndarray, str],
-    adata: anndata.AnnData,
-):
-    """Construct an array used for masking.
-
-    Given population identifiers `idx1` and potentially `idx2`,
-    this function creates an array `obs_col` that identifies both populations
-    for observations contained in `adata`.
-    In particular, `obs_col` will take values `group1` (resp. `group2`)
-    for `idx1` (resp `idx2`).
-
-    Parameters
-    ----------
-    idx1
-        Can be of three types. First, it can corresponds to a boolean mask that
-        has the same shape as adata. It can also corresponds to a list of indices.
-        Last, it can correspond to string query of adata.obs columns.
-    idx2
-        Same as above
-    adata
-        Anndata
-    """
-
-    def ravel_idx(my_idx, obs_df):
-        return (
-            obs_df.index.isin(obs_df.query(my_idx).index)
-            if isinstance(my_idx, str)
-            else np.asarray(my_idx).ravel()
-        )
-
-    obs_df = adata.obs
-    idx1 = ravel_idx(idx1, obs_df)
-    g1_key = "one"
-    obs_col = np.array(["None"] * adata.shape[0], dtype=str)
-    obs_col[idx1] = g1_key
-    group1 = [g1_key]
-    group2 = None if idx2 is None else "two"
-    if idx2 is not None:
-        idx2 = ravel_idx(idx2, obs_df)
-        obs_col[idx2] = group2
-    if (obs_col[idx1].shape[0] == 0) or (obs_col[idx2].shape[0] == 0):
-        raise ValueError("One of idx1 or idx2 has size zero.")
-    return obs_col, group1, group2
-
-
-def _de_core(
-    adata_manager,
-    model_fn,
-    representation_fn,
-    groupby,
-    group1,
-    group2,
-    idx1,
-    idx2,
-    all_stats,
-    all_stats_fn,
-    col_names,
-    mode,
-    batchid1,
-    batchid2,
-    delta,
-    batch_correction,
-    fdr,
-    silent,
-    **kwargs,
-):
-    """Internal function for DE interface."""
-    adata = adata_manager.adata
-    if group1 is None and idx1 is None:
-        group1 = adata.obs[groupby].astype("category").cat.categories.tolist()
-        if len(group1) == 1:
-            raise ValueError("Only a single group in the data. Can't run DE on a single group.")
-
-    if not isinstance(group1, IterableClass) or isinstance(group1, str):
-        group1 = [group1]
-
-    # make a temp obs key using indices
-    temp_key = None
-    if idx1 is not None:
-        obs_col, group1, group2 = _prepare_obs(idx1, idx2, adata)
-        temp_key = "_scvi_temp_de"
-        adata.obs[temp_key] = obs_col
-        groupby = temp_key
-
-    df_results = []
-    dc = DifferentialComputation(model_fn, representation_fn, adata_manager)
-    for g1 in track(
-        group1,
-        description="DE...",
-        disable=silent,
-    ):
-        cell_idx1 = (adata.obs[groupby] == g1).to_numpy().ravel()
-        if group2 is None:
-            cell_idx2 = ~cell_idx1
-        else:
-            cell_idx2 = (adata.obs[groupby] == group2).to_numpy().ravel()
-
-        all_info = dc.get_bayes_factors(
-            cell_idx1,
-            cell_idx2,
-            mode=mode,
-            delta=delta,
-            batchid1=batchid1,
-            batchid2=batchid2,
-            use_observed_batches=not batch_correction,
-            **kwargs,
-        )
-
-        if all_stats is True:
-            genes_properties_dict = all_stats_fn(adata_manager, cell_idx1, cell_idx2)
-            all_info = {**all_info, **genes_properties_dict}
-
-        res = pd.DataFrame(all_info, index=col_names)
-        sort_key = "proba_de" if mode == "change" else "bayes_factor"
-        res = res.sort_values(by=sort_key, ascending=False)
-        if mode == "change":
-            res[f"is_de_fdr_{fdr}"] = _fdr_de_prediction(res["proba_de"], fdr=fdr)
-        if idx1 is None:
-            g2 = "Rest" if group2 is None else group2
-            res["comparison"] = f"{g1} vs {g2}"
-            res["group1"] = g1
-            res["group2"] = g2
-        df_results.append(res)
-
-    if temp_key is not None:
-        del adata.obs[temp_key]
-
-    result = pd.concat(df_results, axis=0)
-
-    return result
-
-
-def _fdr_de_prediction(posterior_probas: pd.Series, fdr: float = 0.05) -> pd.Series:
-    """Compute posterior expected FDR and tag features as DE."""
-    if not posterior_probas.ndim == 1:
-        raise ValueError("posterior_probas should be 1-dimensional")
-    original_index = posterior_probas.index
-    sorted_pgs = posterior_probas.sort_values(ascending=False)
-    cumulative_fdr = (1.0 - sorted_pgs).cumsum() / (1.0 + np.arange(len(sorted_pgs)))
-    d = (cumulative_fdr <= fdr).sum()
-    is_pred_de = pd.Series(np.zeros_like(cumulative_fdr).astype(bool), index=sorted_pgs.index)
-    is_pred_de.iloc[:d] = True
-    is_pred_de = is_pred_de.loc[original_index]
-    return is_pred_de

--- a/src/scvi/train/_callbacks.py
+++ b/src/scvi/train/_callbacks.py
@@ -18,7 +18,7 @@ from lightning.pytorch.utilities import rank_zero_info
 from scvi import settings
 from scvi.dataloaders import AnnDataLoader
 from scvi.model.base import BaseModelClass
-from scvi.model.base._utils import _load_saved_files
+from scvi.model.base._save_load import _load_saved_files
 
 MetricCallable = Callable[[BaseModelClass], float]
 

--- a/tests/model/test_differential.py
+++ b/tests/model/test_differential.py
@@ -5,12 +5,12 @@ import pytest
 
 from scvi.data import synthetic_iid
 from scvi.model import SCVI
+from scvi.model.base._de_core import _prepare_obs
 from scvi.model.base._differential import (
     DifferentialComputation,
     estimate_delta,
     estimate_pseudocounts_offset,
 )
-from scvi.model.base._utils import _prepare_obs
 
 
 def test_features():


### PR DESCRIPTION
- moves `scvi.model.base._utils._load_legacy_saved_files` to `scvi.model.base._save_load._load_legacy_saved_files`
- moves `scvi.model.base._utils._load_saved_files` to `scvi.model.base._save_load._load_saved_files`
- moves `scvi.model.base._utils._initialize_model` to `scvi.model.base._save_load._initialize_model`
- moves `scvi.model.base._utils._validate_var_names` to `scvi.model.base._save_load._validate_var_names`
- moves `scvi.model.base._utils._prepare_obs` to `scvi.model.base._de_core._prepare_obs`
- moves `scvi.model.base._utils._de_core` to `scvi.model.base._de_core._de_core`
- moves `scvi.model.base._utils._fdr_de_prediction` to `scvi.model.base._de_core_._fdr_de_prediction`
- refactors imports accordingly