### PR TITLE
feat(model): support custom dataloaders in vaemixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ to [Semantic Versioning]. Full commit history is available in the
     distribution with mean-dispersion parameterization for modeling scBS-seq methylation data
     {pr}`2692`.
 - Add support for custom dataloaders in {class}`scvi.model.base.VAEMixin` methods by specifying
-    the `dataloader` argument {pr}`xxxx`.
+    the `dataloader` argument {pr}`2748`.
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ to [Semantic Versioning]. Full commit history is available in the
 - Add experimental class {class}`scvi.distributions.BetaBinomial` implementing the Beta-Binomial
     distribution with mean-dispersion parameterization for modeling scBS-seq methylation data
     {pr}`2692`.
+- Add support for custom dataloaders in {class}`scvi.model.base.VAEMixin` methods by specifying
+    the `dataloader` argument {pr}`xxxx`.
 
 #### Changed
 

--- a/src/scvi/model/base/_log_likelihood.py
+++ b/src/scvi/model/base/_log_likelihood.py
@@ -1,57 +1,92 @@
-"""File for computing log likelihood of the data."""
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any, Callable
 
 import torch
+from torch import Tensor
+
+from scvi.module.base import LossOutput
 
 
-def compute_elbo(vae, data_loader, **kwargs):
-    """Computes the ELBO.
+def compute_elbo(
+    module: Callable[[dict[str, Tensor | None], dict], tuple[Any, Any, LossOutput]],
+    dataloader: Iterator[dict[str, Tensor | None]],
+    **kwargs,
+) -> float:
+    """Compute the evidence lower bound (ELBO) on the data.
 
-    The ELBO is the reconstruction error + the KL divergences
-    between the variational distributions and the priors.
-    It differs from the marginal log likelihood.
-    Specifically, it is a lower bound on the marginal log likelihood
-    plus a term that is constant with respect to the variational distribution.
-    It still gives good insights on the modeling of the data, and is fast to compute.
+    The ELBO is the reconstruction error plus the Kullback-Leibler (KL) divergences between the
+    variational distributions and the priors. It is different from the marginal log-likelihood;
+    specifically, it is a lower bound on the marginal log-likelihood plus a term that is constant
+    with respect to the variational distribution. It still gives good insights on the modeling of
+    the data and is fast to compute.
+
+    Parameters
+    ----------
+    module
+        A callable (can be a :class:`~torch.nn.Module` instance) that takes a dictionary of
+        :class:`~torch.Tensor`s as input and returns a tuple of three elements, where the last
+        element is an instance of :class:`~scvi.module.base.LossOutput`.
+    dataloader
+        An iterator that returns a dictionary of :class:`~torch.Tensor` instances for each
+        minibatch formatted as expected by the ``forward`` method of ``vae``.
+    **kwargs
+        Additional keyword arguments to pass into ``module``.
+
+    Returns
+    -------
+    The evidence lower bound (ELBO) of the data.
     """
-    # Iterate once over the data and compute the elbo
-    elbo = 0
-    for tensors in data_loader:
-        _, _, scvi_loss = vae(tensors, **kwargs)
+    elbo = 0.0
+    for tensors in dataloader:
+        _, _, loss_output = module(tensors, **kwargs)
+        elbo += (loss_output.reconstruction_loss_sum + loss_output.kl_local_sum).item()
 
-        recon_loss = scvi_loss.reconstruction_loss_sum
-        kl_local = scvi_loss.kl_local_sum
-        elbo += (recon_loss + kl_local).item()
-
-    kl_global = scvi_loss.kl_global_sum
-    n_samples = len(data_loader.indices)
+    kl_global = loss_output.kl_global_sum
+    n_samples = len(dataloader.indices)
     elbo += kl_global
+
     return elbo / n_samples
 
 
-# do each one
-def compute_reconstruction_error(vae, data_loader, **kwargs):
-    """Computes log p(x/z), which is the reconstruction error.
+def compute_reconstruction_error(
+    module: Callable[[dict[str, Tensor | None], dict], tuple[Any, Any, LossOutput]],
+    dataloader: Iterator[dict[str, Tensor | None]],
+    **kwargs,
+) -> dict[str, float]:
+    """Compute the reconstruction error on the data.
 
-    Differs from the marginal log likelihood, but still gives good
-    insights on the modeling of the data, and is fast to compute.
+    The reconstruction error is the negative log likelihood of the data given the latent
+    variables. It is different from the marginal log-likelihood, but still gives good insights on
+    the modeling of the data and is fast to compute.
+
+    Parameters
+    ----------
+    module
+        A callable (can be a :class:`~torch.nn.Module` instance) that takes a dictionary of
+        :class:`~torch.Tensor`s as input and returns a tuple of three elements, where the last
+        element is an instance of :class:`~scvi.module.base.LossOutput`.
+    dataloader
+        An iterator that returns a dictionary of :class:`~torch.Tensor` instances for each
+        minibatch formatted as expected by the ``forward`` method of ``vae``.
+    **kwargs
+        Additional keyword arguments to pass into ``module``.
+
+    Returns
+    -------
+    A dictionary of the reconstruction error of the data.
     """
-    # Iterate once over the data and computes the reconstruction error
-    log_lkl = {}
-    for tensors in data_loader:
-        loss_kwargs = {"kl_weight": 1}
-        _, _, losses = vae(tensors, loss_kwargs=loss_kwargs)
-        if not isinstance(losses.reconstruction_loss, dict):
-            rec_loss_dict = {"reconstruction_loss": losses.reconstruction_loss}
-        else:
-            rec_loss_dict = losses.reconstruction_loss
-        for key, value in rec_loss_dict.items():
-            if key in log_lkl:
-                log_lkl[key] += torch.sum(value).item()
-            else:
-                log_lkl[key] = torch.sum(value).item()
+    log_likelihoods = {}
+    for tensors in dataloader:
+        _, _, loss_output = module(tensors, loss_kwargs={"kl_weight": 1}, **kwargs)
+        rec_losses = loss_output.reconstruction_loss
+        if not isinstance(rec_losses, dict):
+            rec_losses = {"reconstruction_loss": rec_losses}
 
-    n_samples = len(data_loader.indices)
-    for key, _ in log_lkl.items():
-        log_lkl[key] = log_lkl[key] / n_samples
-        log_lkl[key] = -log_lkl[key]
-    return log_lkl
+        for key, value in rec_losses.items():
+            log_likelihoods[key] = log_likelihoods.get(key, 0.0) + torch.sum(value).item()
+
+    n_samples = len(dataloader.indices)
+
+    return {key: -(value / n_samples) for key, value in log_likelihoods.items()}

--- a/src/scvi/model/base/_log_likelihood.py
+++ b/src/scvi/model/base/_log_likelihood.py
@@ -28,8 +28,9 @@ def compute_elbo(
         :class:`~torch.Tensor`s as input and returns a tuple of three elements, where the last
         element is an instance of :class:`~scvi.module.base.LossOutput`.
     dataloader
-        An iterator that returns a dictionary of :class:`~torch.Tensor` instances for each
-        minibatch formatted as expected by the ``forward`` method of ``vae``.
+        An iterator over minibatches of data on which to compute the metric. The minibatches
+        should be formatted as a dictionary of :class:`~torch.Tensor` with keys as expected by
+        the ``forward`` method of ``module``.
     **kwargs
         Additional keyword arguments to pass into ``module``.
 
@@ -63,8 +64,9 @@ def compute_reconstruction_error(
         :class:`~torch.Tensor`s as input and returns a tuple of three elements, where the last
         element is an instance of :class:`~scvi.module.base.LossOutput`.
     dataloader
-        An iterator that returns a dictionary of :class:`~torch.Tensor` instances for each
-        minibatch formatted as expected by the ``forward`` method of ``vae``.
+        An iterator over minibatches of data on which to compute the metric. The minibatches
+        should be formatted as a dictionary of :class:`~torch.Tensor` with keys as expected by
+        the ``forward`` method of ``module``.
     **kwargs
         Additional keyword arguments to pass into ``module``.
 

--- a/src/scvi/model/base/_log_likelihood.py
+++ b/src/scvi/model/base/_log_likelihood.py
@@ -42,11 +42,7 @@ def compute_elbo(
         _, _, loss_output = module(tensors, **kwargs)
         elbo += (loss_output.reconstruction_loss_sum + loss_output.kl_local_sum).item()
 
-    kl_global = loss_output.kl_global_sum
-    n_samples = len(dataloader.indices)
-    elbo += kl_global
-
-    return elbo / n_samples
+    return (elbo + loss_output.kl_global_sum) / len(dataloader.dataset)
 
 
 def compute_reconstruction_error(
@@ -86,6 +82,4 @@ def compute_reconstruction_error(
         for key, value in rec_losses.items():
             log_likelihoods[key] = log_likelihoods.get(key, 0.0) + value.sum().item()
 
-    n_samples = len(dataloader.indices)
-
-    return {key: -(value / n_samples) for key, value in log_likelihoods.items()}
+    return {key: -(value / len(dataloader.dataset)) for key, value in log_likelihoods.items()}

--- a/src/scvi/model/base/_log_likelihood.py
+++ b/src/scvi/model/base/_log_likelihood.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Iterator
 from typing import Any, Callable
 
-import torch
 from torch import Tensor
 
 from scvi.module.base import LossOutput
@@ -80,12 +79,12 @@ def compute_reconstruction_error(
     log_likelihoods = {}
     for tensors in dataloader:
         _, _, loss_output = module(tensors, loss_kwargs={"kl_weight": 1}, **kwargs)
-        rec_losses = loss_output.reconstruction_loss
+        rec_losses: dict[str, Tensor] | Tensor = loss_output.reconstruction_loss
         if not isinstance(rec_losses, dict):
             rec_losses = {"reconstruction_loss": rec_losses}
 
         for key, value in rec_losses.items():
-            log_likelihoods[key] = log_likelihoods.get(key, 0.0) + torch.sum(value).item()
+            log_likelihoods[key] = log_likelihoods.get(key, 0.0) + value.sum().item()
 
     n_samples = len(dataloader.indices)
 

--- a/src/scvi/model/base/_vaemixin.py
+++ b/src/scvi/model/base/_vaemixin.py
@@ -27,10 +27,11 @@ class VAEMixin:
     ) -> float:
         """Compute the evidence lower bound (ELBO) on the data.
 
-        The ELBO is a lower bound on the log-likelihood of the data used for optimization of VAEs.
-
-        The ELBO is a lower bound on the log likelihood of the data used for optimization
-        of VAEs. Note, this is not the negative ELBO, higher is better.
+        The ELBO is the reconstruction error plus the Kullback-Leibler (KL) divergences between the
+        variational distributions and the priors. It is different from the marginal log-likelihood;
+        specifically, it is a lower bound on the marginal log-likelihood plus a term that is
+        constant with respect to the variational distribution. It still gives good insights on the
+        modeling of the data and is fast to compute.
 
         Parameters
         ----------
@@ -40,12 +41,14 @@ class VAEMixin:
             ``None``, it defaults to the object used to initialize the model.
         indices
             Indices of observations in ``adata`` to use. If ``None``, defaults to all observations.
+            Ignored if ``dataloader`` is not ``None``.
         batch_size
-            Minibatch size for the forward pass. Only used if ``dataloader`` is ``None``. If
-            ``None``, defaults to ``scvi.settings.batch_size``.
+            Minibatch size for the forward pass. If ``None``, defaults to
+            ``scvi.settings.batch_size``. Ignored if ``dataloader`` is not ``None``.
         dataloader
-            An iterator that returns a dictionary of :class:`~torch.Tensor` instances for each
-            minibatch formatted as expected by the model.
+            An iterator over minibatches of data on which to compute the metric. The minibatches
+            should be formatted as a dictionary of :class:`~torch.Tensor`s with keys as
+            expected by the model. If ``None``, a dataloader is created from ``adata``.
         **kwargs
             Additional keyword arguments to pass into the forward method of the module.
 
@@ -94,24 +97,27 @@ class VAEMixin:
             ``None``, it defaults to the object used to initialize the model.
         indices
             Indices of observations in ``adata`` to use. If ``None``, defaults to all observations.
+            Ignored if ``dataloader`` is not ``None``.
         n_mc_samples
-            Number of Monte Carlo samples to use for the estimator.
+            Number of Monte Carlo samples to use for the estimator. Passed into the module's
+            ``marginal_ll`` method.
         batch_size
-            Minibatch size for the forward pass. Only used if ``dataloader`` is ``None``. If
-            ``None``, defaults to ``scvi.settings.batch_size``.
+            Minibatch size for the forward pass. If ``None``, defaults to
+            ``scvi.settings.batch_size``. Ignored if ``dataloader`` is not ``None``.
         return_mean
             Whether to return the mean of the marginal log-likelihood or the marginal-log
             likelihood for each observation.
         dataloader
-            An iterator that returns a dictionary of :class:`~torch.Tensor` instances for each
-            minibatch formatted as expected by the model.
+            An iterator over minibatches of data on which to compute the metric. The minibatches
+            should be formatted as a dictionary of :class:`~torch.Tensor`s with keys as
+            expected by the model. If ``None``, a dataloader is created from ``adata``.
         **kwargs
             Additional keyword arguments to pass into the module's ``marginal_ll`` method.
 
         Returns
         -------
-        A tensor of shape ``(n_obs,)`` with the marginal log-likelihood for each observation if
-        ``return_mean`` is ``False``. Otherwise, returns the mean marginal log-likelihood.
+        If ``True``, returns the mean marginal log-likelihood. Otherwise returns a tensor of shape
+        ``(n_obs,)`` with the marginal log-likelihood for each observation.
 
         Notes
         -----
@@ -155,11 +161,13 @@ class VAEMixin:
         batch_size: int | None = None,
         dataloader: Iterator[dict[str, Tensor | None]] = None,
         **kwargs,
-    ) -> float:
+    ) -> dict[str, float]:
         r"""Compute the reconstruction error on the data.
 
-        This is typically written as :math:`p(x \mid z)`, the likelihood term given one posterior
-        sample. Note, this is not the negative likelihood, higher is better.
+        The reconstruction error is the negative log likelihood of the data given the latent
+        variables. It is different from the marginal log-likelihood, but still gives good insights
+        on the modeling of the data and is fast to compute. This is typically written as
+        :math:`p(x \mid z)`, the likelihood term given one posterior sample.
 
         Parameters
         ----------
@@ -169,12 +177,14 @@ class VAEMixin:
             ``None``, it defaults to the object used to initialize the model.
         indices
             Indices of observations in ``adata`` to use. If ``None``, defaults to all observations.
+            Ignored if ``dataloader`` is not ``None``
         batch_size
-            Minibatch size for the forward pass. Only used if ``dataloader`` is ``None``. If
-            ``None``, defaults to ``scvi.settings.batch_size``.
+            Minibatch size for the forward pass. If ``None``, defaults to
+            ``scvi.settings.batch_size``. Ignored if ``dataloader`` is not ``None``
         dataloader
-            An iterator that returns a dictionary of :class:`~torch.Tensor` instances for each
-            minibatch formatted as expected by the model.
+            An iterator over minibatches of data on which to compute the metric. The minibatches
+            should be formatted as a dictionary of :class:`~torch.Tensor`s with keys as
+            expected by the model. If ``None``, a dataloader is created from ``adata``.
         **kwargs
             Additional keyword arguments to pass into the forward method of the module.
 
@@ -222,6 +232,7 @@ class VAEMixin:
             ``None``, it defaults to the object used to initialize the model.
         indices
             Indices of observations in ``adata`` to use. If ``None``, defaults to all observations.
+            Ignored if ``dataloader`` is not ``None``
         give_mean
             If ``True``, returns the mean of the latent distribution. If ``False``, returns an
             estimate of the mean using ``mc_samples`` Monte Carlo samples.
@@ -230,14 +241,15 @@ class VAEMixin:
             closed-form mean (e.g., the logistic normal distribution). Not used if ``give_mean`` is
             ``True`` or if ``return_dist`` is ``True``.
         batch_size
-            Minibatch size for the forward pass. Only used if ``dataloader`` is ``None``. If
-            ``None``, defaults to ``scvi.settings.batch_size``.
+            Minibatch size for the forward pass. If ``None``, defaults to
+            ``scvi.settings.batch_size``. Ignored if ``dataloader`` is not ``None``
         return_dist
             If ``True``, returns the mean and variance of the latent distribution. Otherwise,
             returns the mean of the latent distribution.
         dataloader
-            An iterator that returns a dictionary of :class:`~torch.Tensor` instances for each
-            minibatch formatted as expected by the model.
+            An iterator over minibatches of data on which to compute the metric. The minibatches
+            should be formatted as a dictionary of :class:`~torch.Tensor`s with keys as
+            expected by the model. If ``None``, a dataloader is created from ``adata``.
 
         Returns
         -------

--- a/src/scvi/model/base/_vaemixin.py
+++ b/src/scvi/model/base/_vaemixin.py
@@ -64,8 +64,7 @@ class VAEMixin:
 
         if adata is not None and dataloader is not None:
             raise ValueError("Only one of `adata` or `dataloader` can be provided.")
-
-        if dataloader is None:
+        elif dataloader is None:
             adata = self._validate_anndata(adata)
             dataloader = self._make_data_loader(
                 adata=adata, indices=indices, batch_size=batch_size
@@ -130,8 +129,7 @@ class VAEMixin:
                 "The model's module must implement `marginal_ll` to compute the marginal "
                 "log-likelihood."
             )
-
-        if adata is not None and dataloader is not None:
+        elif adata is not None and dataloader is not None:
             raise ValueError("Only one of `adata` or `dataloader` can be provided.")
 
         if dataloader is None:

--- a/src/scvi/model/base/_vaemixin.py
+++ b/src/scvi/model/base/_vaemixin.py
@@ -47,8 +47,8 @@ class VAEMixin:
             ``scvi.settings.batch_size``. Ignored if ``dataloader`` is not ``None``.
         dataloader
             An iterator over minibatches of data on which to compute the metric. The minibatches
-            should be formatted as a dictionary of :class:`~torch.Tensor`s with keys as
-            expected by the model. If ``None``, a dataloader is created from ``adata``.
+            should be formatted as a dictionary of :class:`~torch.Tensor` with keys as expected by
+            the model. If ``None``, a dataloader is created from ``adata``.
         **kwargs
             Additional keyword arguments to pass into the forward method of the module.
 
@@ -108,8 +108,8 @@ class VAEMixin:
             likelihood for each observation.
         dataloader
             An iterator over minibatches of data on which to compute the metric. The minibatches
-            should be formatted as a dictionary of :class:`~torch.Tensor`s with keys as
-            expected by the model. If ``None``, a dataloader is created from ``adata``.
+            should be formatted as a dictionary of :class:`~torch.Tensor` with keys as expected by
+            the model. If ``None``, a dataloader is created from ``adata``.
         **kwargs
             Additional keyword arguments to pass into the module's ``marginal_ll`` method.
 
@@ -181,8 +181,8 @@ class VAEMixin:
             ``scvi.settings.batch_size``. Ignored if ``dataloader`` is not ``None``
         dataloader
             An iterator over minibatches of data on which to compute the metric. The minibatches
-            should be formatted as a dictionary of :class:`~torch.Tensor`s with keys as
-            expected by the model. If ``None``, a dataloader is created from ``adata``.
+            should be formatted as a dictionary of :class:`~torch.Tensor` with keys as expected by
+            the model. If ``None``, a dataloader is created from ``adata``.
         **kwargs
             Additional keyword arguments to pass into the forward method of the module.
 
@@ -246,8 +246,8 @@ class VAEMixin:
             returns the mean of the latent distribution.
         dataloader
             An iterator over minibatches of data on which to compute the metric. The minibatches
-            should be formatted as a dictionary of :class:`~torch.Tensor`s with keys as
-            expected by the model. If ``None``, a dataloader is created from ``adata``.
+            should be formatted as a dictionary of :class:`~torch.Tensor` with keys as expected by
+            the model. If ``None``, a dataloader is created from ``adata``.
 
         Returns
         -------

--- a/tests/model/test_scvi.py
+++ b/tests/model/test_scvi.py
@@ -984,3 +984,17 @@ def test_scvi_batch_embeddings(
 
     with pytest.raises(KeyError):
         _ = model.get_batch_representation()
+
+
+def test_scvi_inference_custom_dataloader(n_latent: int = 5):
+    adata = synthetic_iid()
+    SCVI.setup_anndata(adata, batch_key="batch")
+
+    model = SCVI(adata, n_latent=n_latent)
+    model.train(max_epochs=1)
+
+    dataloader = model._make_data_loader(adata)
+    _ = model.get_elbo(dataloader=dataloader)
+    _ = model.get_marginal_ll(dataloader=dataloader)
+    _ = model.get_reconstruction_error(dataloader=dataloader)
+    _ = model.get_latent_representation(dataloader=dataloader)


### PR DESCRIPTION
adds custom dataloader arguments to vaemixin methods. currently does not check that the dataloader outputs in the correct format such that errors will be raised at the module level, which will potentially be confusing.

also includes a refactor of some of the vaemixin methods, including more detailed and consistent docstrings.