### PR TITLE
refactor: rename data_module to datamodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ to [Semantic Versioning]. Full commit history is available in the
     {func}`scvi.model.base._de_core_._fdr_de_prediction` {pr}`2731`.
 - {func}`scvi.data.synthetic_iid` now generates unique variable names for protein and
     accessibility data {pr}`2739`.
+- The `data_module` argument in {meth}`scvi.model.base.UnsupervisedTrainingMixin.train` has been
+    renamed to `datamodule` for consistency {pr}`2749`.
 
 #### Removed
 

--- a/src/scvi/autotune/_experiment.py
+++ b/src/scvi/autotune/_experiment.py
@@ -540,4 +540,4 @@ def _trainable(
         model.train(**train_args)
     else:
         model = experiment.model_cls(**model_args)
-        model.train(data_module=experiment.data, **train_args)
+        model.train(datamodule=experiment.data, **train_args)

--- a/src/scvi/model/base/_training_mixin.py
+++ b/src/scvi/model/base/_training_mixin.py
@@ -29,7 +29,7 @@ class UnsupervisedTrainingMixin:
         early_stopping: bool = False,
         datasplitter_kwargs: dict | None = None,
         plan_kwargs: dict | None = None,
-        data_module: LightningDataModule | None = None,
+        datamodule: LightningDataModule | None = None,
         **trainer_kwargs,
     ):
         """Train the model.
@@ -39,71 +39,71 @@ class UnsupervisedTrainingMixin:
         max_epochs
             The maximum number of epochs to train the model. The actual number of epochs may be
             less if early stopping is enabled. If ``None``, defaults to a heuristic based on
-            :func:`~scvi.model.get_max_epochs_heuristic`. Must be passed in if ``data_module`` is
+            :func:`~scvi.model.get_max_epochs_heuristic`. Must be passed in if ``datamodule`` is
             passed in, and it does not have an ``n_obs`` attribute.
         %(param_accelerator)s
         %(param_devices)s
         train_size
             Size of training set in the range ``[0.0, 1.0]``. Passed into
-            :class:`~scvi.dataloaders.DataSplitter`. Not used if ``data_module`` is passed in.
+            :class:`~scvi.dataloaders.DataSplitter`. Not used if ``datamodule`` is passed in.
         validation_size
             Size of the test set. If ``None``, defaults to ``1 - train_size``. If
             ``train_size + validation_size < 1``, the remaining cells belong to a test set. Passed
-            into :class:`~scvi.dataloaders.DataSplitter`. Not used if ``data_module`` is passed in.
+            into :class:`~scvi.dataloaders.DataSplitter`. Not used if ``datamodule`` is passed in.
         shuffle_set_split
             Whether to shuffle indices before splitting. If ``False``, the val, train, and test set
             are split in the sequential order of the data according to ``validation_size`` and
             ``train_size`` percentages. Passed into :class:`~scvi.dataloaders.DataSplitter`. Not
-            used if ``data_module`` is passed in.
+            used if ``datamodule`` is passed in.
         load_sparse_tensor
             ``EXPERIMENTAL`` If ``True``, loads data with sparse CSR or CSC layout as a
             :class:`~torch.Tensor` with the same layout. Can lead to speedups in data transfers to
             GPUs, depending on the sparsity of the data. Passed into
-            :class:`~scvi.dataloaders.DataSplitter`. Not used if ``data_module`` is passed in.
+            :class:`~scvi.dataloaders.DataSplitter`. Not used if ``datamodule`` is passed in.
         batch_size
             Minibatch size to use during training. Passed into
-            :class:`~scvi.dataloaders.DataSplitter`. Not used if ``data_module`` is passed in.
+            :class:`~scvi.dataloaders.DataSplitter`. Not used if ``datamodule`` is passed in.
         early_stopping
             Perform early stopping. Additional arguments can be passed in through ``**kwargs``.
             See :class:`~scvi.train.Trainer` for further options.
         datasplitter_kwargs
             Additional keyword arguments passed into :class:`~scvi.dataloaders.DataSplitter`.
             Values in this argument can be overwritten by arguments directly passed into this
-            method, when appropriate. Not used if ``data_module`` is passed in.
+            method, when appropriate. Not used if ``datamodule`` is passed in.
         plan_kwargs
             Additional keyword arguments passed into :class:`~scvi.train.TrainingPlan`. Values in
             this argument can be overwritten by arguments directly passed into this method, when
             appropriate.
-        data_module
+        datamodule
             ``EXPERIMENTAL`` A :class:`~lightning.pytorch.core.LightningDataModule` instance to use
             for training in place of the default :class:`~scvi.dataloaders.DataSplitter`. Can only
             be passed in if the model was not initialized with :class:`~anndata.AnnData`.
         **kwargs
            Additional keyword arguments passed into :class:`~scvi.train.Trainer`.
         """
-        if data_module is not None and not self._module_init_on_train:
+        if datamodule is not None and not self._module_init_on_train:
             raise ValueError(
-                "Cannot pass in `data_module` if the model was initialized with `adata`."
+                "Cannot pass in `datamodule` if the model was initialized with `adata`."
             )
-        elif data_module is None and self._module_init_on_train:
+        elif datamodule is None and self._module_init_on_train:
             raise ValueError(
-                "If the model was not initialized with `adata`, a `data_module` must be passed in."
+                "If the model was not initialized with `adata`, a `datamodule` must be passed in."
             )
 
         if max_epochs is None:
-            if data_module is None:
+            if datamodule is None:
                 max_epochs = get_max_epochs_heuristic(self.adata.n_obs)
-            elif hasattr(data_module, "n_obs"):
-                max_epochs = get_max_epochs_heuristic(data_module.n_obs)
+            elif hasattr(datamodule, "n_obs"):
+                max_epochs = get_max_epochs_heuristic(datamodule.n_obs)
             else:
                 raise ValueError(
-                    "If `data_module` does not have `n_obs` attribute, `max_epochs` must be "
+                    "If `datamodule` does not have `n_obs` attribute, `max_epochs` must be "
                     "passed in."
                 )
 
-        if data_module is None:
+        if datamodule is None:
             datasplitter_kwargs = datasplitter_kwargs or {}
-            data_module = self._data_splitter_cls(
+            datamodule = self._data_splitter_cls(
                 self.adata_manager,
                 train_size=train_size,
                 validation_size=validation_size,
@@ -115,11 +115,11 @@ class UnsupervisedTrainingMixin:
             )
         elif self.module is None:
             self.module = self._module_cls(
-                data_module.n_vars,
-                n_batch=data_module.n_batch,
-                n_labels=getattr(data_module, "n_labels", 1),
-                n_continuous_cov=getattr(data_module, "n_continuous_cov", 0),
-                n_cats_per_cov=getattr(data_module, "n_cats_per_cov", None),
+                datamodule.n_vars,
+                n_batch=datamodule.n_batch,
+                n_labels=getattr(datamodule, "n_labels", 1),
+                n_continuous_cov=getattr(datamodule, "n_continuous_cov", 0),
+                n_cats_per_cov=getattr(datamodule, "n_cats_per_cov", None),
                 **self._module_kwargs,
             )
 
@@ -133,7 +133,7 @@ class UnsupervisedTrainingMixin:
         runner = self._train_runner_cls(
             self,
             training_plan=training_plan,
-            data_splitter=data_module,
+            data_splitter=datamodule,
             max_epochs=max_epochs,
             accelerator=accelerator,
             devices=devices,

--- a/tests/autotune/test_tune.py
+++ b/tests/autotune/test_tune.py
@@ -43,13 +43,13 @@ def test_run_autotune_scvi_no_anndata(save_path: str, n_batches: int = 3):
     SCVI.setup_anndata(adata, batch_key="batch")
     manager = SCVI._get_most_recent_anndata_manager(adata)
 
-    data_module = DataSplitter(manager)
-    data_module.n_vars = adata.n_vars
-    data_module.n_batch = n_batches
+    datamodule = DataSplitter(manager)
+    datamodule.n_vars = adata.n_vars
+    datamodule.n_batch = n_batches
 
     experiment = run_autotune(
         SCVI,
-        data_module,
+        datamodule,
         metrics=["elbo_validation"],
         mode="min",
         search_space={

--- a/tests/model/test_scvi.py
+++ b/tests/model/test_scvi.py
@@ -906,36 +906,36 @@ def test_scvi_no_anndata(n_batches: int = 3, n_latent: int = 5):
     SCVI.setup_anndata(adata, batch_key="batch")
     manager = SCVI._get_most_recent_anndata_manager(adata)
 
-    data_module = DataSplitter(manager)
-    data_module.n_vars = adata.n_vars
-    data_module.n_batch = n_batches
+    datamodule = DataSplitter(manager)
+    datamodule.n_vars = adata.n_vars
+    datamodule.n_batch = n_batches
 
     model = SCVI(n_latent=5)
     assert model._module_init_on_train
     assert model.module is None
 
-    # cannot infer default max_epochs without n_obs set in data_module
+    # cannot infer default max_epochs without n_obs set in datamodule
     with pytest.raises(ValueError):
-        model.train(data_module=data_module)
+        model.train(datamodule=datamodule)
 
-    # must pass in data_module if not initialized with adata
+    # must pass in datamodule if not initialized with adata
     with pytest.raises(ValueError):
         model.train()
 
-    model.train(max_epochs=1, data_module=data_module)
+    model.train(max_epochs=1, datamodule=datamodule)
 
     # must set n_obs for defaulting max_epochs
-    data_module.n_obs = 100_000_000  # large number for fewer default epochs
-    model.train(data_module=data_module)
+    datamodule.n_obs = 100_000_000  # large number for fewer default epochs
+    model.train(datamodule=datamodule)
 
     model = SCVI(adata, n_latent=5)
     assert not model._module_init_on_train
     assert model.module is not None
     assert hasattr(model, "adata")
 
-    # initialized with adata, cannot pass in data_module
+    # initialized with adata, cannot pass in datamodule
     with pytest.raises(ValueError):
-        model.train(data_module=data_module)
+        model.train(datamodule=datamodule)
 
 
 @pytest.mark.parametrize("embedding_dim", [5, 10])


### PR DESCRIPTION
BREAKING CHANGE: renames data_module argument to datamodule in train methods.