### PR TITLE
feat(model): save mudata var names per modality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,11 @@ to [Semantic Versioning]. Full commit history is available in the
     accessibility data {pr}`2739`.
 - The `data_module` argument in {meth}`scvi.model.base.UnsupervisedTrainingMixin.train` has been
     renamed to `datamodule` for consistency {pr}`2749`.
+- Change the default saving method of variable names for {class}`mudata.MuData` based models
+    (_e.g._ {class}`scvi.model.TOTALVI`) to a dictionary of per-mod variable names instead of a
+    concatenated array of all variable names. Users may replicate the previous behavior by
+    passing in `legacy_mudata_format=True` to {meth}`scvi.model.base.BaseModelClass.save`
+    {pr}`2769`.
 
 #### Removed
 

--- a/src/scvi/model/base/_save_load.py
+++ b/src/scvi/model/base/_save_load.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import logging
 import os
 import warnings
-from typing import Literal, Optional
+from typing import Literal
 
 import anndata
 import mudata
@@ -24,7 +26,7 @@ def _load_legacy_saved_files(
     dir_path: str,
     file_name_prefix: str,
     load_adata: bool,
-) -> tuple[dict, np.ndarray, dict, Optional[AnnData]]:
+) -> tuple[dict, np.ndarray, dict, AnnData | None]:
     model_path = os.path.join(dir_path, f"{file_name_prefix}{SAVE_KEYS.LEGACY_MODEL_FNAME}")
     var_names_path = os.path.join(
         dir_path, f"{file_name_prefix}{SAVE_KEYS.LEGACY_VAR_NAMES_FNAME}"
@@ -55,9 +57,9 @@ def _load_legacy_saved_files(
 def _load_saved_files(
     dir_path: str,
     load_adata: bool,
-    prefix: Optional[str] = None,
-    map_location: Optional[Literal["cpu", "cuda"]] = None,
-    backup_url: Optional[str] = None,
+    prefix: str | None = None,
+    map_location: Literal["cpu", "cuda"] | None = None,
+    backup_url: str | None = None,
 ) -> tuple[dict, np.ndarray, dict, AnnData]:
     """Helper to load saved files."""
     file_name_prefix = prefix or ""


### PR DESCRIPTION
previously, mudata-based models (totalvi and tangram) saved variable names in a flat array with values concatenated across all modalities - this is what happens when MuData.var_names is called directly. this is an issue for performing scarches on such a model as we cannot pad with zeros without being able to map individual variable names back to their respective modalities.

this commit sets the default to saving per-modality var names as a dictionary, with keys corresponding to modality keys and values to variable names. additionally, it adds a flag to the save method in case a user wants to use the legacy saving format.

old model saves will still be loaded successfully as the code will detect if the legacy save was used and validate var_names accordingly.

BREAKING CHANGE: changes the default saving scheme for mudata-based models. see above for details.