### PR TITLE
Add normal distribution modelling of scVI for handling log-normalized data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ to [Semantic Versioning]. Full commit history is available in the
 
 ## Version 1.2 (unreleased)
 
+### 1.2.1 (unreleased)
+
+#### Added
+
+- Add normal distribution for the outputs of generative model.
+
 ### 1.2.0 (unreleased)
 
 #### Added

--- a/src/scvi/model/_scvi.py
+++ b/src/scvi/model/_scvi.py
@@ -116,7 +116,7 @@ class SCVI(
         n_layers: int = 1,
         dropout_rate: float = 0.1,
         dispersion: Literal["gene", "gene-batch", "gene-label", "gene-cell"] = "gene",
-        gene_likelihood: Literal["zinb", "nb", "poisson"] = "zinb",
+        gene_likelihood: Literal["zinb", "nb", "poisson", 'normal'] = "zinb",
         latent_distribution: Literal["normal", "ln"] = "normal",
         **kwargs,
     ):

--- a/src/scvi/model/_scvi.py
+++ b/src/scvi/model/_scvi.py
@@ -116,7 +116,7 @@ class SCVI(
         n_layers: int = 1,
         dropout_rate: float = 0.1,
         dispersion: Literal["gene", "gene-batch", "gene-label", "gene-cell"] = "gene",
-        gene_likelihood: Literal["zinb", "nb", "poisson", 'normal'] = "zinb",
+        gene_likelihood: Literal["zinb", "nb", "poisson", "normal"] = "zinb",
         latent_distribution: Literal["normal", "ln"] = "normal",
         **kwargs,
     ):

--- a/src/scvi/module/_vae.py
+++ b/src/scvi/module/_vae.py
@@ -511,7 +511,7 @@ class VAE(EmbeddingModuleMixin, BaseMinifiedModeModuleClass):
             px = NegativeBinomial(mu=px_rate, theta=px_r, scale=px_scale)
         elif self.gene_likelihood == "poisson":
             px = Poisson(px_rate, scale=px_scale)
-        elif self.gene_likelihood == 'normal':
+        elif self.gene_likelihood == "normal":
             px = Normal(px_rate, torch.exp(px_scale))
 
         # Priors
@@ -523,8 +523,8 @@ class VAE(EmbeddingModuleMixin, BaseMinifiedModeModuleClass):
                 local_library_log_vars,
             ) = self._compute_local_library_params(batch_index)
             pl = Normal(local_library_log_means, local_library_log_vars.sqrt())
-            
-        if self.gene_likelihood == 'normal':
+
+        if self.gene_likelihood == "normal":
             pl = None
         pz = Normal(torch.zeros_like(z), torch.ones_like(z))
 


### PR DESCRIPTION
Hi, I have implemented a normal-distribution-based scVI to handle data after log-normalization. Would you please review it? I have tested the clustering performance of it and it looks good. Thanks.