### PR TITLE
build: upperbound on torchmetrics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "scikit-learn>=0.21.2",
     "sparse>=0.14.0",
     "tensorboard>=2.0",
-    "torchmetrics>=0.11.0,<1.4.0",
+    "torchmetrics>=0.11.0,<1.4.0",  # upperbound see 2783
     "xarray>=2023.2.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "scikit-learn>=0.21.2",
     "sparse>=0.14.0",
     "tensorboard>=2.0",
-    "torchmetrics>=0.11.0",
+    "torchmetrics>=0.11.0,<1.4.0",
     "xarray>=2023.2.0",
 ]
 


### PR DESCRIPTION
newest torchmetrics release causes an io error on tests collection as seen here: https://github.com/scverse/scvi-tools/actions/runs/8974265349/job/24646281639. has something to do with it's next pretty-errors dependency and how it interacts with pytest.

temporary upperbound while I figure out what's going on.