### PR TITLE
ci: add pytest-pretty plugin, register custom marks

### DIFF
--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -51,6 +51,7 @@ jobs:
           MPLBACKEND: agg
           PLATFORM: ${{ matrix.os }}
           DISPLAY: :42
+          COLUMNS: 120
         run: |
           coverage run -m pytest -v --color=yes
           coverage report

--- a/.github/workflows/test_linux_cuda.yml
+++ b/.github/workflows/test_linux_cuda.yml
@@ -57,6 +57,7 @@ jobs:
           MPLBACKEND: agg
           PLATFORM: ${{ matrix.os }}
           DISPLAY: :42
+          COLUMNS: 120
         run: |
           coverage run -m pytest -v --color=yes --accelerator cuda --devices auto
           coverage report

--- a/.github/workflows/test_linux_private.yml
+++ b/.github/workflows/test_linux_private.yml
@@ -72,6 +72,7 @@ jobs:
           PLATFORM: ${{ matrix.os }}
           DISPLAY: :42
           HF_API_TOKEN: ${{ secrets.HF_API_TOKEN }}
+          COLUMNS: 120
         run: |
           coverage run -m pytest -v --color=yes --private
           coverage report

--- a/.github/workflows/test_linux_resolution.yml
+++ b/.github/workflows/test_linux_resolution.yml
@@ -66,6 +66,7 @@ jobs:
           MPLBACKEND: agg
           PLATFORM: ${{ matrix.os }}
           DISPLAY: :42
+          COLUMNS: 120
         run: |
           coverage run -m pytest -v --color=yes
           coverage report

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -61,6 +61,7 @@ jobs:
           MPLBACKEND: agg
           PLATFORM: ${{ matrix.os }}
           DISPLAY: :42
+          COLUMNS: 120
         run: |
           coverage run -m pytest -v --color=yes
           coverage report

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -61,6 +61,7 @@ jobs:
           MPLBACKEND: agg
           PLATFORM: ${{ matrix.os }}
           DISPLAY: :42
+          COLUMNS: 120
         run: |
           coverage run -m pytest -v --color=yes
           coverage report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 build-backend = "hatchling.build"
 requires = ["hatchling"]
 
-
 [project]
 name = "scvi-tools"
 version = "1.1.3"
@@ -49,7 +48,7 @@ dependencies = [
 
 
 [project.optional-dependencies]
-tests = ["pytest", "coverage", "scvi-tools[optional]"]
+tests = ["pytest", "pytest-pretty", "coverage", "scvi-tools[optional]"]
 editing = ["jupyter", "pre-commit"]
 dev = ["scvi-tools[editing,tests]"]
 
@@ -119,6 +118,11 @@ omit = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 xfail_strict = true
+markers = [
+    "internet: mark tests that requires internet access",
+    "optional: mark optional tests",
+    "private: mark tests that are private",
+]
 
 [tool.ruff]
 src = ["src"]
@@ -210,8 +214,6 @@ skip-magic-trailing-comma = false
 
 # Like Black, automatically detect the appropriate line ending.
 line-ending = "auto"
-
-
 
 [tool.jupytext]
 formats = "ipynb,md"


### PR DESCRIPTION
as suggested on the pytest-pretty documentation, adds an env variable COLUMNS set to 120 that displays wider outputs for pytest, making it easier to visualize error messages.

also explicitly registers our custom pytest marks on the pyproject so that there are no warnings on collection.