### PR TITLE
Fix for get_normalized_expression

### DIFF
--- a/src/scvi/model/base/_rnamixin.py
+++ b/src/scvi/model/base/_rnamixin.py
@@ -236,7 +236,7 @@ class RNASeqMixin:
                 )
             return_numpy = True
         if library_size == "latent":
-            generative_output_key = "mu"
+            generative_output_key = "mu" if self.module.gene_likelihood == "nb" else "rate"
             scaling = 1
         else:
             generative_output_key = "scale"


### PR DESCRIPTION
There is currently a problem when using the scvi model with `gene_likelihood='poisson'` and trying to get the normalized expression:

```
vae = scvi.model.SCVI(
    adata,
    gene_likelihood='poisson'
)
vae.get_normalized_expression(
    adata=adata,
    library_size="latent",
)
```
It throws the error:
```
RNASeqMixin.get_normalized_expression(self, adata, indices, transform_batch, gene_list, library_size, n_samples, n_samples_overall, weights, batch_size, return_mean, return_numpy, **importance_weighting_kwargs)
    257 inference_kwargs = {"n_samples": n_samples}
    258 inference_outputs, generative_outputs = self.module.forward(
    259     tensors=tensors,
    260     inference_kwargs=inference_kwargs,
    261     generative_kwargs=generative_kwargs,
    262     compute_loss=False,
    263 )
--> 264 exp_ = getattr(generative_outputs["px"], generative_output_key)
    265 exp_ = exp_[..., gene_mask]
    266 exp_ *= scaling

 
AttributeError: 'Poisson' object has no attribute 'mu'
```

In the current implementation the `get_normalized_expression` fails for all likelihood that are not `zinb/nb` because `generative_outputs["px"]` does not have the attribute `mu`.

I tried to make a fix for the Poisson likelihood but I am unsure what exactly you would like to use for the normal distribution.