### PR TITLE
feat(autotune): add support for ray 2.24

### DIFF
--- a/src/scvi/autotune/_experiment.py
+++ b/src/scvi/autotune/_experiment.py
@@ -474,7 +474,6 @@ class AutotuneExperiment:
         run_config = RunConfig(
             name=self.name,
             storage_path=self.logging_dir,
-            local_dir=self.logging_dir,
             log_to_file=True,
             verbose=1,
         )


### PR DESCRIPTION
ray 2.24 apparently removed the local_dir argument from RunConfig, which should now be equivalent to storage_path (we were specifying both arguments as settings.logging_dir before). this commit just removes the local_dir argument on our end from autotune.Experiment.

see https://github.com/scverse/scvi-tools/actions/runs/9435814911/job/25989750995 for an example failure.