### PR TITLE
feat: add support for scipy 1.14.0

### DIFF
--- a/src/scvi/data/_preprocessing.py
+++ b/src/scvi/data/_preprocessing.py
@@ -262,7 +262,7 @@ def organize_cite_seq_10x(adata: anndata.AnnData, copy: bool = False) -> Optiona
     if copy:
         adata = adata.copy()
 
-    pro_array = adata[:, adata.var["feature_types"] == "Antibody Capture"].X.copy().A
+    pro_array = adata[:, adata.var["feature_types"] == "Antibody Capture"].X.copy().toarray()
     pro_names = np.array(adata.var_names[adata.var["feature_types"] == "Antibody Capture"])
 
     genes = (adata.var["feature_types"] != "Antibody Capture").values

--- a/src/scvi/external/scar/_model.py
+++ b/src/scvi/external/scar/_model.py
@@ -231,7 +231,7 @@ class SCAR(RNASeqMixin, VAEMixin, UnsupervisedTrainingMixin, BaseModelClass):
             )
             for b in range(n_batch):
                 try:
-                    count_batch = raw_adata[batch_idx == b].X.astype(int).A
+                    count_batch = raw_adata[batch_idx == b].X.astype(int).toarray()
                 except MemoryError as err:
                     raise MemoryError("use more batches by setting a higher n_batch") from err
                 log_prob_batch = Multinomial(


### PR DESCRIPTION
scipy 1.14.0 has an expired deprecation for the .A attribute of sparse arrays and matrices, which can be replaced with a call to array().