### PR TITLE
build: specify all direct dependencies in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,19 +31,27 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 dependencies = [
+    "anndata",
     "docrep>=0.3.2",
     "flax",
+    "jax",
+    "jaxlib",
     "lightning>=2.0",
     "ml-collections>=0.1.1",
     "mudata>=0.1.2",
     "numpy<2.0",
     "numpyro>=0.12.1",
+    "pandas",
     "pyro-ppl>=1.6.0",
+    "optax",
     "rich>=12.0.0",
     "scikit-learn>=0.21.2",
+    "scipy",
     "sparse>=0.14.0",
     "tensorboard>=2.0",
+    "torch",
     "torchmetrics>=0.11.0",
+    "tqdm",
     "xarray>=2023.2.0",
 ]
 


### PR DESCRIPTION
reverts #2669.

realized it's not best practice to exclude direct dependencies in the pyproject, even though they're included as indirect ones.