### PR TITLE
fix(train) disable adversarial classifier for a single batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,11 @@ to [Semantic Versioning]. Full commit history is available in the
     concatenated array of all variable names. Users may replicate the previous behavior by
     passing in `legacy_mudata_format=True` to {meth}`scvi.model.base.BaseModelClass.save`
     {pr}`2769`.
-- Changed internal activation function in {class}``` scvi.nn.DecoderTOTALVI`` to Softplus to increase   numerical stability. This is the new default for new models. Previously trained models will be loaded   with exponential activation function {pr} ```2913\`.
+- Changed internal activation function in {class}`scvi.nn.DecoderTOTALVI` to Softplus to
+    increase numerical stability. This is the new default for new models. Previously trained models
+    will be loaded with exponential activation function {pr} `2913`.
+- Disable adversarial classifier if training with a single batch.
+    Previously this raised a None error {pr} `2914`.
 
 #### Removed
 

--- a/src/scvi/train/_trainingplans.py
+++ b/src/scvi/train/_trainingplans.py
@@ -1,3 +1,4 @@
+import warnings
 from collections import OrderedDict
 from collections.abc import Iterable
 from functools import partial
@@ -16,7 +17,7 @@ from lightning.pytorch.strategies.ddp import DDPStrategy
 from pyro.nn import PyroModule
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 
-from scvi import REGISTRY_KEYS
+from scvi import REGISTRY_KEYS, settings
 from scvi.module import Classifier
 from scvi.module.base import (
     BaseModuleClass,
@@ -514,14 +515,22 @@ class AdversarialTrainingPlan(TrainingPlan):
             **loss_kwargs,
         )
         if adversarial_classifier is True:
-            self.n_output_classifier = self.module.n_batch
-            self.adversarial_classifier = Classifier(
-                n_input=self.module.n_latent,
-                n_hidden=32,
-                n_labels=self.n_output_classifier,
-                n_layers=2,
-                logits=True,
-            )
+            if self.module.n_batch==1:
+                warnings.warn(
+                    "Disabling adversarial classifier.",
+                    UserWarning,
+                    stacklevel=settings.warnings_stacklevel,
+                )
+                self.adversarial_classifier = False
+            else:
+                self.n_output_classifier = self.module.n_batch
+                self.adversarial_classifier = Classifier(
+                    n_input=self.module.n_latent,
+                    n_hidden=32,
+                    n_labels=self.n_output_classifier,
+                    n_layers=2,
+                    logits=True,
+                )
         else:
             self.adversarial_classifier = adversarial_classifier
         self.scale_adversarial_loss = scale_adversarial_loss

--- a/tests/model/test_multivi.py
+++ b/tests/model/test_multivi.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from scvi.data import synthetic_iid
 from scvi.model import MULTIVI
@@ -67,3 +68,11 @@ def test_multivi():
     )
     assert vae.n_proteins == data.obsm["protein_expression"].shape[1]
     vae.train(3)
+
+
+def test_multivi_single_batch():
+    data = synthetic_iid(n_batches=1)
+    MULTIVI.setup_anndata(data, batch_key="batch")
+    vae = MULTIVI(data, n_genes=50, n_regions=50)
+    with pytest.warns(UserWarning):
+        vae.train(3)


### PR DESCRIPTION
Adversarial classifier was beforehand also activated on single batches which leads to None errors. Raises a warning now and disables the adversarial classifier.