### PR TITLE
Error in scanvi_ref multiclass accuracy calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,8 @@ to [Semantic Versioning]. Full commit history is available in the
 
 #### Fixed
 
+- Fix multiclass accuracy bug which happend during SemiSupervisedDataSplitter usage of scvi->
+    scanvi transfer learning. there was a batch with 1 sample per one of the classes {pr}`2938`.
 - Disable adversarial classifier if training with a single batch.
     Previously this raised a None error {pr}`2914`.
 - {meth}`~scvi.model.SCVI.get_normalized_expression` fixed for Poisson distribution and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,6 @@ to [Semantic Versioning]. Full commit history is available in the
 #### Fixed
 
 - Fix logging of accuracy for cases with 1 sample per class in scANVI {pr}`2938`.
-      the DataSplitter {pr}`2938`.
 - Disable adversarial classifier if training with a single batch.
     Previously this raised a None error {pr}`2914`.
 - {meth}`~scvi.model.SCVI.get_normalized_expression` fixed for Poisson distribution and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@ to [Semantic Versioning]. Full commit history is available in the
 
 #### Fixed
 
-- Fix logging of accuracy for cases with 1 sample per class in scANVI as this could happend with
+- Fix logging of accuracy for cases with 1 sample per class in scANVI {pr}`2938`.
       the DataSplitter {pr}`2938`.
 - Disable adversarial classifier if training with a single batch.
     Previously this raised a None error {pr}`2914`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,8 +97,8 @@ to [Semantic Versioning]. Full commit history is available in the
 
 #### Fixed
 
-- Fix multiclass accuracy bug which happend during SemiSupervisedDataSplitter usage of scvi->
-    scanvi transfer learning. there was a batch with 1 sample per one of the classes {pr}`2938`.
+- Fix logging of accuracy for cases with 1 sample per class in scANVI as this could happend with
+      the DataSplitter {pr}`2938`.
 - Disable adversarial classifier if training with a single batch.
     Previously this raised a None error {pr}`2914`.
 - {meth}`~scvi.model.SCVI.get_normalized_expression` fixed for Poisson distribution and

--- a/src/scvi/train/_trainingplans.py
+++ b/src/scvi/train/_trainingplans.py
@@ -741,7 +741,7 @@ class SemiSupervisedTrainingPlan(TrainingPlan):
             return
 
         classification_loss = loss_output.classification_loss
-        true_labels = loss_output.true_labels.squeeze()
+        true_labels = loss_output.true_labels.squeeze(-1)  # the -1 is added for case of dim==1
         logits = loss_output.logits
         predicted_labels = torch.argmax(logits, dim=-1)
 

--- a/src/scvi/train/_trainingplans.py
+++ b/src/scvi/train/_trainingplans.py
@@ -741,7 +741,7 @@ class SemiSupervisedTrainingPlan(TrainingPlan):
             return
 
         classification_loss = loss_output.classification_loss
-        true_labels = loss_output.true_labels.squeeze(-1)  # the -1 is added for case of dim==1
+        true_labels = loss_output.true_labels.squeeze(-1)
         logits = loss_output.logits
         predicted_labels = torch.argmax(logits, dim=-1)
 


### PR DESCRIPTION
added -1 to the squeeze in order to deal with the case of dim==1 in a multiclass batch where there is 1 sample for the usage of scvi-> scanvi transfer learning

close https://github.com/scverse/scvi-tools/issues/2934

