### PR TITLE
Fix solo bug with large batches

### DIFF
--- a/src/scvi/external/solo/_model.py
+++ b/src/scvi/external/solo/_model.py
@@ -259,16 +259,15 @@ class SOLO(BaseModelClass):
             Seed for reproducibility
         """
         adata = adata_manager.adata
-        n_obs = adata.n_obs if indices is None else len(indices)
+        allowed_indices = np.arange(adata.n_obs) if indices is None else indices
+        n_obs = len(allowed_indices)
         num_doublets = doublet_ratio * n_obs
 
         # counts can be in many locations, this uses where it was registered in setup
         x = adata_manager.get_from_registry(REGISTRY_KEYS.X_KEY)
-        if indices is not None:
-            x = x[indices]
 
         random_state = np.random.RandomState(seed=seed)
-        parent_inds = random_state.choice(n_obs, size=(num_doublets, 2))
+        parent_inds = random_state.choice(allowed_indices, size=(num_doublets, 2))
         doublets = x[parent_inds[:, 0]] + x[parent_inds[:, 1]]
 
         doublets_ad = AnnData(doublets)


### PR DESCRIPTION
Hello everyone,
this is my first time contributing here, so let me know if I got something wrong with the way I approached this.

I have a very large batch in an AnnData object. This batch has 803283 cells (and there are 10811 genes in the AnnData).

After training an scVI model, I ran the following:
`solo = scvi.external.SOLO.from_scvi_model(scvi_model, restrict_to_batch="<batch>")`
and got this error:
```
ValueError                                Traceback (most recent call last)
Cell In[109], line 1
----> 1 doublets = x[parent_inds[:, 0]] + x[parent_inds[:, 1]]

File ~/miniconda3/envs/scvi/lib/python3.12/site-packages/scipy/sparse/_csr.py:24, in _csr_base.__getitem__(self, key)
     22 def __getitem__(self, key):
     23     if self.ndim == 2:
---> 24         return super().__getitem__(key)
     26     if isinstance(key, tuple) and len(key) == 1:
     27         key = key[0]

File ~/miniconda3/envs/scvi/lib/python3.12/site-packages/scipy/sparse/_index.py:83, in IndexMixin.__getitem__(self, key)
     81         return self._get_arrayXint(row, col)
     82     elif isinstance(col, slice):
---> 83         return self._get_arrayXslice(row, col)
     84 else:  # row.ndim == 2
     85     if isinstance(col, INT_TYPES):

File ~/miniconda3/envs/scvi/lib/python3.12/site-packages/scipy/sparse/_csr.py:277, in _csr_base._get_arrayXslice(self, row, col)
    275     col = np.arange(*col.indices(self.shape[1]))
    276     return self._get_arrayXarray(row, col)
--> 277 return self._major_index_fancy(row)._get_submatrix(minor=col)

File ~/miniconda3/envs/scvi/lib/python3.12/site-packages/scipy/sparse/_compressed.py:765, in _cs_matrix._major_index_fancy(self, idx)
    762 np.cumsum(row_nnz, out=res_indptr[1:])
    764 nnz = res_indptr[-1]
--> 765 res_indices = np.empty(nnz, dtype=idx_dtype)
    766 res_data = np.empty(nnz, dtype=self.dtype)
    767 csr_row_index(
    768     M,
    769     indices,
   (...)
    774     res_data
    775 )

ValueError: negative dimensions are not allowed
```

So I started digging into this and found the following:
1. When [this line](https://github.com/scverse/scvi-tools/blob/89d772a9f0d198dd144b59801acbb3c67d163645/src/scvi/external/solo/_model.py#L268) is executed AND either `x[parent_inds[:, 0]]` or `x[parent_inds[:, 1]]` create a sparse matrix that has more than int32MAX stored values, the above error occurs
2. When creating slices directly from `AnnData.X`, this restriction somehow appears to vanish, which I have not found a technical reason for - so I concluded that slicing once (`x = x[batch_indices]`) somehow introduces this int32MAX size limit, which comes into effect when performing `x[parent_inds[:, 0]]`. 
3. My solution changes the code, so that only a single slicing operation is performed. I think the code changes themselves do not need too much explanation. 

If you have any idea why this happens, or if you have a better solution, please enlighten me :D