### PR TITLE
fix(train): in case of last batch <=2, move to validation if possible

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
           )$
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.7.0
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ default_stages:
 minimum_pre_commit_version: 2.16.0
 repos:
   - repo: https://github.com/asottile/blacken-docs
-    rev: 1.19.0
+    rev: 1.19.1
     hooks:
       - id: blacken-docs
 
@@ -41,7 +41,7 @@ repos:
           )$
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.0
+    rev: v0.7.1
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ to [Semantic Versioning]. Full commit history is available in the
 #### Added
 
 - Added adaptive handling for last training minibatch of 1-2 cells in case of
-    `datasplitter_kwargs={"drop_last": False}` and `train_size = None` by moving them into validation set, if available.
+    `datasplitter_kwargs={"drop_last": False}` and `train_size = None` by moving them into
+    validation set, if available.
     {pr}`3036`.
 
 #### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,8 @@ to [Semantic Versioning]. Full commit history is available in the
 #### Added
 
 - Added adaptive handling for last training minibatch of 1-2 cells in case of
-    `datasplitter_kwargs={"drop_last": False}` by moving them into validation set, if available.
+    `datasplitter_kwargs={"drop_last": False}` and `train_size = None` by moving them into validation set, if available.
     {pr}`3036`.
--
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ to [Semantic Versioning]. Full commit history is available in the
 
 #### Added
 
+- Added adaptive handling for last training minibatch of 1-2 cells in case of `datasplitter_kwargs={"drop_last": False}` by moving them into validation set, if available. {pr}`3036`.
+-
+
 #### Fixed
 
 - Breaking Change: Fix `get_outlier_cell_sample_pairs` function in {class}`scvi.external.MRVI`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ to [Semantic Versioning]. Full commit history is available in the
 
 #### Added
 
-- Added adaptive handling for last training minibatch of 1-2 cells in case of `datasplitter_kwargs={"drop_last": False}` by moving them into validation set, if available. {pr}`3036`.
+- Added adaptive handling for last training minibatch of 1-2 cells in case of
+    `datasplitter_kwargs={"drop_last": False}` by moving them into validation set, if available.
+    {pr}`3036`.
 -
 
 #### Fixed

--- a/src/scvi/dataloaders/_data_splitting.py
+++ b/src/scvi/dataloaders/_data_splitting.py
@@ -166,9 +166,7 @@ def validate_data_split_with_external_indexing(
 
     if batch_size is not None:
         num_of_cells = n_train % batch_size
-        if (num_of_cells < 3 and num_of_cells > 0) and not (
-            num_of_cells == 1 and drop_last is True
-        ):
+        if (num_of_cells < 3 and num_of_cells > 0) and drop_last is False:
             warnings.warn(
                 f"Last batch will have a small size of {num_of_cells} "
                 f"samples. Consider changing settings.batch_size or batch_size in model.train "

--- a/src/scvi/dataloaders/_data_splitting.py
+++ b/src/scvi/dataloaders/_data_splitting.py
@@ -69,15 +69,12 @@ def validate_data_split(
 
     if batch_size is not None:
         num_of_cells = n_train % batch_size
-        if (num_of_cells < 3 and num_of_cells > 0) and not (
-            num_of_cells == 1 and drop_last is True
-        ):
+        if (num_of_cells < 3 and num_of_cells > 0) and drop_last is False:
             if not train_size_is_none:
                 warnings.warn(
                     f"Last batch will have a small size of {num_of_cells} "
                     f"samples. Consider changing settings.batch_size or batch_size in model.train "
-                    f"from currently {batch_size} to avoid errors during model training, "
-                    f"or use drop_last parameter if there is 1 cell left",
+                    f"from currently {batch_size} to avoid errors during model training.",
                     UserWarning,
                     stacklevel=settings.warnings_stacklevel,
                 )
@@ -86,7 +83,8 @@ def validate_data_split(
                 if n_val > 0:
                     n_val += num_of_cells
                     warnings.warn(
-                        f"{num_of_cells} cells moved from training set to validation set",
+                        f"{num_of_cells} cells moved from training set to validation set."
+                        f" if you want to avoid it please use train_size parameter during train.",
                         UserWarning,
                         stacklevel=settings.warnings_stacklevel,
                     )
@@ -175,8 +173,7 @@ def validate_data_split_with_external_indexing(
                 f"Last batch will have a small size of {num_of_cells} "
                 f"samples. Consider changing settings.batch_size or batch_size in model.train "
                 f"from currently {settings.batch_size} to avoid errors during model training "
-                f"or change the given external indices accordingly or use drop_last parameter if "
-                f"there is 1 cell left",
+                f"or change the given external indices accordingly.",
                 UserWarning,
                 stacklevel=settings.warnings_stacklevel,
             )

--- a/src/scvi/dataloaders/_data_splitting.py
+++ b/src/scvi/dataloaders/_data_splitting.py
@@ -163,8 +163,8 @@ def validate_data_split_with_external_indexing(
         if n_train % batch_size < 3 and n_train % batch_size > 0:
             warnings.warn(
                 f"Last batch will have a small size of {n_train % batch_size} "
-                f"samples. Consider changing settings.batch_size or batch_size in model.train from "
-                f"currently {settings.batch_size} to avoid errors during model training "
+                f"samples. Consider changing settings.batch_size or batch_size in model.train "
+                f"from currently {settings.batch_size} to avoid errors during model training "
                 f"or change the given external indices accordingly",
                 UserWarning,
                 stacklevel=settings.warnings_stacklevel,

--- a/src/scvi/dataloaders/_data_splitting.py
+++ b/src/scvi/dataloaders/_data_splitting.py
@@ -243,7 +243,7 @@ class DataSplitter(pl.LightningDataModule):
             self.n_train, self.n_val = validate_data_split_with_external_indexing(
                 self.adata_manager.adata.n_obs,
                 self.external_indexing,
-                self.data_loader_kwargs["batch_size"],
+                self.data_loader_kwargs.pop("batch_size", settings.batch_size),
                 self.drop_last,
             )
         else:
@@ -251,7 +251,7 @@ class DataSplitter(pl.LightningDataModule):
                 self.adata_manager.adata.n_obs,
                 self.train_size,
                 self.validation_size,
-                self.data_loader_kwargs["batch_size"],
+                self.data_loader_kwargs.pop("batch_size", settings.batch_size),
                 self.drop_last,
             )
 
@@ -423,7 +423,7 @@ class SemiSupervisedDataSplitter(pl.LightningDataModule):
                 n_labeled_train, n_labeled_val = validate_data_split_with_external_indexing(
                     n_labeled_idx,
                     [labeled_idx_train, labeled_idx_val, labeled_idx_test],
-                    self.data_loader_kwargs["batch_size"],
+                    self.data_loader_kwargs.pop("batch_size", settings.batch_size),
                     self.drop_last,
                 )
             else:
@@ -431,7 +431,7 @@ class SemiSupervisedDataSplitter(pl.LightningDataModule):
                     n_labeled_idx,
                     self.train_size,
                     self.validation_size,
-                    self.data_loader_kwargs["batch_size"],
+                    self.data_loader_kwargs.pop("batch_size", settings.batch_size),
                     self.drop_last,
                 )
 
@@ -463,7 +463,7 @@ class SemiSupervisedDataSplitter(pl.LightningDataModule):
                 n_unlabeled_train, n_unlabeled_val = validate_data_split_with_external_indexing(
                     n_unlabeled_idx,
                     [unlabeled_idx_train, unlabeled_idx_val, unlabeled_idx_test],
-                    self.data_loader_kwargs["batch_size"],
+                    self.data_loader_kwargs.pop("batch_size", settings.batch_size),
                     self.drop_last,
                 )
             else:
@@ -471,7 +471,7 @@ class SemiSupervisedDataSplitter(pl.LightningDataModule):
                     n_unlabeled_idx,
                     self.train_size,
                     self.validation_size,
-                    self.data_loader_kwargs["batch_size"],
+                    self.data_loader_kwargs.pop("batch_size", settings.batch_size),
                     self.drop_last,
                 )
 

--- a/src/scvi/dataloaders/_data_splitting.py
+++ b/src/scvi/dataloaders/_data_splitting.py
@@ -64,10 +64,10 @@ def validate_data_split(n_samples: int, train_size: float, validation_size: floa
         )
 
     if n_train % settings.batch_size == 1 and n_val > 2:
-        #a final batch of size == 1
+        # a final batch of size == 1
         warnings.warn(
-            f"Last batch will have exactly size of 1 sample and will cause error during "
-            f"training. 1 sample was moved from validation to training in order for it to run.",
+            "Last batch will have exactly size of 1 sample and will cause error during "
+            "training. 1 sample was moved from validation to training in order for it to run.",
             UserWarning,
             stacklevel=settings.warnings_stacklevel,
         )

--- a/src/scvi/dataloaders/_data_splitting.py
+++ b/src/scvi/dataloaders/_data_splitting.py
@@ -40,8 +40,8 @@ def validate_data_split(n_samples: int, train_size: float, validation_size: floa
 
     if n_train % settings.batch_size < 3 and n_train % settings.batch_size > 0:
         warnings.warn(
-            f"Last batch will have a small size of {n_train % settings.batch_size}"
-            f"samples. Consider changing settings.batch_size or batch_size in model.train"
+            f"Last batch will have a small size of {n_train % settings.batch_size} "
+            f"samples. Consider changing settings.batch_size or batch_size in model.train "
             f"currently {settings.batch_size} to avoid errors during model training.",
             UserWarning,
             stacklevel=settings.warnings_stacklevel,
@@ -59,9 +59,20 @@ def validate_data_split(n_samples: int, train_size: float, validation_size: floa
     if n_train == 0:
         raise ValueError(
             f"With n_samples={n_samples}, train_size={train_size} and "
-            f"validation_size={validation_size}, the resulting train set will be empty. Adjust"
+            f"validation_size={validation_size}, the resulting train set will be empty. Adjust "
             "any of the aforementioned parameters."
         )
+
+    if n_train % settings.batch_size == 1 and n_val > 2:
+        #a final batch of size == 1
+        warnings.warn(
+            f"Last batch will have exactly size of 1 sample and will cause error during "
+            f"training. 1 sample was moved from validation to training in order for it to run.",
+            UserWarning,
+            stacklevel=settings.warnings_stacklevel,
+        )
+        n_train += 1
+        n_val -= 1
 
     return n_train, n_val
 
@@ -131,6 +142,15 @@ def validate_data_split_with_external_indexing(
 
     n_train = len(external_indexing[0])
     n_val = len(external_indexing[1])
+
+    if n_train % settings.batch_size < 3 and n_train % settings.batch_size > 0:
+        warnings.warn(
+            f"Last batch will have a small size of {n_train % settings.batch_size} "
+            f"samples. Consider changing settings.batch_size or batch_size in model.train "
+            f"currently {settings.batch_size} to avoid errors during model training.",
+            UserWarning,
+            stacklevel=settings.warnings_stacklevel,
+        )
 
     return n_train, n_val
 

--- a/src/scvi/dataloaders/_data_splitting.py
+++ b/src/scvi/dataloaders/_data_splitting.py
@@ -64,8 +64,8 @@ def validate_data_split(n_samples: int, train_size: float, validation_size: floa
             num_of_cells = n_train % batch_size
             warnings.warn(
                 f"Last batch will have a small size of {num_of_cells} "
-                f"samples. Consider changing settings.batch_size or batch_size in model.train from"
-                f" currently {batch_size} to avoid errors during model training. Those cells "
+                f"samples. Consider changing settings.batch_size or batch_size in model.train "
+                f"from currently {batch_size} to avoid errors during model training. Those cells "
                 f"will be removed from the training set automatically",
                 UserWarning,
                 stacklevel=settings.warnings_stacklevel,

--- a/src/scvi/dataloaders/_data_splitting.py
+++ b/src/scvi/dataloaders/_data_splitting.py
@@ -72,15 +72,16 @@ def validate_data_split(
         if (num_of_cells < 3 and num_of_cells > 0) and not (
             num_of_cells == 1 and drop_last is True
         ):
-            warnings.warn(
-                f"Last batch will have a small size of {num_of_cells} "
-                f"samples. Consider changing settings.batch_size or batch_size in model.train "
-                f"from currently {batch_size} to avoid errors during model training, "
-                f"or use drop_last parameter if there is 1 cell left",
-                UserWarning,
-                stacklevel=settings.warnings_stacklevel,
-            )
-            if train_size_is_none:
+            if not train_size_is_none:
+                warnings.warn(
+                    f"Last batch will have a small size of {num_of_cells} "
+                    f"samples. Consider changing settings.batch_size or batch_size in model.train "
+                    f"from currently {batch_size} to avoid errors during model training, "
+                    f"or use drop_last parameter if there is 1 cell left",
+                    UserWarning,
+                    stacklevel=settings.warnings_stacklevel,
+                )
+            else:
                 n_train -= num_of_cells
                 if n_val > 0:
                     n_val += num_of_cells
@@ -402,7 +403,7 @@ class SemiSupervisedDataSplitter(pl.LightningDataModule):
         super().__init__()
         self.adata_manager = adata_manager
         self.train_size_is_none = not bool(train_size)
-        self.train_size = 0.9 if train_size is None else float(train_size)
+        self.train_size = 0.9 if self.train_size_is_none else float(train_size)
         self.validation_size = validation_size
         self.shuffle_set_split = shuffle_set_split
         self.drop_last = kwargs.pop("drop_last", False)

--- a/src/scvi/dataloaders/_data_splitting.py
+++ b/src/scvi/dataloaders/_data_splitting.py
@@ -69,8 +69,9 @@ def validate_data_split(
 
     if batch_size is not None:
         num_of_cells = n_train % batch_size
-        if ((num_of_cells < 3 and num_of_cells > 0) and
-            not (num_of_cells == 1 and drop_last is True)):
+        if (num_of_cells < 3 and num_of_cells > 0) and not (
+            num_of_cells == 1 and drop_last is True
+        ):
             warnings.warn(
                 f"Last batch will have a small size of {num_of_cells} "
                 f"samples. Consider changing settings.batch_size or batch_size in model.train "
@@ -166,8 +167,9 @@ def validate_data_split_with_external_indexing(
 
     if batch_size is not None:
         num_of_cells = n_train % batch_size
-        if ((num_of_cells < 3 and num_of_cells > 0)
-            and not (num_of_cells == 1 and drop_last is True)):
+        if (num_of_cells < 3 and num_of_cells > 0) and not (
+            num_of_cells == 1 and drop_last is True
+        ):
             warnings.warn(
                 f"Last batch will have a small size of {num_of_cells} "
                 f"samples. Consider changing settings.batch_size or batch_size in model.train "
@@ -263,7 +265,7 @@ class DataSplitter(pl.LightningDataModule):
                 self.validation_size,
                 self.data_loader_kwargs.pop("batch_size", settings.batch_size),
                 self.drop_last,
-                self.train_size_is_none
+                self.train_size_is_none,
             )
 
     def setup(self, stage: str | None = None):
@@ -446,7 +448,7 @@ class SemiSupervisedDataSplitter(pl.LightningDataModule):
                     self.validation_size,
                     self.data_loader_kwargs.pop("batch_size", settings.batch_size),
                     self.drop_last,
-                    self.train_size_is_none
+                    self.train_size_is_none,
                 )
 
                 labeled_permutation = self._labeled_indices
@@ -487,7 +489,7 @@ class SemiSupervisedDataSplitter(pl.LightningDataModule):
                     self.validation_size,
                     self.data_loader_kwargs.pop("batch_size", settings.batch_size),
                     self.drop_last,
-                    self.train_size_is_none
+                    self.train_size_is_none,
                 )
 
                 unlabeled_permutation = self._unlabeled_indices

--- a/src/scvi/dataloaders/_data_splitting.py
+++ b/src/scvi/dataloaders/_data_splitting.py
@@ -21,7 +21,8 @@ from scvi.model._utils import parse_device_args
 from scvi.utils._docstrings import devices_dsp
 
 
-def validate_data_split(n_samples: int, train_size: float, validation_size: float | None = None):
+def validate_data_split(n_samples: int, train_size: float, validation_size: float | None = None,
+                        batch_size: int | None = None, drop_last: bool | int = False):
     """Check data splitting parameters and return n_train and n_val.
 
     Parameters
@@ -32,20 +33,15 @@ def validate_data_split(n_samples: int, train_size: float, validation_size: floa
         Size of train set. Need to be: 0 < train_size <= 1.
     validation_size
         Size of validation set. Need to be 0 <= validation_size < 1
+    batch_size
+        batch size of each iteration. If `None`, do not minibatch
+    drop_last
+        drops last non-full batch
     """
     if train_size > 1.0 or train_size <= 0.0:
         raise ValueError("Invalid train_size. Must be: 0 < train_size <= 1")
 
     n_train = ceil(train_size * n_samples)
-
-    if n_train % settings.batch_size < 3 and n_train % settings.batch_size > 0:
-        warnings.warn(
-            f"Last batch will have a small size of {n_train % settings.batch_size} "
-            f"samples. Consider changing settings.batch_size or batch_size in model.train "
-            f"currently {settings.batch_size} to avoid errors during model training.",
-            UserWarning,
-            stacklevel=settings.warnings_stacklevel,
-        )
 
     if validation_size is None:
         n_val = n_samples - n_train
@@ -63,23 +59,33 @@ def validate_data_split(n_samples: int, train_size: float, validation_size: floa
             "any of the aforementioned parameters."
         )
 
-    if n_train % settings.batch_size == 1 and n_val > 2:
-        # a final batch of size == 1
-        warnings.warn(
-            "Last batch will have exactly size of 1 sample and will cause error during "
-            "training. 1 sample was moved from validation to training in order for it to run.",
-            UserWarning,
-            stacklevel=settings.warnings_stacklevel,
-        )
-        n_train += 1
-        n_val -= 1
+    if batch_size is not None and not drop_last:
+        if n_train % batch_size < 3 and n_train % batch_size > 0:
+            num_of_cells = n_train % batch_size
+            warnings.warn(
+                f"Last batch will have a small size of {num_of_cells} "
+                f"samples. Consider changing settings.batch_size or batch_size in model.train from"
+                f" currently {batch_size} to avoid errors during model training. Those cells "
+                f"will be removed from the training set automatically",
+                UserWarning,
+                stacklevel=settings.warnings_stacklevel,
+            )
+            n_train -= num_of_cells
+            if n_val > 0:
+                n_val += num_of_cells
+                warnings.warn(
+                    f" {num_of_cells} cells moved from training set to "
+                    f"validation set",
+                    UserWarning,
+                    stacklevel=settings.warnings_stacklevel,
+            )
 
     return n_train, n_val
 
 
-def validate_data_split_with_external_indexing(
-    n_samples: int,
+def validate_data_split_with_external_indexing(n_samples: int,
     external_indexing: list[np.array, np.array, np.array] | None = None,
+    batch_size: int | None = None, drop_last: bool | int = False
 ):
     """Check data splitting parameters and return n_train and n_val.
 
@@ -90,6 +96,10 @@ def validate_data_split_with_external_indexing(
     external_indexing
         A list of data split indices in the order of training, validation, and test sets.
         Validation and test set are not required and can be left empty.
+    batch_size
+        batch size of each iteration. If `None`, do not minibatch
+    drop_last
+        drops last non-full batch
     """
     if not isinstance(external_indexing, list):
         raise ValueError("External indexing is not of list type")
@@ -143,14 +153,16 @@ def validate_data_split_with_external_indexing(
     n_train = len(external_indexing[0])
     n_val = len(external_indexing[1])
 
-    if n_train % settings.batch_size < 3 and n_train % settings.batch_size > 0:
-        warnings.warn(
-            f"Last batch will have a small size of {n_train % settings.batch_size} "
-            f"samples. Consider changing settings.batch_size or batch_size in model.train "
-            f"currently {settings.batch_size} to avoid errors during model training.",
-            UserWarning,
-            stacklevel=settings.warnings_stacklevel,
-        )
+    if batch_size is not None and not drop_last:
+        if n_train % batch_size < 3 and n_train % batch_size > 0:
+            warnings.warn(
+                f"Last batch will have a small size of {n_train % batch_size} "
+                f"samples. Consider changing settings.batch_size or batch_size in model.train from "
+                f"currently {settings.batch_size} to avoid errors during model training "
+                f"or change the given external indices accordingly",
+                UserWarning,
+                stacklevel=settings.warnings_stacklevel,
+            )
 
     return n_train, n_val
 
@@ -223,13 +235,14 @@ class DataSplitter(pl.LightningDataModule):
 
         if self.external_indexing is not None:
             self.n_train, self.n_val = validate_data_split_with_external_indexing(
-                self.adata_manager.adata.n_obs,
-                self.external_indexing,
+                self.adata_manager.adata.n_obs, self.external_indexing,
+                self.data_loader_kwargs["batch_size"], self.drop_last
             )
         else:
-            self.n_train, self.n_val = validate_data_split(
-                self.adata_manager.adata.n_obs, self.train_size, self.validation_size
-            )
+            self.n_train, self.n_val = validate_data_split(self.adata_manager.adata.n_obs,
+                 self.train_size, self.validation_size, self.data_loader_kwargs["batch_size"],
+                                                           self.drop_last
+                                                           )
 
     def setup(self, stage: str | None = None):
         """Split indices in train/test/val sets."""
@@ -399,10 +412,12 @@ class SemiSupervisedDataSplitter(pl.LightningDataModule):
                 n_labeled_train, n_labeled_val = validate_data_split_with_external_indexing(
                     n_labeled_idx,
                     [labeled_idx_train, labeled_idx_val, labeled_idx_test],
+                    self.data_loader_kwargs["batch_size"], self.drop_last
                 )
             else:
-                n_labeled_train, n_labeled_val = validate_data_split(
-                    n_labeled_idx, self.train_size, self.validation_size
+                n_labeled_train, n_labeled_val = validate_data_split(n_labeled_idx,
+                    self.train_size, self.validation_size, self.data_loader_kwargs["batch_size"],
+                                                                     self.drop_last
                 )
 
                 labeled_permutation = self._labeled_indices
@@ -433,10 +448,12 @@ class SemiSupervisedDataSplitter(pl.LightningDataModule):
                 n_unlabeled_train, n_unlabeled_val = validate_data_split_with_external_indexing(
                     n_unlabeled_idx,
                     [unlabeled_idx_train, unlabeled_idx_val, unlabeled_idx_test],
+                    self.data_loader_kwargs["batch_size"], self.drop_last
                 )
             else:
-                n_unlabeled_train, n_unlabeled_val = validate_data_split(
-                    n_unlabeled_idx, self.train_size, self.validation_size
+                n_unlabeled_train, n_unlabeled_val = validate_data_split(n_unlabeled_idx,
+                    self.train_size, self.validation_size, self.data_loader_kwargs["batch_size"],
+                                                                         self.drop_last
                 )
 
                 unlabeled_permutation = self._unlabeled_indices

--- a/src/scvi/external/cellassign/_model.py
+++ b/src/scvi/external/cellassign/_model.py
@@ -143,7 +143,7 @@ class CellAssign(UnsupervisedTrainingMixin, BaseModelClass):
         lr: float = 3e-3,
         accelerator: str = "auto",
         devices: int | list[int] | str = "auto",
-        train_size: float = 0.9,
+        train_size: float | None = None,
         validation_size: float | None = None,
         shuffle_set_split: bool = True,
         batch_size: int = 1024,

--- a/src/scvi/external/contrastivevi/_contrastive_data_splitting.py
+++ b/src/scvi/external/contrastivevi/_contrastive_data_splitting.py
@@ -53,7 +53,7 @@ class ContrastiveDataSplitter(DataSplitter):
         adata_manager: AnnDataManager,
         background_indices: list[int],
         target_indices: list[int],
-        train_size: float = 0.9,
+        train_size: float | None = None,
         validation_size: float | None = None,
         shuffle_set_split: bool = True,
         load_sparse_tensor: bool = False,
@@ -81,15 +81,15 @@ class ContrastiveDataSplitter(DataSplitter):
                 self.n_background,
                 self.train_size,
                 self.validation_size,
-                self.data_loader_kwargs.pop("batch_size", settings.batch_size),
-                self.drop_last,
+                self.data_loader_kwargs.pop("batch_size", settings.batch_size) if
+                self.train_size_was_none and not self.drop_last else None,
             )
             self.n_target_train, self.n_target_val = validate_data_split(
                 self.n_target,
                 self.train_size,
                 self.validation_size,
-                self.data_loader_kwargs.pop("batch_size", settings.batch_size),
-                self.drop_last,
+                self.data_loader_kwargs.pop("batch_size", settings.batch_size) if
+                self.train_size_was_none and not self.drop_last else None,
             )
         else:
             # we need to intersect the external indexing given with the bg/target indices
@@ -101,8 +101,6 @@ class ContrastiveDataSplitter(DataSplitter):
                 validate_data_split_with_external_indexing(
                     self.n_background,
                     [self.background_train_idx, self.background_val_idx, self.background_test_idx],
-                    self.data_loader_kwargs.pop("batch_size", settings.batch_size),
-                    self.drop_last,
                 )
             )
             self.background_train_idx, self.background_val_idx, self.background_test_idx = (
@@ -117,8 +115,6 @@ class ContrastiveDataSplitter(DataSplitter):
             self.n_target_train, self.n_target_val = validate_data_split_with_external_indexing(
                 self.n_target,
                 [self.target_train_idx, self.target_val_idx, self.target_test_idx],
-                self.data_loader_kwargs.pop("batch_size", settings.batch_size),
-                self.drop_last,
             )
             self.target_train_idx, self.target_val_idx, self.target_test_idx = (
                 self.target_train_idx.tolist(),

--- a/src/scvi/external/contrastivevi/_contrastive_data_splitting.py
+++ b/src/scvi/external/contrastivevi/_contrastive_data_splitting.py
@@ -81,17 +81,17 @@ class ContrastiveDataSplitter(DataSplitter):
                 self.n_background,
                 self.train_size,
                 self.validation_size,
-                self.data_loader_kwargs.pop("batch_size", settings.batch_size)
-                if self.train_size_was_none and not self.drop_last
-                else None,
+                self.data_loader_kwargs.pop("batch_size", settings.batch_size),
+                self.drop_last,
+                self.train_size_is_none
             )
             self.n_target_train, self.n_target_val = validate_data_split(
                 self.n_target,
                 self.train_size,
                 self.validation_size,
-                self.data_loader_kwargs.pop("batch_size", settings.batch_size)
-                if self.train_size_was_none and not self.drop_last
-                else None,
+                self.data_loader_kwargs.pop("batch_size", settings.batch_size),
+                self.drop_last,
+                self.train_size_is_none
             )
         else:
             # we need to intersect the external indexing given with the bg/target indices
@@ -103,6 +103,8 @@ class ContrastiveDataSplitter(DataSplitter):
                 validate_data_split_with_external_indexing(
                     self.n_background,
                     [self.background_train_idx, self.background_val_idx, self.background_test_idx],
+                    self.data_loader_kwargs.pop("batch_size", settings.batch_size),
+                    self.drop_last,
                 )
             )
             self.background_train_idx, self.background_val_idx, self.background_test_idx = (
@@ -117,6 +119,8 @@ class ContrastiveDataSplitter(DataSplitter):
             self.n_target_train, self.n_target_val = validate_data_split_with_external_indexing(
                 self.n_target,
                 [self.target_train_idx, self.target_val_idx, self.target_test_idx],
+                self.data_loader_kwargs.pop("batch_size", settings.batch_size),
+                self.drop_last,
             )
             self.target_train_idx, self.target_val_idx, self.target_test_idx = (
                 self.target_train_idx.tolist(),

--- a/src/scvi/external/contrastivevi/_contrastive_data_splitting.py
+++ b/src/scvi/external/contrastivevi/_contrastive_data_splitting.py
@@ -83,7 +83,7 @@ class ContrastiveDataSplitter(DataSplitter):
                 self.validation_size,
                 self.data_loader_kwargs.pop("batch_size", settings.batch_size),
                 self.drop_last,
-                self.train_size_is_none
+                self.train_size_is_none,
             )
             self.n_target_train, self.n_target_val = validate_data_split(
                 self.n_target,
@@ -91,7 +91,7 @@ class ContrastiveDataSplitter(DataSplitter):
                 self.validation_size,
                 self.data_loader_kwargs.pop("batch_size", settings.batch_size),
                 self.drop_last,
-                self.train_size_is_none
+                self.train_size_is_none,
             )
         else:
             # we need to intersect the external indexing given with the bg/target indices

--- a/src/scvi/external/contrastivevi/_contrastive_data_splitting.py
+++ b/src/scvi/external/contrastivevi/_contrastive_data_splitting.py
@@ -81,14 +81,14 @@ class ContrastiveDataSplitter(DataSplitter):
                 self.n_background,
                 self.train_size,
                 self.validation_size,
-                self.data_loader_kwargs["batch_size"],
+                self.data_loader_kwargs.pop("batch_size", settings.batch_size),
                 self.drop_last,
             )
             self.n_target_train, self.n_target_val = validate_data_split(
                 self.n_target,
                 self.train_size,
                 self.validation_size,
-                self.data_loader_kwargs["batch_size"],
+                self.data_loader_kwargs.pop("batch_size", settings.batch_size),
                 self.drop_last,
             )
         else:
@@ -101,7 +101,7 @@ class ContrastiveDataSplitter(DataSplitter):
                 validate_data_split_with_external_indexing(
                     self.n_background,
                     [self.background_train_idx, self.background_val_idx, self.background_test_idx],
-                    self.data_loader_kwargs["batch_size"],
+                    self.data_loader_kwargs.pop("batch_size", settings.batch_size),
                     self.drop_last,
                 )
             )
@@ -117,7 +117,7 @@ class ContrastiveDataSplitter(DataSplitter):
             self.n_target_train, self.n_target_val = validate_data_split_with_external_indexing(
                 self.n_target,
                 [self.target_train_idx, self.target_val_idx, self.target_test_idx],
-                self.data_loader_kwargs["batch_size"],
+                self.data_loader_kwargs.pop("batch_size", settings.batch_size),
                 self.drop_last,
             )
             self.target_train_idx, self.target_val_idx, self.target_test_idx = (

--- a/src/scvi/external/contrastivevi/_contrastive_data_splitting.py
+++ b/src/scvi/external/contrastivevi/_contrastive_data_splitting.py
@@ -78,10 +78,12 @@ class ContrastiveDataSplitter(DataSplitter):
         self.n_target = len(target_indices)
         if external_indexing is None:
             self.n_background_train, self.n_background_val = validate_data_split(
-                self.n_background, self.train_size, self.validation_size
+                self.n_background, self.train_size, self.validation_size,
+                self.data_loader_kwargs["batch_size"], self.drop_last
             )
             self.n_target_train, self.n_target_val = validate_data_split(
-                self.n_target, self.train_size, self.validation_size
+                self.n_target, self.train_size, self.validation_size,
+                self.data_loader_kwargs["batch_size"], self.drop_last
             )
         else:
             # we need to intersect the external indexing given with the bg/target indices
@@ -93,6 +95,7 @@ class ContrastiveDataSplitter(DataSplitter):
                 validate_data_split_with_external_indexing(
                     self.n_background,
                     [self.background_train_idx, self.background_val_idx, self.background_test_idx],
+                    self.data_loader_kwargs["batch_size"], self.drop_last
                 )
             )
             self.background_train_idx, self.background_val_idx, self.background_test_idx = (
@@ -107,6 +110,7 @@ class ContrastiveDataSplitter(DataSplitter):
             self.n_target_train, self.n_target_val = validate_data_split_with_external_indexing(
                 self.n_target,
                 [self.target_train_idx, self.target_val_idx, self.target_test_idx],
+                self.data_loader_kwargs["batch_size"], self.drop_last
             )
             self.target_train_idx, self.target_val_idx, self.target_test_idx = (
                 self.target_train_idx.tolist(),

--- a/src/scvi/external/contrastivevi/_model.py
+++ b/src/scvi/external/contrastivevi/_model.py
@@ -136,7 +136,7 @@ class ContrastiveVI(BaseModelClass):
         max_epochs: int | None = None,
         accelerator: str = "auto",
         devices: int | list[int] | str = "auto",
-        train_size: float = 0.9,
+        train_size: float | None = None,
         validation_size: float | None = None,
         shuffle_set_split: bool = True,
         load_sparse_tensor: bool = False,

--- a/src/scvi/external/gimvi/_model.py
+++ b/src/scvi/external/gimvi/_model.py
@@ -172,7 +172,7 @@ class GIMVI(VAEMixin, BaseModelClass):
         accelerator: str = "auto",
         devices: int | list[int] | str = "auto",
         kappa: int = 5,
-        train_size: float = 0.9,
+        train_size: float | None = None,
         validation_size: float | None = None,
         shuffle_set_split: bool = True,
         batch_size: int = 128,

--- a/src/scvi/external/mrvi/_model.py
+++ b/src/scvi/external/mrvi/_model.py
@@ -201,7 +201,7 @@ class MRVI(JaxTrainingMixin, BaseModelClass):
         max_epochs: int | None = None,
         accelerator: str | None = "auto",
         devices: int | list[int] | str = "auto",
-        train_size: float = 0.9,
+        train_size: float | None = None,
         validation_size: float | None = None,
         batch_size: int = 128,
         early_stopping: bool = False,

--- a/src/scvi/external/scbasset/_model.py
+++ b/src/scvi/external/scbasset/_model.py
@@ -106,7 +106,7 @@ class SCBASSET(BaseModelClass):
         lr: float = 0.01,
         accelerator: str = "auto",
         devices: int | list[int] | str = "auto",
-        train_size: float = 0.9,
+        train_size: float | None = None,
         validation_size: float | None = None,
         shuffle_set_split: bool = True,
         batch_size: int = 128,

--- a/src/scvi/external/solo/_model.py
+++ b/src/scvi/external/solo/_model.py
@@ -293,7 +293,7 @@ class SOLO(BaseModelClass):
         lr: float = 1e-3,
         accelerator: str = "auto",
         devices: int | list[int] | str = "auto",
-        train_size: float = 0.9,
+        train_size: float | None = None,
         validation_size: float | None = None,
         shuffle_set_split: bool = True,
         batch_size: int = 128,

--- a/src/scvi/external/velovi/_model.py
+++ b/src/scvi/external/velovi/_model.py
@@ -129,7 +129,7 @@ class VELOVI(VAEMixin, UnsupervisedTrainingMixin, BaseModelClass):
         weight_decay: float = 1e-2,
         accelerator: str = "auto",
         devices: int | list[int] | str = "auto",
-        train_size: float = 0.9,
+        train_size: float | None = None,
         validation_size: float | None = None,
         batch_size: int = 256,
         early_stopping: bool = True,

--- a/src/scvi/model/_multivi.py
+++ b/src/scvi/model/_multivi.py
@@ -231,7 +231,7 @@ class MULTIVI(VAEMixin, UnsupervisedTrainingMixin, BaseModelClass, ArchesMixin):
         lr: float = 1e-4,
         accelerator: str = "auto",
         devices: int | list[int] | str = "auto",
-        train_size: float = 0.9,
+        train_size: float | None = None,
         validation_size: float | None = None,
         shuffle_set_split: bool = True,
         batch_size: int = 128,

--- a/src/scvi/model/_peakvi.py
+++ b/src/scvi/model/_peakvi.py
@@ -151,7 +151,7 @@ class PEAKVI(ArchesMixin, VAEMixin, UnsupervisedTrainingMixin, BaseModelClass):
         lr: float = 1e-4,
         accelerator: str = "auto",
         devices: int | list[int] | str = "auto",
-        train_size: float = 0.9,
+        train_size: float | None = None,
         validation_size: float | None = None,
         shuffle_set_split: bool = True,
         batch_size: int = 128,

--- a/src/scvi/model/_scanvi.py
+++ b/src/scvi/model/_scanvi.py
@@ -356,7 +356,7 @@ class SCANVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseMinifiedModeModelClass):
         max_epochs: int | None = None,
         n_samples_per_label: float | None = None,
         check_val_every_n_epoch: int | None = None,
-        train_size: float = 0.9,
+        train_size: float | None = None,
         validation_size: float | None = None,
         shuffle_set_split: bool = True,
         batch_size: int = 128,

--- a/src/scvi/model/_totalvi.py
+++ b/src/scvi/model/_totalvi.py
@@ -197,7 +197,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
         lr: float = 4e-3,
         accelerator: str = "auto",
         devices: int | list[int] | str = "auto",
-        train_size: float = 0.9,
+        train_size: float | None = None,
         validation_size: float | None = None,
         shuffle_set_split: bool = True,
         batch_size: int = 256,

--- a/src/scvi/model/base/_jaxmixin.py
+++ b/src/scvi/model/base/_jaxmixin.py
@@ -24,7 +24,7 @@ class JaxTrainingMixin:
         max_epochs: int | None = None,
         accelerator: str = "auto",
         devices: int | list[int] | str = "auto",
-        train_size: float = 0.9,
+        train_size: float | None = None,
         validation_size: float | None = None,
         shuffle_set_split: bool = True,
         batch_size: int = 128,

--- a/src/scvi/model/base/_pyromixin.py
+++ b/src/scvi/model/base/_pyromixin.py
@@ -92,7 +92,7 @@ class PyroSviTrainMixin:
         max_epochs: int | None = None,
         accelerator: str = "auto",
         device: int | str = "auto",
-        train_size: float = 0.9,
+        train_size: float | None = None,
         validation_size: float | None = None,
         shuffle_set_split: bool = True,
         batch_size: int = 128,

--- a/src/scvi/model/base/_training_mixin.py
+++ b/src/scvi/model/base/_training_mixin.py
@@ -24,7 +24,7 @@ class UnsupervisedTrainingMixin:
         max_epochs: int | None = None,
         accelerator: str = "auto",
         devices: int | list[int] | str = "auto",
-        train_size: float = 0.9,
+        train_size: float | None = None,
         validation_size: float | None = None,
         shuffle_set_split: bool = True,
         load_sparse_tensor: bool = False,

--- a/tests/model/test_scvi.py
+++ b/tests/model/test_scvi.py
@@ -477,8 +477,8 @@ def test_scvi_n_obs_error(n_latent: int = 5):
     model = SCVI(adata, n_latent=n_latent)
     with pytest.raises(ValueError):
         model.train(1, train_size=1.0)
-    with pytest.warns(UserWarning):
-        # Warning is emitted if last batch less than 3 cells.
+    with pytest.raises(ValueError):
+        # Warning is emitted if last batch less than 3 cells + failure.
         model.train(1, train_size=1.0, batch_size=127)
     model.train(1, train_size=1.0, datasplitter_kwargs={"drop_last": True})
 
@@ -488,6 +488,7 @@ def test_scvi_n_obs_error(n_latent: int = 5):
     model = SCVI(adata, n_latent=n_latent)
     with pytest.raises(ValueError):
         model.train(1, train_size=0.9)  # np.ceil(n_cells * 0.9) % 128 == 1
+    model.train(1, train_size=0.9, datasplitter_kwargs={"drop_last": True})  # np.ceil(n_cells * 0.9) % 128 == 1
     model.train(1)
     assert model.is_trained is True
 

--- a/tests/model/test_scvi.py
+++ b/tests/model/test_scvi.py
@@ -475,12 +475,20 @@ def test_scvi_n_obs_error(n_latent: int = 5):
     adata = adata[0:129].copy()
     SCVI.setup_anndata(adata)
     model = SCVI(adata, n_latent=n_latent)
-    with pytest.raises(ValueError):
+    with pytest.warns(UserWarning):
         model.train(1, train_size=1.0)
     with pytest.warns(UserWarning):
         # Warning is emitted if last batch less than 3 cells.
         model.train(1, train_size=1.0, batch_size=127)
     model.train(1, train_size=1.0, datasplitter_kwargs={"drop_last": True})
+
+    adata = synthetic_iid()
+    adata = adata[0:143].copy()
+    SCVI.setup_anndata(adata)
+    model = SCVI(adata, n_latent=n_latent)
+    with pytest.warns(UserWarning):
+        model.train(1, train_size=0.9) #np.ceil(n_cells * 0.9) % 128 == 1
+
     assert model.is_trained is True
 
 

--- a/tests/model/test_scvi.py
+++ b/tests/model/test_scvi.py
@@ -488,7 +488,9 @@ def test_scvi_n_obs_error(n_latent: int = 5):
     model = SCVI(adata, n_latent=n_latent)
     with pytest.raises(ValueError):
         model.train(1, train_size=0.9)  # np.ceil(n_cells * 0.9) % 128 == 1
-    model.train(1, train_size=0.9, datasplitter_kwargs={"drop_last": True})  # np.ceil(n_cells * 0.9) % 128 == 1
+    model.train(
+        1, train_size=0.9, datasplitter_kwargs={"drop_last": True}
+    )  # np.ceil(n_cells * 0.9) % 128 == 1
     model.train(1)
     assert model.is_trained is True
 

--- a/tests/model/test_scvi.py
+++ b/tests/model/test_scvi.py
@@ -475,7 +475,7 @@ def test_scvi_n_obs_error(n_latent: int = 5):
     adata = adata[0:129].copy()
     SCVI.setup_anndata(adata)
     model = SCVI(adata, n_latent=n_latent)
-    with pytest.warns(UserWarning):
+    with pytest.raises(ValueError):
         model.train(1, train_size=1.0)
     with pytest.warns(UserWarning):
         # Warning is emitted if last batch less than 3 cells.
@@ -486,9 +486,9 @@ def test_scvi_n_obs_error(n_latent: int = 5):
     adata = adata[0:143].copy()
     SCVI.setup_anndata(adata)
     model = SCVI(adata, n_latent=n_latent)
-    with pytest.warns(UserWarning):
+    with pytest.raises(ValueError):
         model.train(1, train_size=0.9)  # np.ceil(n_cells * 0.9) % 128 == 1
-
+    model.train(1)
     assert model.is_trained is True
 
 


### PR DESCRIPTION
In case that train_size is None and the size of the last batch during training is <=2 , we adaptively move those samples from training to validation if possible. If train_size is set by user we do no fix this error and let the user change its train_size, selected indices or use drop last batch option.
close https://github.com/scverse/scvi-tools/issues/3035

