### PR TITLE
fix: gimVI mini batch append on CPU first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,14 +30,15 @@ to [Semantic Versioning]. Full commit history is available in the
 - Implemented variance of ZINB distribution. {pr}`3044`.
 - Add {class}`scvi.external.METHYLVI` for modeling methylation data from single-cell
     bisulfite sequencing (scBS-seq) experiments {pr}`2834`.
-  
+
 #### Fixed
 
 - Breaking Change: Fix `get_outlier_cell_sample_pairs` function in {class}`scvi.external.MRVI`
     to correctly compute the maxmimum log-density across in-sample cells rather than the
     aggregated posterior log-density {pr}`3007`.
 - Fix references to `scvi.external` in `scvi.external.SCAR.setup_anndata`.
-
+- Fix gimVI to append mini batches first into CPU during get_imputed and get_latent operations {pr}`30XX`.
+-
 #### Changed
 
 #### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ to [Semantic Versioning]. Full commit history is available in the
 - Fix references to `scvi.external` in `scvi.external.SCAR.setup_anndata`.
 - Fix gimVI to append mini batches first into CPU during get_imputed and get_latent operations {pr}`30XX`.
 -
+
 #### Changed
 
 #### Removed

--- a/src/scvi/external/gimvi/_model.py
+++ b/src/scvi/external/gimvi/_model.py
@@ -312,10 +312,10 @@ class GIMVI(VAEMixin, BaseModelClass):
                 latent.append(
                     self.module.sample_from_posterior_z(
                         sample_batch, mode, deterministic=deterministic
-                    )
+                    ).cpu().detach()
                 )
 
-            latent = torch.cat(latent).cpu().detach().numpy()
+            latent = torch.cat(latent).numpy()
             latents.append(latent)
 
         return latents
@@ -371,7 +371,7 @@ class GIMVI(VAEMixin, BaseModelClass):
                             label,
                             deterministic=deterministic,
                             decode_mode=decode_mode,
-                        )
+                        ).cpu().detach()
                     )
                 else:
                     imputed_value.append(
@@ -382,10 +382,10 @@ class GIMVI(VAEMixin, BaseModelClass):
                             label,
                             deterministic=deterministic,
                             decode_mode=decode_mode,
-                        )
+                        ).cpu().detach()
                     )
 
-            imputed_value = torch.cat(imputed_value).cpu().detach().numpy()
+            imputed_value = torch.cat(imputed_value).numpy()
             imputed_values.append(imputed_value)
 
         return imputed_values

--- a/src/scvi/external/gimvi/_model.py
+++ b/src/scvi/external/gimvi/_model.py
@@ -312,7 +312,9 @@ class GIMVI(VAEMixin, BaseModelClass):
                 latent.append(
                     self.module.sample_from_posterior_z(
                         sample_batch, mode, deterministic=deterministic
-                    ).cpu().detach()
+                    )
+                    .cpu()
+                    .detach()
                 )
 
             latent = torch.cat(latent).numpy()
@@ -371,7 +373,9 @@ class GIMVI(VAEMixin, BaseModelClass):
                             label,
                             deterministic=deterministic,
                             decode_mode=decode_mode,
-                        ).cpu().detach()
+                        )
+                        .cpu()
+                        .detach()
                     )
                 else:
                     imputed_value.append(
@@ -382,7 +386,9 @@ class GIMVI(VAEMixin, BaseModelClass):
                             label,
                             deterministic=deterministic,
                             decode_mode=decode_mode,
-                        ).cpu().detach()
+                        )
+                        .cpu()
+                        .detach()
                     )
 
             imputed_value = torch.cat(imputed_value).numpy()


### PR DESCRIPTION
Fixing gimVI get_latent and get_imputed to append mini batches into CPU first (and not to GPU first) in order to save GPU memory, as was done in VAE.

close https://github.com/scverse/scvi-tools/issues/3057