### PR TITLE
bug: Fix bad tutorial link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ to [Semantic Versioning]. Full commit history is available in the
     to correctly compute the maxmimum log-density across in-sample cells rather than the
     aggregated posterior log-density {pr}`3007`.
 - Fix references to `scvi.external` in `scvi.external.SCAR.setup_anndata`.
-- Fix gimVI to append mini batches first into CPU during get_imputed and get_latent operations {pr}`30XX`.
+- Fix gimVI to append mini batches first into CPU during get_imputed and get_latent operations {pr}`3058`.
 -
 
 #### Changed


### PR DESCRIPTION
Remove bad tutorial link which was a legacy merge during the merge of https://github.com/scverse/scvi-tools/commit/7c96323e9b1191a95ae0a8e1ba0216af1a2dd732