### PR TITLE
test: Fix slow tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,8 +127,9 @@ testpaths = ["tests"]
 xfail_strict = true
 markers = [
     "internet: mark tests that requires internet access",
-    "optional: mark optional tests",
-    "private: mark tests that are private",
+    "optional: mark optional tests, usually take more time",
+    "private: mark tests that uses private keys, like HF",
+    "multigpu: mark tests that are used to check multi GPU performance",
 ]
 
 [tool.ruff]

--- a/src/scvi/data/_preprocessing.py
+++ b/src/scvi/data/_preprocessing.py
@@ -446,7 +446,7 @@ def add_dna_sequence(
 
     sequence_df = pd.concat(seq_dfs, axis=0).loc[adata.var_names]
     adata.varm[sequence_varm_key] = sequence_df
-    adata.varm[code_varm_key] = sequence_df.applymap(_dna_to_code)
+    adata.varm[code_varm_key] = sequence_df.map(_dna_to_code)
 
 
 def reads_to_fragments(

--- a/src/scvi/utils/_docstrings.py
+++ b/src/scvi/utils/_docstrings.py
@@ -140,6 +140,10 @@ param_layer = """\
 layer
     if not `None`, uses this as the key in `adata.layers` for raw count data."""
 
+idx_layer = """\
+idx_layer
+    if not `None`, A vector string represents the different modalities """
+
 param_cat_cov_keys = """\
 categorical_covariate_keys
     keys in `adata.obs` that correspond to categorical data.
@@ -194,6 +198,7 @@ setup_anndata_dsp = DocstringProcessor(
     param_unlabeled_category=param_unlabeled_category,
     param_modalities=param_modalities,
     param_copy=param_copy,
+    idx_layer=idx_layer,
     returns=returns,
 )
 

--- a/tests/data/test_anndata.py
+++ b/tests/data/test_anndata.py
@@ -6,8 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import torch
-from scipy import sparse
-from scipy.sparse.csr import csr_matrix
+from scipy.sparse import csr_matrix
 
 import scvi
 from scvi import REGISTRY_KEYS
@@ -59,7 +58,7 @@ def test_transfer_fields_correct_mapping(adata1, adata2):
     adata1_manager.transfer_fields(adata2)
     labels_mapping = adata1_manager.get_state_registry("labels").categorical_mapping
     correct_label = np.where(labels_mapping == "label_1")[0][0]
-    assert adata2.obs["_scvi_labels"][0] == correct_label
+    assert adata2.obs._scvi_labels.iloc[0] == correct_label
 
 
 def test_transfer_fields_correct_batch(adata1, adata2):
@@ -76,8 +75,8 @@ def test_transfer_fields_same_batch_and_label(adata1, adata2):
     adata1_manager = generic_setup_adata_manager(adata1)
     del adata2.obs["batch"]
     adata1_manager.transfer_fields(adata2)
-    assert adata2.obs["_scvi_batch"][0] == 0
-    assert adata2.obs["_scvi_labels"][0] == 0
+    assert adata2.obs._scvi_batch.iloc[0] == 0
+    assert adata2.obs._scvi_labels.iloc[0] == 0
 
 
 def test_transfer_fields_subset(adata1, adata2):
@@ -443,7 +442,7 @@ def test_anntorchdataset_numpy(adata):
 
 def test_anntorchdataset_numpy_sparse(adata):
     # check AnnTorchDataset returns numpy array counts were sparse
-    adata.X = sparse.csr_matrix(adata.X)
+    adata.X = csr_matrix(adata.X)
     adata_manager = generic_setup_adata_manager(adata)
     bd = AnnTorchDataset(adata_manager)
     for value in bd[1].values():
@@ -452,7 +451,7 @@ def test_anntorchdataset_numpy_sparse(adata):
 
 def test_anntorchdataset_getitem_numpy_sparse(adata):
     # check AnnTorchDataset returns numpy array if pro exp was sparse
-    adata.obsm["protein_expression"] = sparse.csr_matrix(adata.obsm["protein_expression"])
+    adata.obsm["protein_expression"] = csr_matrix(adata.obsm["protein_expression"])
     adata_manager = generic_setup_adata_manager(
         adata, batch_key="batch", protein_expression_obsm_key="protein_expression"
     )

--- a/tests/model/test_differential.py
+++ b/tests/model/test_differential.py
@@ -51,7 +51,7 @@ def test_features():
 
 def test_differential_computation(save_path):
     n_latent = 5
-    adata = synthetic_iid()
+    adata = synthetic_iid(batch_size=50, n_genes=30, n_proteins=20, n_regions=20)
     SCVI.setup_anndata(
         adata,
         batch_key="batch",

--- a/tests/model/test_multivi.py
+++ b/tests/model/test_multivi.py
@@ -86,6 +86,7 @@ def test_multivi_single_batch():
         vae.train(3)
 
 
+@pytest.mark.internet
 def test_multivi_mudata_rna_prot_external():
     # Example on how to download protein adata to mudata (from multivi tutorial) - mudata RNA/PROT
     adata = scvi.data.pbmcs_10x_cite_seq()

--- a/tests/model/test_scvi.py
+++ b/tests/model/test_scvi.py
@@ -686,7 +686,7 @@ def test_early_stopping():
 
 
 def test_de_features():
-    adata = synthetic_iid()
+    adata = synthetic_iid(batch_size=50, n_genes=20, n_proteins=20, n_regions=20)
     SCVI.setup_anndata(
         adata,
         batch_key="batch",
@@ -1280,9 +1280,11 @@ def test_scvi_normal_likelihood():
     model.get_normalized_expression(n_samples=2)
 
 
+@pytest.mark.optional
 def test_scvi_num_workers():
-    adata = synthetic_iid()
-    scvi.settings.dl_num_workers = 7
+    # this test takes time we use a small dataset
+    adata = synthetic_iid(batch_size=50, n_genes=20, n_proteins=20, n_regions=20)
+    scvi.settings.dl_num_workers = 3
     scvi.settings.dl_persistent_workers = True
     SCVI.setup_anndata(adata, batch_key="batch")
 

--- a/tests/model/test_totalvi.py
+++ b/tests/model/test_totalvi.py
@@ -250,22 +250,6 @@ def test_totalvi(save_path):
     model.differential_expression(idx1=[0, 1, 2])
     model.differential_expression(groupby="labels")
 
-    # test with missing proteins
-    adata = pbmcs_10x_cite_seq(
-        save_path=save_path,
-        protein_join="outer",
-    )
-    TOTALVI.setup_anndata(
-        adata, batch_key="batch", protein_expression_obsm_key="protein_expression"
-    )
-    model = TOTALVI(adata)
-    assert model.module.protein_batch_mask is not None
-    model.train(1, train_size=0.5)
-
-    model = TOTALVI(adata, override_missing_proteins=True)
-    assert model.module.protein_batch_mask is None
-    model.train(1, train_size=0.5)
-
 
 def test_totalvi_model_library_size(save_path):
     adata = synthetic_iid()
@@ -496,6 +480,7 @@ def test_totalvi_reordered_mapping_mudata():
     model.get_elbo(mdata2)
 
 
+@pytest.mark.internet
 def test_totalvi_missing_proteins(save_path):
     # test with missing proteins
     adata = pbmcs_10x_cite_seq(


### PR DESCRIPTION
make several tests run faster by using smaller data or putting them under optional. 
It reduces 8 minutes from the default linux test which now takes just 3 min!