### PR TITLE
Support of dask arrays in AnnTorchDataset.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ to [Semantic Versioning]. Full commit history is available in the
     AutoZI, CellAssign and GimVI. {pr}`3121`.
 - Add {class}`scvi.external.RESOLVI` for bias correction in single-cell resolved spatial
     transcriptomics {pr}`3144`.
+- Add Support of dask arrays in AnnTorchDataset. {pr}`3193`.
 
 #### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
     "torchmetrics>=0.11.0",
     "tqdm",
     "xarray>=2023.2.0",
+    "dask",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,10 +95,12 @@ regseq = ["biopython>=1.81", "genomepy"]
 # scvi.criticism and read 10x
 scanpy = ["scanpy>=1.10", "scikit-misc"]
 # for convinient files sharing
-pooch = ["pooch"]
+file_sharing = ["pooch"]
+# for parallelization engine
+parallel = ["dask[array]>=2023.5.1,<2024.8.0"]
 
 optional = [
-    "scvi-tools[autotune,aws,hub,pooch,regseq,scanpy]"
+    "scvi-tools[autotune,aws,hub,file_sharing,regseq,scanpy,parallel]"
 ]
 tutorials = [
     "cell2location",

--- a/src/scvi/data/_anntorchdataset.py
+++ b/src/scvi/data/_anntorchdataset.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-import dask.array as da
 import h5py
 import numpy as np
 import pandas as pd
@@ -12,6 +11,7 @@ from scipy.sparse import issparse
 from torch.utils.data import Dataset
 
 from scvi._constants import REGISTRY_KEYS
+from scvi.utils import is_package_installed
 
 if TYPE_CHECKING:
     import torch
@@ -154,8 +154,10 @@ class AnnTorchDataset(Dataset):
                 # used to record the type data minification
                 # TODO: Adata manager should have a list of which fields it will load
                 continue
-            elif isinstance(data, da.Array):
-                sliced_data = data[indexes].compute()
+            elif is_package_installed("dask"):
+                import dask.array as da
+                if isinstance(data, da.Array):
+                    sliced_data = data[indexes].compute()
             else:
                 raise TypeError(f"{key} is not a supported type")
 

--- a/src/scvi/data/_anntorchdataset.py
+++ b/src/scvi/data/_anntorchdataset.py
@@ -156,6 +156,7 @@ class AnnTorchDataset(Dataset):
                 continue
             elif is_package_installed("dask"):
                 import dask.array as da
+
                 if isinstance(data, da.Array):
                     sliced_data = data[indexes].compute()
             else:

--- a/src/scvi/data/_anntorchdataset.py
+++ b/src/scvi/data/_anntorchdataset.py
@@ -9,6 +9,7 @@ import pandas as pd
 from anndata.abc import CSCDataset, CSRDataset
 from scipy.sparse import issparse
 from torch.utils.data import Dataset
+import dask.array as da
 
 from scvi._constants import REGISTRY_KEYS
 
@@ -153,6 +154,8 @@ class AnnTorchDataset(Dataset):
                 # used to record the type data minification
                 # TODO: Adata manager should have a list of which fields it will load
                 continue
+            elif issparse(data) or isinstance(data, da.Array):
+                sliced_data = data[indexes].compute()
             else:
                 raise TypeError(f"{key} is not a supported type")
 

--- a/src/scvi/data/_anntorchdataset.py
+++ b/src/scvi/data/_anntorchdataset.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-import dask.array as da
 import h5py
 import numpy as np
 import pandas as pd
 from anndata.abc import CSCDataset, CSRDataset
 from scipy.sparse import issparse
 from torch.utils.data import Dataset
+import dask.array as da
 
 from scvi._constants import REGISTRY_KEYS
 
@@ -154,7 +154,7 @@ class AnnTorchDataset(Dataset):
                 # used to record the type data minification
                 # TODO: Adata manager should have a list of which fields it will load
                 continue
-            elif issparse(data) or isinstance(data, da.Array):
+            elif isinstance(data, da.Array):
                 sliced_data = data[indexes].compute()
             else:
                 raise TypeError(f"{key} is not a supported type")

--- a/src/scvi/data/_anntorchdataset.py
+++ b/src/scvi/data/_anntorchdataset.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+import dask.array as da
 import h5py
 import numpy as np
 import pandas as pd
 from anndata.abc import CSCDataset, CSRDataset
 from scipy.sparse import issparse
 from torch.utils.data import Dataset
-import dask.array as da
 
 from scvi._constants import REGISTRY_KEYS
 

--- a/src/scvi/data/_utils.py
+++ b/src/scvi/data/_utils.py
@@ -16,9 +16,9 @@ from mudata import MuData
 from torch import as_tensor, sparse_csc_tensor, sparse_csr_tensor
 
 from scvi import REGISTRY_KEYS, settings
+from scvi.utils import is_package_installed
 
 from . import _constants
-from scvi.utils import is_package_installed
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -250,6 +250,7 @@ def _check_nonnegative_integers(
         data = data[:100]
     elif is_package_installed("dask"):
         import dask.array as da
+
         if isinstance(data, da.Array):
             data = data[:100, :100].compute()
 
@@ -330,6 +331,7 @@ def _check_fragment_counts(
             data = data[:]
     elif is_package_installed("dask"):
         import dask.array as da
+
         if isinstance(data, da.Array):
             if data.shape[0] >= 400:
                 data = data[:400].compute()

--- a/src/scvi/data/_utils.py
+++ b/src/scvi/data/_utils.py
@@ -5,6 +5,7 @@ import warnings
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
+import dask.array as da
 import h5py
 import numpy as np
 import pandas as pd
@@ -14,7 +15,6 @@ from anndata.abc import CSCDataset, CSRDataset
 from anndata.io import read_elem
 from mudata import MuData
 from torch import as_tensor, sparse_csc_tensor, sparse_csr_tensor
-import dask.array as da
 
 from scvi import REGISTRY_KEYS, settings
 
@@ -248,7 +248,7 @@ def _check_nonnegative_integers(
     # for backed anndata
     if isinstance(data, h5py.Dataset) or isinstance(data, SparseDataset):
         data = data[:100]
-    elif isinstance(data, da.Array): 
+    elif isinstance(data, da.Array):
         data = data[:100, :100].compute()
 
     if isinstance(data, np.ndarray):
@@ -326,7 +326,7 @@ def _check_fragment_counts(
             data = data[:400]
         else:
             data = data[:]
-    elif isinstance(data, da.Array): 
+    elif isinstance(data, da.Array):
         if data.shape[0] >= 400:
             data = data[:400].compute()
         else:

--- a/src/scvi/utils/__init__.py
+++ b/src/scvi/utils/__init__.py
@@ -1,6 +1,6 @@
 from ._attrdict import attrdict
 from ._decorators import unsupported_if_adata_minified
-from ._dependencies import dependencies, error_on_missing_dependencies
+from ._dependencies import dependencies, error_on_missing_dependencies, is_package_installed
 from ._docstrings import de_dsp, setup_anndata_dsp
 from ._jax import device_selecting_PRNGKey
 from ._track import track
@@ -13,5 +13,6 @@ __all__ = [
     "device_selecting_PRNGKey",
     "unsupported_if_adata_minified",
     "error_on_missing_dependencies",
+    "is_package_installed",
     "dependencies",
 ]

--- a/src/scvi/utils/_dependencies.py
+++ b/src/scvi/utils/_dependencies.py
@@ -34,4 +34,3 @@ def is_package_installed(module):
         return True  # If no exception is raised, the package is installed
     except ImportError:
         return False  # If ImportError is raised, the package is not installed
-

--- a/src/scvi/utils/_dependencies.py
+++ b/src/scvi/utils/_dependencies.py
@@ -26,3 +26,12 @@ def dependencies(*modules) -> Callable:
         return wrapper
 
     return decorator
+
+
+def is_package_installed(module):
+    try:
+        importlib.import_module(module)  # Try importing the package
+        return True  # If no exception is raised, the package is installed
+    except ImportError:
+        return False  # If ImportError is raised, the package is not installed
+

--- a/tests/data/test_anndata.py
+++ b/tests/data/test_anndata.py
@@ -444,6 +444,7 @@ def test_anntorchdataset_numpy(adata):
 @dependencies("dask")
 def test_anntorchdataset_dask():
     import dask.array as da
+
     # check that AnnTorchDataset returns numpy array
     adata = synthetic_iid()
     adata.X = da.from_array(adata.X)

--- a/tests/data/test_anndata.py
+++ b/tests/data/test_anndata.py
@@ -12,6 +12,7 @@ import scvi
 from scvi import REGISTRY_KEYS
 from scvi.data import AnnTorchDataset, _constants, synthetic_iid
 from scvi.data.fields import ObsmField, ProteinObsmField
+from scvi.utils import dependencies
 
 from .utils import generic_setup_adata_manager
 
@@ -434,6 +435,20 @@ def test_anntorchdataset_from_manager(adata):
 
 def test_anntorchdataset_numpy(adata):
     # check that AnnTorchDataset returns numpy array
+    adata_manager = generic_setup_adata_manager(adata)
+    bd = AnnTorchDataset(adata_manager)
+    for value in bd[1].values():
+        assert isinstance(value, np.ndarray)
+
+
+@dependencies("dask")
+def test_anntorchdataset_dask():
+    import dask.array as da
+    # check that AnnTorchDataset returns numpy array
+    adata = synthetic_iid()
+    adata.X = da.from_array(adata.X)
+    raw_counts = adata.X.copy()
+    adata.layers["raw"] = raw_counts
     adata_manager = generic_setup_adata_manager(adata)
     bd = AnnTorchDataset(adata_manager)
     for value in bd[1].values():


### PR DESCRIPTION
Dask Array Support has been added to AnnData in the recent years (see e.g. https://anndata.readthedocs.io/en/latest/tutorials/notebooks/anndata_dask_array.html). The commit adds dask array support for the AnnTorchDataset.