### PR TITLE
fix: library_size in totalvi, summary_stats duplicate fields and checkpointing with autotune

### DIFF
--- a/.github/workflows/test_linux_autotune.yml
+++ b/.github/workflows/test_linux_autotune.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel uv
           python -m uv pip install --system "scvi-tools[tests] @ ."
-          python -m pip install "jax[cuda]==0.4.35"
+          python -m pip install "jax[cuda12]==0.4.35"
           python -m pip install nvidia-nccl-cu12
 
       - name: Run pytest

--- a/.github/workflows/test_linux_autotune.yml
+++ b/.github/workflows/test_linux_autotune.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel uv
+          python -m pip install nvidia-nccl-cu12
           python -m uv pip install --system "scvi-tools[tests,cuda] @ ."
 
       - name: Run pytest

--- a/.github/workflows/test_linux_autotune.yml
+++ b/.github/workflows/test_linux_autotune.yml
@@ -51,9 +51,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel uv
-          python -m uv pip install --system "scvi-tools[tests] @ ."
-          python -m pip install "jax[cuda12]==0.4.35"
-          python -m pip install nvidia-nccl-cu12
+          python -m uv pip install --system "scvi-tools[tests,cuda] @ ."
 
       - name: Run pytest
         env:

--- a/.github/workflows/test_linux_cuda.yml
+++ b/.github/workflows/test_linux_cuda.yml
@@ -58,9 +58,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel uv
-          python -m uv pip install --system "scvi-tools[tests] @ ."
-          python -m pip install "jax[cuda12]==0.4.35"
           python -m pip install nvidia-nccl-cu12
+          python -m uv pip install --system "scvi-tools[cuda,tests] @ ."
 
       - name: Run pytest
         env:

--- a/.github/workflows/test_linux_cuda.yml
+++ b/.github/workflows/test_linux_cuda.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel uv
           python -m uv pip install --system "scvi-tools[tests] @ ."
-          python -m pip install "jax[cuda]==0.4.35"
+          python -m pip install "jax[cuda12]==0.4.35"
           python -m pip install nvidia-nccl-cu12
 
       - name: Run pytest

--- a/.github/workflows/test_linux_multigpu.yml
+++ b/.github/workflows/test_linux_multigpu.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel uv
           python -m uv pip install --system "scvi-tools[tests] @ ."
-          python -m pip install "jax[cuda]==0.4.35"
+          python -m pip install "jax[cuda12]==0.4.35"
           python -m pip install nvidia-nccl-cu12
 
       - name: Run pytest

--- a/.github/workflows/test_linux_multigpu.yml
+++ b/.github/workflows/test_linux_multigpu.yml
@@ -51,9 +51,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel uv
-          python -m uv pip install --system "scvi-tools[tests] @ ."
-          python -m pip install "jax[cuda12]==0.4.35"
           python -m pip install nvidia-nccl-cu12
+          python -m uv pip install --system "scvi-tools[cuda,tests] @ ."
 
       - name: Run pytest
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ to [Semantic Versioning]. Full commit history is available in the
 
 #### Added
 
+- Add checkpointing with autotune, {pr}`3452`.
+
 #### Fixed
+
+- fix in library size calculation in totalvi, {pr}`3452`.
 
 #### Changed
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,11 +11,20 @@ For the basic CPU version run:
 ```bash
 pip install -U scvi-tools
 ```
-
 or
-
 ```bash
 conda install scvi-tools -c conda-forge
+```
+
+In order to install scvi-tools with Nvidia GPU CUDA support, for Linux Systems
+(such as Ubuntu or RedHat) use:
+
+```bash
+pip install -U scvi-tools[cuda]
+```
+And for Apple Silicon metal (MPS) support:
+```bash
+pip install -U scvi-tools[metal]
 ```
 
 Don't know how to get started with virtual environments or `conda`/`pip`? Check out the
@@ -55,17 +64,7 @@ an accelerated device, we recommend installing scvi-tools directly and letting t
 be installed automatically by your package manager of choice.
 
 If you plan on taking advantage of an accelerated device (e.g. Nvidia GPU or Apple Silicon),
-which is likely, scvi-tools supports it.
-In order to install scvi-tools with Nvidia GPU CUDA support, for Linux Systems
-(such as Ubuntu or RedHat) use:
-
-```bash
-pip install -U scvi-tools[cuda]
-```
-And for Apple Silicon metal (MPS) support:
-```bash
-pip install -U scvi-tools[metal]
-```
+which is likely, scvi-tools supports it and you should install with the GPU support dependency of scvi-tools.
 
 However, there might be cases where the GPU HW is not supporting the latest installation of PyTorch and Jax.
 In this case we recommend installing PyTorch and JAX _before_ installing scvi-tools.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,8 @@ dependencies = [
     "anndata>=0.11",
     "docrep>=0.3.2",
     "flax",
-    "jax<0.7.0",
-    "jaxlib<0.7.0",
+    "jax==0.4.35",
+    "jaxlib==0.4.34",
     "lightning>=2.0",
     "ml-collections>=0.1.1",
     "mudata>=0.1.2",
@@ -63,7 +63,7 @@ tests = ["pytest", "pytest-pretty", "coverage", "selenium", "scvi-tools[optional
 editing = ["jupyter", "pre-commit"]
 dev = ["scvi-tools[editing,tests]"]
 test = ["scvi-tools[tests]"]
-cuda = ["torchvision", "torchaudio", "jax[cuda12]<0.7.0"]
+cuda = ["torchvision", "torchaudio", "jax[cuda12]==0.4.35"]
 metal = ["torchvision", "torchaudio", "jax-metal"]
 
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,8 @@ dependencies = [
     "anndata>=0.11",
     "docrep>=0.3.2",
     "flax",
-    "jax==0.4.35",
-    "jaxlib==0.4.35",
+    "jax<0.7.0",
+    "jaxlib<0.7.0",
     "lightning>=2.0",
     "ml-collections>=0.1.1",
     "mudata>=0.1.2",
@@ -63,7 +63,7 @@ tests = ["pytest", "pytest-pretty", "coverage", "selenium", "scvi-tools[optional
 editing = ["jupyter", "pre-commit"]
 dev = ["scvi-tools[editing,tests]"]
 test = ["scvi-tools[tests]"]
-cuda = ["torchvision", "torchaudio", "jax[cuda12]==0.4.35"]
+cuda = ["torchvision", "torchaudio", "jax[cuda12]<0.7.0"]
 metal = ["torchvision", "torchaudio", "jax-metal"]
 
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "docrep>=0.3.2",
     "flax",
     "jax==0.4.35",
-    "jaxlib==0.4.34",
+    "jaxlib==0.4.35",
     "lightning>=2.0",
     "ml-collections>=0.1.1",
     "mudata>=0.1.2",

--- a/src/scvi/autotune/_experiment.py
+++ b/src/scvi/autotune/_experiment.py
@@ -289,6 +289,8 @@ class AutotuneExperiment:
         Name of the experiment, used for logging purposes. Defaults to a unique ID.
     logging_dir
         Base directory to store experiment logs. Defaults to :attr:`~scvi.settings.logging_dir`.
+    save_checkpoints
+        If True, checkpoints will be saved and reported to Ray. Default False.
     scheduler_kwargs
         Additional keyword arguments to pass to the scheduler.
     searcher_kwargs
@@ -326,6 +328,7 @@ class AutotuneExperiment:
         resources: dict[Literal["cpu", "gpu", "memory"], float] | None = None,
         name: str | None = None,
         logging_dir: str | None = None,
+        save_checkpoints: bool = False,
         scheduler_kwargs: dict | None = None,
         searcher_kwargs: dict | None = None,
         scib_stage: str | None = "train_end",
@@ -346,6 +349,7 @@ class AutotuneExperiment:
         self.resources = resources
         self.name = name
         self.logging_dir = logging_dir
+        self.save_checkpoints = save_checkpoints
         self.scib_stage = scib_stage
         self.scib_subsample_rows = scib_subsample_rows
         self.scib_indices_list = scib_indices_list
@@ -667,7 +671,9 @@ class AutotuneExperiment:
             {},
         )
 
-        return callback_cls(metrics=self.metrics, on="validation_end", save_checkpoints=False)
+        return callback_cls(
+            metrics=self.metrics, on="validation_end", save_checkpoints=self.save_checkpoints
+        )
 
     @property
     def scib_metrics_callback(self) -> Callback:
@@ -684,7 +690,7 @@ class AutotuneExperiment:
         return callback_cls(
             metrics=self.metrics,
             on=self.scib_stage,
-            save_checkpoints=False,
+            save_checkpoints=self.save_checkpoints,
             num_rows_to_select=self.scib_subsample_rows,
             indices_list=self.scib_indices_list,
         )

--- a/src/scvi/autotune/_tune.py
+++ b/src/scvi/autotune/_tune.py
@@ -29,6 +29,7 @@ def run_autotune(
     resources: dict[Literal["cpu", "gpu", "memory"], float] | None = None,
     experiment_name: str | None = None,
     logging_dir: str | None = None,
+    save_checkpoints: bool = False,
     scheduler_kwargs: dict | None = None,
     searcher_kwargs: dict | None = None,
     scib_stage: str | None = "train_end",
@@ -97,6 +98,8 @@ def run_autotune(
         to the model class name.
     logging_dir
         Base directory to store experiment logs. Defaults to :attr:`~scvi.settings.logging_dir`.
+    save_checkpoints
+        If True, checkpoints will be saved and reported to Ray. Default False.
     scheduler_kwargs
         Additional keyword arguments to pass to the scheduler.
     searcher_kwargs
@@ -147,6 +150,7 @@ def run_autotune(
         resources=resources,
         name=experiment_name,
         logging_dir=logging_dir,
+        save_checkpoints=save_checkpoints,
         scheduler_kwargs=scheduler_kwargs,
         searcher_kwargs=searcher_kwargs,
         scib_stage=scib_stage,

--- a/src/scvi/data/_manager.py
+++ b/src/scvi/data/_manager.py
@@ -385,6 +385,11 @@ class AnnDataManager:
         summary_stats = {}
         for field_registry in registry[_constants._FIELD_REGISTRIES_KEY].values():
             field_summary_stats = field_registry[_constants._SUMMARY_STATS_KEY]
+            for summary_stats_key in list(field_summary_stats.keys()):
+                if summary_stats_key in list(summary_stats.keys()):
+                    raise RuntimeError(
+                        "Trying to set a field that is already existing in model's summary stats"
+                    )
             summary_stats.update(field_summary_stats)
         return attrdict(summary_stats)
 

--- a/src/scvi/model/_totalvi.py
+++ b/src/scvi/model/_totalvi.py
@@ -531,6 +531,7 @@ class TOTALVI(
                     px_scale += generative_outputs["px_"]["rate"].cpu()[..., gene_mask]
                 else:
                     px_scale += generative_outputs["px_"]["scale"].cpu()[..., gene_mask]
+                    px_scale *= library_size
 
                 py_ = generative_outputs["py_"]
                 # probability of background

--- a/tests/autotune/test_tune.py
+++ b/tests/autotune/test_tune.py
@@ -8,7 +8,8 @@ from scvi.model import SCANVI, SCVI, TOTALVI
 
 
 @pytest.mark.autotune
-def test_run_autotune_scvi_basic(save_path: str):
+@pytest.mark.parametrize("save_checkpoints", [True, False])
+def test_run_autotune_scvi_basic(save_path: str, save_checkpoints: bool):
     from ray import tune
     from ray.tune import ResultGrid
 
@@ -33,6 +34,7 @@ def test_run_autotune_scvi_basic(save_path: str):
         },
         num_samples=2,
         seed=0,
+        save_checkpoints=save_checkpoints,
         scheduler="asha",
         searcher="hyperopt",
         ignore_reinit_error=True,

--- a/tests/model/test_totalvi.py
+++ b/tests/model/test_totalvi.py
@@ -772,18 +772,3 @@ def test_totalvi_logits_backwards_compat(save_path: str):
     model.save(model_path, overwrite=True)
     model = TOTALVI.load(model_path, adata)
     assert isinstance(model.module.decoder.activation_function_bg, ExpActivation)
-
-
-# def test_totalvi_old_activation_load(save_path: str):
-#     """See #2913. Check old model saves use the old behavior."""
-#     model_path = "tests/test_data/exp_activation_totalvi"
-#     model = TOTALVI.load(model_path)
-#
-#     assert isinstance(model.module.decoder.activation_function_bg, ExpActivation)
-#     resave_model_path = os.path.join(save_path, "exp_activation_totalvi_re")
-#     model.save(resave_model_path, overwrite=True)
-#     adata = model.adata
-#     del model
-#
-#     model = TOTALVI.load(resave_model_path, adata)
-#     assert isinstance(model.module.decoder.activation_function_bg, ExpActivation)


### PR DESCRIPTION
fix in library size in totalvi, added a check for existing fields in summary_stats and added checkpointing for autotune
close https://github.com/scverse/scvi-tools/issues/1906
close https://github.com/scverse/scvi-tools/issues/1744
close https://github.com/scverse/scvi-tools/issues/2580

