### PR TITLE
update CytoVI docstrings/ fix RTD rendering issues

### DIFF
--- a/src/scvi/external/cytovi/_model.py
+++ b/src/scvi/external/cytovi/_model.py
@@ -301,7 +301,7 @@ class CYTOVI(
         Parameters
         ----------
         %(param_adata)s
-        layer : str, optional
+        layer
             if not `None`, uses this as the key in `adata.layers` for the transformed
             protein expression data.
         %(param_batch_key)s
@@ -309,7 +309,7 @@ class CYTOVI(
         %(param_sample_key)s
         %(param_cat_cov_keys)s
         %(param_cont_cov_keys)s
-        nan_layer : str, optional
+        nan_layer
             Optional layer key containing binary NaN feature mask to handle overlapping
             antibody panels.
         """
@@ -373,43 +373,43 @@ class CYTOVI(
 
         Parameters
         ----------
-        max_epochs : Optional[int], optional
+        max_epochs
             Number of passes through the dataset, by default 1000.
-        lr : float, optional
+        lr
             Learning rate for optimization, by default 1e-3.
-        accelerator : str, optional
+        accelerator
             Accelerator to use for training, by default "auto".
-        devices : Union[int, list[int], str], optional
+        devices
             Devices to use for training, by default "auto".
-        train_size : float, optional
+        train_size
             Size of the training set in the range [0.0, 1.0], by default 0.9.
-        validation_size : Optional[float], optional
+        validation_size
             Size of the test set. If `None`, defaults to 1 - `train_size`. If
             `train_size + validation_size < 1`, the remaining cells belong to a test set.
-        batch_size : int, optional
+        batch_size
             Minibatch size to use during training, by default 128.
-        early_stopping : bool, optional
+        early_stopping
             Whether to perform early stopping with respect to the validation set, by default True.
-        check_val_every_n_epoch : Optional[int], optional
+        check_val_every_n_epoch
             Check validation set every n train epochs. By default, the validation set is not
             checked, unless `early_stopping` is `True` or `reduce_lr_on_plateau` is `True`.
             If either of the latter conditions are met, the validation set is checked
             every epoch.
-        n_steps_kl_warmup : Union[int, None], optional
+        n_steps_kl_warmup
             Number of training steps (minibatches) to scale weight on KL divergences from 0 to 1.
             Only activated when `n_epochs_kl_warmup` is set to None. If `None`, defaults
             to `floor(0.75 * adata.n_obs)`.
-        n_epochs_kl_warmup : Union[int, None], optional
+        n_epochs_kl_warmup
             Number of epochs to scale weight on KL divergences from 0 to 1.
             Overrides `n_steps_kl_warmup` when both are not `None`, by default 400.
-        adversarial_classifier : Optional[bool], optional
+        adversarial_classifier
             Whether to use an adversarial classifier in the latent space. This helps mixing when
             there are missing proteins in any of the batches. Defaults to `True` if missing
             proteins are detected.
-        plan_kwargs : Optional[dict], optional
+        plan_kwargs
             Keyword arguments for the `AdversarialTrainingPlan` class. Keyword arguments passed to
             `train()` will overwrite values present in `plan_kwargs`, when appropriate.
-        early_stopping_patience : Optional[int], optional
+        early_stopping_patience
             Number of epochs to wait before early stopping, by default 30.
         **kwargs
             Other keyword arguments for the `Trainer` class.
@@ -543,12 +543,12 @@ class CYTOVI(
 
         Parameters
         ----------
-        adata : Optional[AnnData], optional
+        adata
             AnnData object with equivalent structure to initial AnnData. If `None`, defaults to the
             AnnData object used to initialize the model.
-        indices : Optional[Sequence[int]], optional
+        indices
             Indices of cells in adata to use. If `None`, all cells are used.
-        transform_batch : Optional[Sequence[Union[Number, str]]], optional
+        transform_batch
             Batch to condition on.
             If transform_batch is:
             - 'all', then the mean across batches is used
@@ -556,35 +556,34 @@ class CYTOVI(
             - int, then batch transform_batch is used.
             This behaviour affects only proteins that are detected across multiple batches.
             Unobserved proteins are decoded in the batch(es), in which they were measured.
-        protein_list : Optional[Sequence[str]], optional
+        protein_list
             Return frequencies of expression for a subset of protein.
             This can save memory when working with large datasets and few proteins are
             of interest.
-        n_samples : int, optional
+        n_samples
             Number of posterior samples to use for estimation.
-        n_samples_overall : int, optional
+        n_samples_overall
             Number of posterior samples to use for estimation. Overrides `n_samples`.
-        weights : Union[Literal["uniform", "importance"], None], optional
+        weights
             Weights to use for sampling. If `None`, defaults to `"uniform"`.
-        batch_size : Optional[int], optional
+        batch_size
             Minibatch size for data loading into model. Defaults to `scvi.settings.batch_size`.
-        return_mean : bool, optional
+        return_mean
             Whether to return the mean of the samples.
-        return_numpy : Optional[bool], optional
+        return_numpy
             Return a :class:`~numpy.ndarray` instead of a :class:`~pandas.DataFrame`. DataFrame
             includes gene names as columns. If either `n_samples=1` or `return_mean=True`,
             defaults to `False`. Otherwise, it defaults to `True`.
-        nan_warning : Optional[bool], optional
+        nan_warning
             Whether to show a warning if missing proteins are detected between batches.
-        **importance_weighting_kwargs : dict
+        **importance_weighting_kwargs
             Additional keyword arguments for importance weighting.
 
         Returns
         -------
-        Union[np.ndarray, pd.DataFrame]
-            If `n_samples` > 1 and `return_mean` is False, then the shape is
-            `(samples, cells, genes)`. Otherwise, shape is `(cells, genes)`. In this case,
-            return type is :class:`~pandas.DataFrame` unless `return_numpy` is True.
+        If `n_samples` > 1 and `return_mean` is False, then the shape is
+        `(samples, cells, genes)`. Otherwise, shape is `(cells, genes)`. In this case,
+        return type is :class:`~pandas.DataFrame` unless `return_numpy` is True.
         """
         adata = self._validate_anndata(adata)
         all_batches = list(np.unique(self.adata_manager.get_from_registry("batch")))
@@ -732,58 +731,57 @@ class CYTOVI(
 
         Parameters
         ----------
-        adata : Optional[AnnData], optional
+        adata
             Annotated data matrix, by default None
-        groupby : Optional[str], optional
+        groupby
             Key in `adata.obs` containing the groups, by default None
-        group1 : Optional[list[str]], optional
+        group1
             List of group names for group 1, by default None
-        group2 : Optional[list[str]], optional
+        group2
             List of group names for group 2, by default None
-        idx1 : Union[list[int], list[bool], str, None], optional
+        idx1
             Indices or boolean mask for group 1, by default None
-        idx2 : Union[list[int], list[bool], str, None], optional
+        idx2
             Indices or boolean mask for group 2, by default None
-        mode : Literal["vanilla", "change"], optional
+        mode
             Differential expression mode, by default "change"
-        test_mode : Literal["two", "three"], optional
+        test_mode
             Test mode for differential expression, by default "two"
-        delta : float, optional
+        delta
             Minimum fold change for differential expression, by default 0.25
-        batch_size : Optional[int], optional
+        batch_size
             Batch size for computation, by default None
-        all_stats : bool, optional
+        all_stats
             Whether to compute all statistics, by default False
-        batch_correction : bool, optional
+        batch_correction
             Whether to perform batch correction, by default False
-        batchid1 : Optional[list[str]], optional
+        batchid1
             List of batch IDs for group 1, by default None
-        batchid2 : Optional[list[str]], optional
+        batchid2
             List of batch IDs for group 2, by default None
-        fdr_target : float, optional
+        fdr_target
             Target false discovery rate, by default 0.05
-        silent : bool, optional
+        silent
             Whether to suppress progress bar and messages, by default False
-        weights : Union[Literal["uniform", "importance"], None], optional
+        weights
             Weights to use for sampling, by default "uniform"
-        filter_outlier_cells : bool, optional
+        filter_outlier_cells
             Whether to filter outlier cells, by default False
-        lfc_clipping : bool, optional
+        lfc_clipping
             Whether to clip log fold change values, by default True
-        clipping_range : tuple, optional
+        clipping_range
             Range for clipping log fold change values, by default (0, 1)
-        balance_samples: Optional[bool], by default None,
+        balance_samples
             Whether to subsample equal amount of cells per sample based on `sample_key`.
             If `None`, defaults to `True` if more than one sample is present in the data.
-        importance_weighting_kwargs : Union[dict, None], optional
+        importance_weighting_kwargs
             Keyword arguments for importance weighting, by default None
         **kwargs
             Additional keyword arguments for differential expression computation
 
         Returns
         -------
-        pd.DataFrame
-            Differential expression DataFrame.
+        Differential expression DataFrame.
         """
         adata = self._validate_anndata(adata)
         col_names = adata.var_names
@@ -979,33 +977,33 @@ class CYTOVI(
 
         Parameters
         ----------
-        adata : AnnData, optional
+        adata
             AnnData object to use. If `None`, defaults to the model's internal AnnData.
-        groupby : str, optional
+        groupby
             Key in `adata.obs` that contains condition or group labels.
             If not provided, returns log-probabilities per sample without aggregation.
-        batch_size : int, default: 128
-            Mini-batch size for computing log-probabilities.
-        downsample_cells : int, optional
+        batch_size
+            Mini-batch size for computing log-probabilities. Default: 128.
+        downsample_cells
             If provided, randomly subsample this many cells before computing
             log-probabilities.
-        dof : float, optional
+        dof
             Degrees of freedom to use in the sampling distribution, if applicable.
-        aggregation_fn : Callable, default: `log_median`
+        aggregation_fn
             Function used to aggregate log-probabilities across samples.
-            Common choices include `log_median` or `logsumexp`.
-        return_log_probs : bool, default: False
+            Common choices include `log_median` or `logsumexp`. Default: `log_median`.
+        return_log_probs
             If `True`, skip aggregation and return per-sample log-probabilities directly.
+            Default: False.
 
         Returns
         -------
-        pd.DataFrame
-            If `return_log_probs=True` or `groupby=None`, returns a DataFrame of
-            shape `(n_cells, n_samples)` containing log-sample-probabilities.
+        If `return_log_probs=True` or `groupby=None`, returns a DataFrame of
+        shape `(n_cells, n_samples)` containing log-sample-probabilities.
 
-            Otherwise, returns a DataFrame of shape `(n_cells, n_conditions)` where
-            each column corresponds to the differential abundance log-ratio for one
-            condition compared to all others.
+        Otherwise, returns a DataFrame of shape `(n_cells, n_conditions)` where
+        each column corresponds to the differential abundance log-ratio for one
+        condition compared to all others.
 
         Examples
         --------
@@ -1061,29 +1059,27 @@ class CYTOVI(
 
         Parameters
         ----------
-        adata_reference : AnnData
+        adata_reference
             Annotated data matrix for the reference dataset. This dataset contains the categories
             to be imputed onto the query data.
-        cat_key : str
+        cat_key
             The key in the `.obs` attribute of `adata_reference` that specifies the categorical
             variable (e.g., cell types or clusters) to impute.
-        use_rep : str, optional
+        use_rep
             The key in the `.obsm` attribute to use as the representation space (e.g., latent
             space). If `None`, the function will attempt to use a default latent
-            representation X_CytoVI.
-        n_neighbors : int, optional (default: 20)
+            representation `X_CytoVI`.
+        n_neighbors
             The number of nearest neighbors to use for imputation. The imputation is based on
-            similarity in the chosen representation space.
-        return_uncertainty : bool, optional (default: False)
+            similarity in the chosen representation space. Default: 20.
+        return_uncertainty
             If `True`, the function will also return the uncertainty of the imputation.
+            Default: False.
 
         Returns
         -------
-        np.ndarray
-            A numpy array of imputed categories for the query dataset, corresponding
-            to the categorical variable
-            specified by `cat_key`.
-        ```
+        Array of imputed categories for the query dataset, corresponding to the categorical
+        variable specified by `cat_key`.
 
         Notes
         -----
@@ -1152,31 +1148,32 @@ class CYTOVI(
         return_query_only: bool = False,
     ):
         """
-        Impute modality expression in query dataset using a reference and shared representation.
+        Impute modality expression in a query dataset using a reference and a shared representation.
 
         Parameters
         ----------
-        reference_batch : str
-            Identifier for the reference batch in `adata.obs[batch_key]`.
-        adata_rna : AnnData
+        reference_batch
+            Identifier for the reference batch in ``adata.obs[batch_key]``.
+        adata_rna
             Annotated data matrix containing the expression data to impute.
-        layer_key : str
-            Key in the `.layers` attribute of `adata_rna` for the reference expression data.
-        use_rep : str, optional
-            Key in the `.obsm` attribute to use as the representation space (e.g., latent space).
-            If `None`, defaults to `X_CytoVI`.
-        n_neighbors : int, optional (default: 20)
-            Number of nearest neighbors to use for imputation.
-        compute_uncertainty : bool, optional (default: False)
-            If `True`, also computes the uncertainty of the imputation.
-        return_query_only : bool, optional (default: False)
-            If `True`, return only the imputed query dataset as an AnnData object.
+        layer_key
+            Key in ``adata_rna.layers`` for the reference expression data.
+        use_rep
+            Key in ``.obsm`` to use as the representation space (e.g., latent space).
+            If ``None``, defaults to ``X_CytoVI``.
+        n_neighbors
+            Number of nearest neighbors to use for imputation. Default: 20.
+        compute_uncertainty
+            If ``True``, also computes the uncertainty of the imputation. Default: False.
+        return_query_only
+            If ``True``, return only the imputed query dataset as an ``AnnData`` object.
+            Default: False.
 
         Returns
         -------
-        AnnData
-            Imputed AnnData object. If `return_query_only` is `True`, only the query dataset is
-              returned. If `return_uncertainty` is `True`, also returns the uncertainty matrix.
+        Imputed ``AnnData`` object. If ``return_query_only`` is ``True``, only the query
+        dataset is returned. If ``compute_uncertainty`` is ``True``, an uncertainty matrix
+        is also returned.
         """
         adata = self.adata
         batch_key = self.batch_key

--- a/src/scvi/external/cytovi/_module.py
+++ b/src/scvi/external/cytovi/_module.py
@@ -23,62 +23,62 @@ class CytoVAE(BaseModuleClass):
 
     Parameters
     ----------
-    n_input : int
+    n_input
         Number of input proteins.
-    n_batch : int, optional
+    n_batch
         Number of batches, if 0, no batch correction is performed. Default is 0.
-    n_labels : int, optional
+    n_labels
         Number of labels. Default is 0.
-    n_hidden : int, optional
+    n_hidden
         Number of nodes per hidden layer. Default is 128.
-    n_latent : int, optional
+    n_latent
         Dimensionality of the latent space. Default is 10.
-    n_layers : int, optional
+    n_layers
         Number of hidden layers used for encoder and decoder NNs. Default is 1.
-    n_continuous_cov : int, optional
+    n_continuous_cov
         Number of continuous covariates. Default is 0.
-    n_cats_per_cov : Optional[Iterable[int]], optional
+    n_cats_per_cov
         Number of categories for each extra categorical covariate. Default is None.
-    dropout_rate : float, optional
+    dropout_rate
         Dropout rate for neural networks. Default is 0.1.
-    log_variational : bool, optional
+    log_variational
         Log(data+1) prior to encoding for numerical stability. Not normalization. Default is False.
-    protein_likelihood : Literal["normal", "beta"], optional
+    protein_likelihood
         One of the following protein likelihood distributions:
         * ``'normal'`` - Normal distribution
         * ``'beta'`` - Beta distribution
         Default is "normal".
-    latent_distribution : Literal["normal", "ln"], optional
+    latent_distribution
         One of the following latent space distributions:
         * ``'normal'`` - Isotropic normal
         * ``'ln'`` - Logistic normal with normal params N(0, 1)
         Default is "normal".
-    encode_covariates : bool, optional
+    encode_covariates
         Whether to concatenate covariates to expression in encoder. Default is False.
-    deeply_inject_covariates : bool, optional
+    deeply_inject_covariates
         Whether to concatenate covariates into output of hidden layers in encoder/decoder.
         This option only applies when `n_layers` > 1. The covariates are concatenated to
         the input of subsequent hidden layers. Default is True.
-    use_batch_norm : Literal["encoder", "decoder", "none", "both"], optional
+    use_batch_norm
         Whether to use batch norm in layers. Default is "both".
-    use_layer_norm : Literal["encoder", "decoder", "none", "both"], optional
+    use_layer_norm
         Whether to use layer norm in layers. Default is "none".
-    var_activation : Optional[Callable], optional
+    var_activation
         Callable used to ensure positivity of the variational distributions' variance.
         When `None`, defaults to `torch.exp`. Default is None.
-    encoder_marker_mask : Optional[list], optional
+    encoder_marker_mask
         List of indices to select specific markers for the encoder. Default is None.
-    extra_encoder_kwargs : Optional[dict], optional
+    extra_encoder_kwargs
         Extra keyword arguments for the encoder. Default is None.
-    extra_decoder_kwargs : Optional[dict], optional
+    extra_decoder_kwargs
         Extra keyword arguments for the decoder. Default is None.
-    scale_activation : Optional[Literal["softplus", None]], optional
+    scale_activation
         Activation function for scaling factors. Default is None.
-    prior_mixture : Optional[bool], optional
+    prior_mixture
         Whether to use a mixture of gaussian prior. Default is True.
-    prior_mixture_k : int, optional
+    prior_mixture_k
         Number of components in the mixture of gaussian prior. Default is 20.
-    prior_label_weight : Optional[int], optional
+    prior_label_weight
         Weight for the prior label. Default is 10.
     """
 
@@ -446,52 +446,50 @@ class CytoVAE(BaseModuleClass):
 class DecoderCytoVI(nn.Module):
     """Decodes data from latent space of ``n_input`` dimensions into ``n_output`` dimensions.
 
-    Uses a fully-connected neural network of ``n_hidden`` layers.
+    Uses a fully connected neural network of ``n_hidden`` layers.
 
     Parameters
     ----------
-    n_input : int
-        The dimensionality of the input (latent space)
-    n_output : int
-        The dimensionality of the output (data space)
-    n_cat_list : Iterable[int], optional
-        A list containing the number of categories for each category of interest. Each category
-        will be included using a one-hot encoding
-    n_layers : int, optional
-        The number of fully-connected hidden layers
-    n_hidden : int, optional
-        The number of nodes per hidden layer
-    inject_covariates : bool, optional
-        Whether to inject covariates in each layer, or just the first (default)
-    use_batch_norm : bool, optional
-        Whether to use batch norm in layers
-    use_layer_norm : bool, optional
-        Whether to use layer norm in layers
-    scale_activation : Literal["softplus", None], optional
-        Activation layer to use for px_rate_decoder
-    protein_likelihood : Literal["normal", "beta"], optional
-        Likelihood function for protein expression
-    decoder_param_eps : float, optional
-        Small epsilon value added to the parameters for numerical stability
+    n_input
+        Dimensionality of the input (latent space).
+    n_output
+        Dimensionality of the output (data space).
+    n_cat_list
+        List of category sizes for each categorical covariate; each is included via one-hot encoding.
+    n_layers
+        Number of fully connected hidden layers. Default: 1.
+    n_hidden
+        Number of nodes per hidden layer. Default: 128.
+    inject_covariates
+        Whether to inject covariates in each layer (``True``) or only in the first layer (``False``). Default: False.
+    use_batch_norm
+        Whether to use batch normalization in layers. Default: False.
+    use_layer_norm
+        Whether to use layer normalization in layers. Default: False.
+    scale_activation
+        Activation used for the scale/rate head (e.g., ``"softplus"`` or ``None``). Default: None.
+    protein_likelihood
+        Likelihood for protein expression (``"normal"`` or ``"beta"``). Default: ``"normal"``.
+    decoder_param_eps
+        Small epsilon added to decoder outputs for numerical stability. Default: 1e-8.
 
     Attributes
     ----------
-    px_decoder : FCLayers
-        Fully-connected layers for decoding the latent space
-    protein_likelihood : Literal["normal", "beta"]
-        Likelihood function for protein expression
-    decoder_param_eps : float
-        Small epsilon value added to the parameters for numerical stability
-    px_param1_decoder : nn.Module
-        Decoder module for the first parameter of the ZINB distribution
-    px_param2_decoder : nn.Module
-        Decoder module for the second parameter of the ZINB distribution
+    px_decoder
+        Fully connected layers that decode the latent space.
+    protein_likelihood
+        Likelihood function used for protein expression.
+    decoder_param_eps
+        Small epsilon added to decoder parameters for numerical stability.
+    px_param1_decoder
+        Decoder module for the first output parameter.
+    px_param2_decoder
+        Decoder module for the second output parameter.
 
     Methods
     -------
     forward(z, *cat_list)
-        Forward computation for a single sample
-
+        Forward computation for a single sample.
     """
 
     def __init__(
@@ -545,15 +543,14 @@ class DecoderCytoVI(nn.Module):
 
         Parameters
         ----------
-        z : torch.Tensor
+        z
             Tensor with shape `(n_input,)`.
-        *cat_list : int
+        *cat_list
             List of category membership(s) for this sample.
 
         Returns
         -------
-        Tuple of torch.Tensor
-            Parameters for the Normal or Beta distribution of protein expression.
+        Parameters for the Normal or Beta distribution of protein expression.
 
         """
         # The decoder returns values for the parameters of the emission distribution

--- a/src/scvi/external/cytovi/_plotting.py
+++ b/src/scvi/external/cytovi/_plotting.py
@@ -25,60 +25,48 @@ def plot_histogram(
     **kwargs,
 ):
     """
-    Create a FacetGrid of histograms for specified markers in AnnData.
+    Create a FacetGrid of histograms for specified markers in an AnnData object.
 
     Parameters
     ----------
-    adata : ad.AnnData
+    adata
         Annotated data matrix.
-
-    marker : Union[str, List[str]], optional
-        Names of markers to plot. 'all' to plot all markers.
-
-    groupby : str, optional
-        Key for grouping or categorizing the data. E.g. key for batch.
-
-    layer_key : str, optional
-        Key for the layer in AnnData.
-
-    downsample : bool, optional
-        Whether to downsample the data if there are too many observations.
-
-    n_obs : int, optional
-        Number of observations to subsample if downsample is True.
-
-    col_wrap : int, optional
-        Number of columns to wrap the plots. If None, it is calculated based on the
-        number of markers.
-
-    tight_layout : bool, optional
-        Whether to use tight layout for the plot.
-
-    save : Union[bool, str], optional
-        If True, the plot is saved as "marker_histogram.png". If a string is provided,
-        the plot is saved with the given filename.
-
-    return_plot : bool, optional
-        Whether to return the FacetGrid object.
-
-    kde_kwargs : dict, optional
-        Additional keyword arguments to pass to Seaborn's kdeplot.
-
-    **kwargs : additional keyword arguments
-        Additional arguments to pass to Seaborn's FacetGrid.
+    marker
+        Marker name or list of marker names to plot. Use ``'all'`` to plot all markers.
+        Default: ``'all'`` uses all variables in ``adata.var_names``.
+    groupby
+        Key in ``adata.obs`` used to group/color the data (e.g., batch or condition).
+        Default: no grouping.
+    layer_key
+        Layer key in ``adata.layers`` to draw values from. Default: use ``X``.
+    downsample
+        Whether to downsample when the number of observations is large. Default: True.
+    n_obs
+        Number of observations to keep if ``downsample`` is True. Default: 10_000.
+    col_wrap
+        Maximum number of columns before wrapping to a new row. If ``None``, chosen
+        automatically based on the number of markers. Default: None.
+    tight_layout
+        Apply a tight layout to the figure. Default: True.
+    save
+        If ``True``, save as ``"marker_histogram.png"``; if a string is provided,
+        use it as the filename. Default: False.
+    return_plot
+        If ``True``, return the ``seaborn.FacetGrid`` object. Default: False.
+    kde_kwargs
+        Additional keyword arguments passed to ``seaborn.kdeplot`` if a density
+        overlay is enabled. Default: ``{}``.
+    **kwargs
+        Additional keyword arguments forwarded to ``seaborn.FacetGrid``.
 
     Returns
     -------
-    None or sns.FacetGrid
-        If return_plot is True, returns the FacetGrid object. Otherwise, returns None.
+    If ``return_plot`` is ``True``, returns the ``seaborn.FacetGrid``; otherwise, nothing.
 
-    Example:
-    ----------
-    # Plot density plots for specific markers
-    cytovi.plot_histogram(adata, marker=['CD3', 'CD4'], group_by='Condition')
-
-    # Plot density plots for all markers
-    cytovi.plot_histogram(adata, marker='all', group_by='Batch')
+    Examples
+    --------
+    >>> cytovi.plot_histogram(adata, marker=['CD3', 'CD4'], groupby='condition')
+    >>> cytovi.plot_histogram(adata, marker='all', groupby='batch')
     """
     import seaborn as sns
 
@@ -157,64 +145,48 @@ def plot_biaxial(
     **kwargs,
 ):
     """
-    Create a PairGrid of biaxial (scatter and density) plots for specified markers in AnnData.
+    Create a PairGrid of biaxial (scatter + optional density) plots for specified markers in an AnnData object.
 
     Parameters
     ----------
-    adata : AnnData
+    adata
         Annotated data matrix.
-
-    marker_x : Union[str, List[str]], optional
-        Variable name(s) to be plotted on the x-axis.
-
-    marker_y : Union[str, List[str]], optional
-        Variable name(s) to be plotted on the y-axis.
-
-    color : str, optional
-        Variable name to be used for coloring the scatter plots.
-
-    n_bins : int, optional
-        Number of levels for density contours in kdeplot.
-
-    layer_key : str, optional
-        Key for the layer in AnnData.
-
-    downsample : bool, optional
-        Whether to downsample the data if there are too many observations.
-
-    n_obs : int, optional
-        Number of observations to keep if downsampling is enabled.
-
-    sample_color_groups : bool, optional
-        Whether to sample observations within each color group if downsampling is enabled.
-
-    save : Union[bool, str], optional
-        If True, save the plot as "marker_histogram.png". If a string is provided, save the
-          plot with the given filename.
-
-    kde : bool, optional
-        Whether to include density contours in the plot.
-
-    kde_kwargs : dict, optional
-        Additional keyword arguments to pass to Seaborn's kdeplot.
-
-    scatter_kwargs : dict, optional
-        Additional keyword arguments to pass to Seaborn's scatterplot.
-
-    **kwargs : additional keyword arguments
-        Additional arguments to pass to Seaborn's PairGrid.
+    marker_x
+        Variable name(s) to plot on the x-axis. A string or a list of marker names.
+    marker_y
+        Variable name(s) to plot on the y-axis. A string or a list of marker names.
+    color
+        Key in ``adata.obs`` used to color points (e.g., batch or condition). Default: no coloring.
+    n_bins
+        Number of contour levels for the KDE density. Default: 10.
+    layer_key
+        Layer key in ``adata.layers`` to draw values from. Default: use ``X``.
+    downsample
+        Whether to downsample when the number of observations is large. Default: True.
+    n_obs
+        Number of observations to keep if ``downsample`` is True. Default: 10_000.
+    sample_color_groups
+        If True and ``color`` is set, sample within each color group. Default: False.
+    save
+        If ``True``, save as ``"marker_biaxial.png"``; if a string is provided, use it as the filename.
+        Default: False.
+    kde
+        Whether to overlay KDE density contours. Default: True.
+    kde_kwargs
+        Additional keyword arguments forwarded to ``seaborn.kdeplot``.
+    scatter_kwargs
+        Additional keyword arguments forwarded to ``seaborn.scatterplot``.
+    **kwargs
+        Additional keyword arguments forwarded to ``seaborn.PairGrid``.
 
     Returns
     -------
-    None
+    No return value; the figure is displayed and optionally saved.
 
-    Example
-    -------
-    # Plot biaxial plots for specific markers
-    cytovi.plot_biaxial(adata, marker_x='CD3', marker_y='CD4', color='Condition')
-
-    # Plot biaxial plots for multiple markers
-    cytovi.plot_biaxial(adata, marker_x=['CD8', 'CD20'], marker_y='CD56', color='batch')
+    Examples
+    --------
+    >>> cytovi.pl.biaxial(adata, marker_x='CD3', marker_y='CD4', color='condition')
+    >>> cytovi.pl.biaxial(adata, marker_x=['CD8', 'CD20'], marker_y='CD56', color='batch')
     """
     import matplotlib.pyplot as plt
     import seaborn as sns

--- a/src/scvi/external/cytovi/_preprocessing.py
+++ b/src/scvi/external/cytovi/_preprocessing.py
@@ -27,25 +27,28 @@ def transform_arcsinh(
     inplace: bool = True,
 ) -> AnnData | None:
     """
-    Apply the arcsinh transformation to the 'raw' layer of an AnnData object.
+    Apply the arcsinh transformation to the raw layer of an AnnData object.
 
     Parameters
     ----------
-        adata (AnnData): The AnnData object to transform.
-        raw_layer_key (str): Key for the raw expression layer in the AnnData object.
-        transformed_layer_key (str): Key for the layer in the AnnData object, where the transformed
-            expression will be saved.
-        global_scaling_factor (float): The global scaling factor to apply.
-        scaling_dict (Optional[Dict[str, float]]): A dictionary of specific scaling factors
-            for markers.
-        transform_scatter (bool): If True, scatter features are omitted from the transformation.
-        inplace (bool): If True, the transformation is applied in place. If False, a new AnnData
-            object is returned.
+    adata
+        AnnData object to transform.
+    raw_layer_key
+        Key for the raw expression layer in the AnnData object.
+    transformed_layer_key
+        Key for the layer where the transformed expression will be saved.
+    global_scaling_factor
+        Global scaling factor to apply.
+    scaling_dict
+        Dictionary of marker-specific scaling factors.
+    transform_scatter
+        If True, scatter features are omitted from the transformation.
+    inplace
+        If True, apply the transformation in place; if False, return a new AnnData.
 
     Returns
     -------
-        Optional[AnnData]: If inplace is False, returns the transformed AnnData object.
-        Otherwise, returns None.
+    If ``inplace`` is False, returns the transformed ``AnnData`` object; otherwise, nothing.
     """
     # check arguments
     validate_layer_key(adata, raw_layer_key)
@@ -101,27 +104,26 @@ def scale(
 
     Parameters
     ----------
-    adata : AnnData
+    adata
         The AnnData object to scale.
-    method : Literal['minmax', 'standard']
-        The scaling method to use. Either 'minmax' or 'standard'.
-    feature_range : Tuple[float, float]
-        The desired range of the scaled data for min-max scaling.
-    transformed_layer_key : str
-        The key of the transformed layer in `adata.layers`.
-    scaled_layer_key : str
-        The key to store the scaled data in `adata.layers`.
-    batch_key : str, optional
-        The key for batch information in `adata.obs`. If provided, scaling is done per batch.
-    feat_eps : float
-        Small epsilon to adjust the feature range and avoid division by zero.
-    inplace : bool
-        If True, the scaling is applied in place. If False, a new AnnData object is returned.
+    method
+        Scaling method: ``'minmax'`` or ``'standard'``.
+    feature_range
+        Desired range for min–max scaling as ``(low, high)``.
+    transformed_layer_key
+        Key of the source (transformed) layer in ``adata.layers``.
+    scaled_layer_key
+        Key to store the scaled data in ``adata.layers``.
+    batch_key
+        Key in ``adata.obs`` for batch labels; if provided, scaling is performed per batch.
+    feat_eps
+        Small epsilon added to the feature range to avoid division by zero.
+    inplace
+        If ``True``, apply in place; if ``False``, return a new ``AnnData``.
 
     Returns
     -------
-    Optional[AnnData]
-        If inplace is False, returns the scaled AnnData object. Otherwise, returns None.
+    If ``inplace`` is ``False``, returns the scaled ``AnnData`` object; otherwise, nothing.
     """
     validate_layer_key(adata, transformed_layer_key)
 
@@ -168,16 +170,18 @@ def register_nan_layer(
 
     Parameters
     ----------
-        adata (AnnData): The AnnData object to process.
-        mask_layer_key (str): The key to store the mask layer in `adata.layers`.
-        scaled_layer_key (str): The key of the scaled layer.
-        inplace (bool): If True, the processing is applied in place. If False, a new
-            AnnData object is returned.
+    adata
+        AnnData object to process.
+    mask_layer_key
+        Key to store the mask layer in ``adata.layers``.
+    scaled_layer_key
+        Key of the scaled layer in ``adata.layers``.
+    inplace
+        If ``True``, apply the processing in place; if ``False``, return a new AnnData.
 
     Returns
     -------
-        Optional[AnnData]: If inplace is False, returns the processed AnnData object.
-        Otherwise, returns None.
+    If ``inplace`` is ``False``, returns the processed ``AnnData`` object; otherwise, nothing.
     """
     validate_layer_key(adata, scaled_layer_key)
 
@@ -208,21 +212,20 @@ def merge_batches(
 
     Parameters
     ----------
-    adata_list : List[AnnData]
+    adata_list
         List of AnnData objects to be merged.
-    mask_layer_key : str, optional
+    mask_layer_key
         The key to store the mask layer in `adata.layers`.
-    batch_key : str, optional
+    batch_key
         The key for the batch information in `adata.obs`.
-    scaled_layer_key : str, optional
+    scaled_layer_key
         The key of the scaled layer.
-    nan_layer_registration : bool, optional
+    nan_layer_registration
         Whether to register a nan layer for imputation of missing proteins.
 
     Returns
     -------
-    AnnData
-        The merged AnnData object.
+    The merged AnnData object.
     """
     # check if there are NaNs before merging and validate layers
     for batch, adata_batch in enumerate(adata_list):
@@ -283,25 +286,24 @@ def subsample(
 
     Parameters
     ----------
-    adata : AnnData
+    adata
         The AnnData object to downsample.
-    n_obs : int, optional
+    n_obs
         The number of observations to downsample to. Default is 10000.
-    random_state : int, optional
+    random_state
         The random state to use for the downsampling. Default is 0.
-    replace : bool, optional
+    replace
         If True, the downsampling is applied with replacement. If False, a new AnnData
         object is returned. Default is False.
-    groupby : str, optional
+    groupby
         The column name in `adata.obs` to group the observations by. Default is None.
-    n_obs_group : int, optional
+    n_obs_group
         The number of observations to downsample to within each group. If not provided,
           it is calculated as `n_obs` divided by the number of unique groups. Default is None.
 
     Returns
     -------
-    AnnData or None
-        If `replace` is False, returns the downsampled AnnData object. Otherwise, returns None.
+    If `replace` is False, returns the downsampled AnnData object. Otherwise, returns None.
 
     Raises
     ------
@@ -364,21 +366,20 @@ def mask_markers(
 
     Parameters
     ----------
-    adata : AnnData
+    adata
         The AnnData object to mask markers in.
-    markers : Union[str, list[str]]
+    markers
         The marker(s) to be masked. Can be a single marker as a string or a list of markers.
-    batch_key : str, optional
+    batch_key
         The key in `adata.obs` that represents the batch information, by default 'batch'.
-    masked_batch : str, optional
+    masked_batch
         The batch in which the marker(s) should be masked, by default '1'.
-    nan_layer_registration : bool, optional
+    nan_layer_registration
         Whether to register a nan layer for imputation of missing proteins, by default True.
 
     Returns
     -------
-    AnnData
-        The masked AnnData object.
+    The masked AnnData object.
     """
     adata_list = []
     idx = adata.obs_names

--- a/src/scvi/external/cytovi/_read_write.py
+++ b/src/scvi/external/cytovi/_read_write.py
@@ -27,23 +27,25 @@ def read_fcs(
 
     Parameters
     ----------
-    path : str
+    path
         Path to a single `.fcs` file or a directory containing `.fcs` files.
-    return_raw_layer : bool, optional (default: True)
+    return_raw_layer
         Whether to store the untransformed data in the `.layers["raw"]` slot of each AnnData
-        object.
-    include_hidden : bool, optional (default: False)
+        object. Default: True.
+    include_hidden
         Whether to include hidden/system files (i.e., those beginning with a period).
-    remove_markers : list of str, optional (default: None)
+        Default: False.
+    remove_markers
         List of marker names (columns in `.var_names`) to remove from each file.
-        Markers not found in the file will be skipped with a warning.
-    sample_name_extractor : dict, optional (default: None)
+        Markers not found in the file will be skipped with a warning. Default: None.
+    sample_name_extractor
         Dictionary with format `{"split": str, "index": int}`.
         Splits the filename by the provided delimiter and extracts the sample name
         from the specified index position. Example:
         `{"split": "_", "index": 0}` will extract `"sample1"` from `"sample1_batchA.fcs"`.
-    verbose : bool, optional (default: True)
-        Whether to print progress and warning messages.
+        Default: None.
+    verbose
+        Whether to print progress and warning messages. Default: True.
 
     Returns
     -------
@@ -141,22 +143,23 @@ def write_fcs(
 
     Parameters
     ----------
-    adata : AnnData
+    adata
         Annotated data matrix, where `adata.X` or `adata.layers[layer]` contains the expression
         data to be written to FCS format.
-    output_path : str, optional
+    output_path
         Directory where the FCS files will be written. If `None`, uses the current working
         directory.
-    split_by : str, optional
+    split_by
         Column in `adata.obs` to group cells by. If specified, an FCS file will be written for
         each group. If not provided, a single FCS file is written using all cells.
-    layer : str, optional
+    layer
         Layer in `adata.layers` to use as the data source. If `None`, uses `adata.X`.
-    prefix : str, default: "export"
-        Prefix for the output FCS file names.
-    verbose : bool, default: True
+    prefix
+        Prefix for the output FCS file names. Default: "export".
+    verbose
         If `True`, prints a message for each written file including the output path and data shape.
-    write_kwargs : dict, optional
+        Default: True.
+    write_kwargs
         Additional keyword arguments to pass to `fcswrite.write_fcs`. This can include
         parameters like `text_kw_pr` for custom text annotations in the FCS file.
 
@@ -176,7 +179,7 @@ def write_fcs(
     - This function automatically removes rows with any NaN values before writing to FCS.
     - Data is cast to `float32` before writing.
     - Only `.X` or `.layers[layer]` is written; metadata from `obs` or `var` is not exported
-    to FCS.
+      to FCS.
 
     Examples
     --------


### PR DESCRIPTION
Parameters blocks:
	•	Removed type hints and trailing colons
	•	Kept defaults in prose (e.g., “Default: 20”).
	•	Used backticks for keys/paths (e.g., adata.obs['batch'], X_CytoVI).

Returns sections:
	•	Uniform prose format.
	•	Clarified shapes/behaviors where helpful; no API changes.

Warns/Raises/Notes/Examples:
	•	Standardized headings and wording.

Minor cleanups:
	•	Fixed a couple of param-name mentions in text to match actual arguments.
	•	Terminology changes.