### PR TITLE
🐛 fix: set LD_LIBRARY_PATH for Kubernetes GPU compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM nvidia/cuda:12.4.0-runtime-ubuntu22.04
 FROM python:3.12 AS base
 
+ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/usr/local/nvidia/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+
 RUN pip install --no-cache-dir uv
 
 RUN uv pip install --system --no-cache torch torchvision torchaudio


### PR DESCRIPTION
On Kubernetes (GKE, EKS, AKS), the NVIDIA device plugin allocates GPUs via CDI and does not set NVIDIA_VISIBLE_DEVICES. Without it, the nvidia-container-runtime skips libcuda.so injection, causing torch.cuda.is_available() to return False even when a GPU is allocated.

GKE always mounts driver libraries at /usr/local/nvidia/lib64 regardless. Setting LD_LIBRARY_PATH to include that path lets PyTorch find libcuda.so without relying on runtime injection.

The existing value is preserved so HPC module systems (which manage their own LD_LIBRARY_PATH via `module load cuda`) are not affected.

An alternative fix is to rebase the image on nvidia/cuda:12.x-runtime-*
instead of python:3.12. NVIDIA base images set LD_LIBRARY_PATH and
NVIDIA_DRIVER_CAPABILITIES correctly out of the box, making the container
work on Kubernetes without any workaround.

To reproduce: 
Run scvi-tools on GKE with nvidia.com/gpu: 1 — model.to_device(0)
raises RuntimeError: Found no NVIDIA driver on your system.
Works on local Docker because --gpus all bypasses the CDI mechanism.