### PR TITLE
ci: bump codecov-action to v6 and fail CI on upload error

### DIFF
--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -56,7 +56,8 @@ jobs:
           coverage run -m pytest -v --color=yes
           coverage report
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
         with:
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: integration

--- a/.github/workflows/test_linux_autotune.yml
+++ b/.github/workflows/test_linux_autotune.yml
@@ -67,7 +67,8 @@ jobs:
           coverage run -m pytest -v --color=yes --autotune-tests --accelerator cuda --devices auto
           coverage report
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
         with:
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: autotune

--- a/.github/workflows/test_linux_cuda.yml
+++ b/.github/workflows/test_linux_cuda.yml
@@ -71,7 +71,8 @@ jobs:
           coverage run -m pytest -v --color=yes --accelerator cuda --devices auto
           coverage report
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
         with:
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: cuda

--- a/.github/workflows/test_linux_custom_dataloader.yml
+++ b/.github/workflows/test_linux_custom_dataloader.yml
@@ -67,7 +67,8 @@ jobs:
           coverage run -m pytest -v --color=yes --custom-dataloader-tests
           coverage report
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
         with:
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: custom_dataloader

--- a/.github/workflows/test_linux_internet.yml
+++ b/.github/workflows/test_linux_internet.yml
@@ -70,7 +70,8 @@ jobs:
           coverage run -m pytest -v --color=yes --internet-tests
           coverage report
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
         with:
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: internet

--- a/.github/workflows/test_linux_jax.yml
+++ b/.github/workflows/test_linux_jax.yml
@@ -69,7 +69,8 @@ jobs:
           coverage run -m pytest -v --color=yes --jax
           coverage report
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
         with:
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: jax

--- a/.github/workflows/test_linux_mlflow.yml
+++ b/.github/workflows/test_linux_mlflow.yml
@@ -66,7 +66,8 @@ jobs:
           coverage run -m pytest -v --color=yes --mlflow-tests --accelerator cuda --devices auto
           coverage report
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
         with:
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: mlflow

--- a/.github/workflows/test_linux_multigpu.yml
+++ b/.github/workflows/test_linux_multigpu.yml
@@ -64,7 +64,8 @@ jobs:
           coverage run -m pytest -v --color=yes --multigpu-tests --accelerator cuda --devices auto
           coverage report
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
         with:
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: multigpu

--- a/.github/workflows/test_linux_nonjax.yml
+++ b/.github/workflows/test_linux_nonjax.yml
@@ -70,7 +70,8 @@ jobs:
           coverage run -m pytest -v --color=yes --ignore=tests/model/test_jaxscvi.py --ignore=tests/external/mrvi_jax/test_jaxmrvi_components.py --ignore=tests/external/tangram/test_tangram.py
           coverage report
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
         with:
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: nonjax

--- a/.github/workflows/test_linux_optional.yml
+++ b/.github/workflows/test_linux_optional.yml
@@ -69,7 +69,8 @@ jobs:
           coverage run -m pytest -v --color=yes --optional
           coverage report
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
         with:
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: optional

--- a/.github/workflows/test_linux_private.yml
+++ b/.github/workflows/test_linux_private.yml
@@ -77,7 +77,8 @@ jobs:
           coverage run -m pytest -v --color=yes --private
           coverage report
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
         with:
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: private

--- a/.github/workflows/test_linux_resolution.yml
+++ b/.github/workflows/test_linux_resolution.yml
@@ -66,7 +66,8 @@ jobs:
           coverage run -m pytest -v --color=yes
           coverage report
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
         with:
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: resolution

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -70,7 +70,8 @@ jobs:
           coverage run -m pytest -v --color=yes
           coverage report
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
         with:
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: macos

--- a/.github/workflows/test_macos_mps.yml
+++ b/.github/workflows/test_macos_mps.yml
@@ -74,7 +74,8 @@ jobs:
           coverage run -m pytest -v --color=yes --accelerator mps --devices auto
           coverage report
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
         with:
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: mps

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -66,7 +66,8 @@ jobs:
           coverage run -m pytest -v --color=yes
           coverage report
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
         with:
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: windows


### PR DESCRIPTION
Two changes to every codecov upload step in this repo:

1. **codecov-action -> `@v6`.** Versions below 6.0.2 verify the codecov CLI binary against Codecov's old Keybase key, which they bricked after migrating accounts, so uploads now fail with `Could not verify signature`. `@v6` (= 6.0.2) ships the updated key.
2. **`fail_ci_if_error: true`.** Matches the `cookiecutter-scverse` template default so a broken upload fails CI loudly instead of passing silently.

Ref: https://github.com/codecov/codecov-action/issues/1956