### PR TITLE
Fix: scArches query mapping for models using a batch embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ to [Semantic Versioning]. The full commit history is available in the [commit lo
 
 - Fix list of metrics to be recorded in {class}`scvi.autotune.AutotuneExperiment`, {pr}`3816`.
 - Fix {class}`scvi.external.RESOLVI` preparing data for every load, {pr}`3887`.
+- Fix scArches query mapping for models using a batch embedding, {pr}`3879`.
 
 #### Changed
 

--- a/src/scvi/external/scviva/_module.py
+++ b/src/scvi/external/scviva/_module.py
@@ -114,7 +114,7 @@ class nicheVAE(VAE):
         layers in the encoder(s) (if ``encoder_covariates`` is ``True``) and the decoder prior to
         passing through the next layer.
     batch_representation
-        ``EXPERIMENTAL`` Method for encoding batch information. One of the following:
+        Method for encoding batch information. One of the following:
 
         * ``"one-hot"``: represent batches with one-hot encodings.
         * ``"embedding"``: represent batches with continuously-valued embeddings using
@@ -256,12 +256,8 @@ class nicheVAE(VAE):
         self.prior_mixture = prior_mixture
         self.semisupervised = semisupervised
 
-        self.batch_representation = batch_representation
         if self.batch_representation == "embedding":
-            self.init_embedding(REGISTRY_KEYS.BATCH_KEY, n_batch, **(batch_embedding_kwargs or {}))
             batch_dim = self.get_embedding(REGISTRY_KEYS.BATCH_KEY).embedding_dim
-        elif self.batch_representation != "one-hot":
-            raise ValueError("`batch_representation` must be one of 'one-hot', 'embedding'.")
 
         use_batch_norm_encoder = use_batch_norm == "encoder" or use_batch_norm == "both"
         use_batch_norm_decoder = use_batch_norm == "decoder" or use_batch_norm == "both"

--- a/src/scvi/model/base/_archesmixin.py
+++ b/src/scvi/model/base/_archesmixin.py
@@ -439,7 +439,7 @@ def _set_params_online_update(
             and "decoder" in key
             and (not freeze_batchnorm_decoder)
         )
-        six = f"_embeddings_dict.{REGISTRY_KEYS.BATCH_KEY}" in key
+        six = "_embeddings_dict." in key
         if one or two or three or four or five or six:
             return True
         else:

--- a/src/scvi/model/base/_archesmixin.py
+++ b/src/scvi/model/base/_archesmixin.py
@@ -439,7 +439,8 @@ def _set_params_online_update(
             and "decoder" in key
             and (not freeze_batchnorm_decoder)
         )
-        if one or two or three or four or five:
+        six = f"_embeddings_dict.{REGISTRY_KEYS.BATCH_KEY}" in key
+        if one or two or three or four or five or six:
             return True
         else:
             return False

--- a/src/scvi/model/base/_embedding_mixin.py
+++ b/src/scvi/model/base/_embedding_mixin.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 class EmbeddingMixin:
-    """``EXPERIMENTAL`` Mixin class for initializing and using embeddings in a model.
+    """Mixin class for initializing and using embeddings in a model.
 
     Must be used with a module that inherits from :class:`~scvi.module.base.EmbeddingModuleMixin`.
 

--- a/src/scvi/module/_vae.py
+++ b/src/scvi/module/_vae.py
@@ -84,7 +84,7 @@ class VAE(EmbeddingModuleMixin, BaseMinifiedModeModuleClass):
         layers in the encoder(s) (if ``encoder_covariates`` is ``True``) and the decoder prior to
         passing through the next layer.
     batch_representation
-        ``EXPERIMENTAL`` Method for encoding batch information. One of the following:
+        Method for encoding batch information. One of the following:
 
         * ``"one-hot"``: represent batches with one-hot encodings.
         * ``"embedding"``: represent batches with continuously-valued embeddings using

--- a/src/scvi/module/base/_embedding_mixin.py
+++ b/src/scvi/module/base/_embedding_mixin.py
@@ -6,7 +6,7 @@ from scvi.nn import Embedding
 
 
 class EmbeddingModuleMixin:
-    """``EXPERIMENTAL`` Mixin class for initializing and using embeddings in a module."""
+    """Mixin class for initializing and using embeddings in a module."""
 
     @property
     def embeddings_dict(self) -> ModuleDict:

--- a/src/scvi/nn/_embedding.py
+++ b/src/scvi/nn/_embedding.py
@@ -27,7 +27,7 @@ def _partial_freeze_hook_factory(freeze: int) -> Callable[[torch.Tensor], torch.
 
 
 class Embedding(nn.Embedding):
-    """``EXPERIMENTAL`` Embedding layer with utility methods for extending."""
+    """`Embedding layer with utility methods for extending."""
 
     @classmethod
     def extend(

--- a/tests/external/scviva/test_scviva.py
+++ b/tests/external/scviva/test_scviva.py
@@ -5,6 +5,7 @@ import pytest
 from anndata import AnnData
 from sklearn.gaussian_process import GaussianProcessClassifier
 
+import scvi
 from scvi.data import synthetic_iid
 from scvi.external import SCVIVA
 from scvi.external.scviva.differential_expression import DifferentialExpressionResults
@@ -418,6 +419,51 @@ def test_scviva_scarches_same_features(split_ref_query_adata):
         ).shape[0]
         == query_adata.shape[0]
     )
+
+
+def test_scviva_scarches_batch_embedding(split_ref_query_adata):
+    """scArches with batch_representation='embedding':
+    batch embedding must have requires_grad=True."""
+    ref_adata, query_adata = split_ref_query_adata
+
+    SCVIVA.preprocessing_anndata(ref_adata, k_nn=K_NN, **setup_kwargs)
+    SCVIVA.setup_anndata(ref_adata, layer="counts", batch_key="batch", **setup_kwargs)
+
+    nichevae = SCVIVA(
+        ref_adata,
+        prior_mixture=False,
+        semisupervised=True,
+        linear_classifier=True,
+        batch_representation="embedding",
+    )
+    nichevae.train(
+        max_epochs=N_EPOCHS_SCVIVA,
+        train_size=0.8,
+        validation_size=0.2,
+        early_stopping=True,
+        check_val_every_n_epoch=1,
+        accelerator="cpu",
+    )
+
+    nichevae.preprocessing_query_anndata(
+        query_adata, reference_model=nichevae, k_nn=K_NN, **setup_kwargs
+    )
+    query_nichevae = nichevae.load_query_data(query_adata, reference_model=nichevae)
+
+    emb = query_nichevae.module.get_embedding(scvi.REGISTRY_KEYS.BATCH_KEY)
+    assert emb.weight.requires_grad, "batch embedding must be trainable during scArches surgery"
+
+    query_nichevae.train(
+        max_epochs=N_EPOCHS_SCVIVA,
+        train_size=0.8,
+        validation_size=0.2,
+        early_stopping=True,
+        check_val_every_n_epoch=1,
+        accelerator="cpu",
+    )
+
+    assert query_nichevae.get_latent_representation(query_adata).shape[0] == query_adata.n_obs
+    assert query_nichevae.get_latent_representation(ref_adata).shape[0] == ref_adata.n_obs
 
 
 @pytest.mark.parametrize("dispersion", ["gene", "gene-batch", "gene-label", "gene-cell"])

--- a/tests/model/test_scvi.py
+++ b/tests/model/test_scvi.py
@@ -1175,19 +1175,12 @@ def _scvi_query_to_reference(**model_kwargs):
 
 @pytest.mark.parametrize("batch_representation", ["one-hot", "embedding"])
 def test_scvi_query_to_reference_mapping(batch_representation):
-    """scArches keeps the reference latent intact while updating the query, for both one-hot and
-    embedding batch representations. The embedding case relies on the freezable-embedding handling
-    in :class:`~scvi.model.base.ArchesMixin` / :class:`~scvi.nn.Embedding`."""
+    """scArches keeps the reference latent intact while updating the query."""
     reference_change, query_change, transfer = _scvi_query_to_reference(
         batch_representation=batch_representation
     )
     assert reference_change < 1e-4  # reference latent intact (frozen path)
     assert query_change > 1e-3  # query latent updated by transfer training
-
-    if batch_representation == "embedding":
-        emb = transfer.module.get_embedding(scvi.REGISTRY_KEYS.BATCH_KEY)
-        assert emb.weight.requires_grad  # re-enabled so the new query row can train
-        assert emb.num_embeddings == 3  # grew by the new query batch
 
 
 def test_scvi_query_to_reference_freezes_reference_embedding_rows():

--- a/tests/model/test_scvi.py
+++ b/tests/model/test_scvi.py
@@ -1145,6 +1145,77 @@ def test_scvi_online_update(save_path):
     model3.get_latent_representation()
 
 
+def _scvi_query_to_reference(**model_kwargs):
+    """scArches query->reference run; returns (reference_change, query_change, transfer_model).
+
+    Holds out ``batch_0`` as a new query batch, trains the reference, transfers via
+    ``load_query_data`` and finetunes the query twice, measuring how much the reference and query
+    latent representations move. ``encode_covariates=True`` makes the batch affect the latent.
+    """
+    adata = synthetic_iid(n_batches=3)
+    ref = adata[adata.obs["batch"] != "batch_0"].copy()
+    query = adata[adata.obs["batch"] == "batch_0"].copy()
+
+    SCVI.setup_anndata(ref, batch_key="batch", labels_key="labels")
+    model = SCVI(ref, n_latent=8, encode_covariates=True, **model_kwargs)
+    model.train(max_epochs=2, batch_size=ref.n_obs)
+    latent_reference = model.get_latent_representation(ref)
+
+    SCVI.prepare_query_anndata(query, model)
+    transfer = SCVI.load_query_data(query, model)
+    train_kwargs = {"plan_kwargs": {"lr": 0.1, "weight_decay": 0.0}}
+    transfer.train(max_epochs=2, batch_size=query.n_obs, **train_kwargs)
+    latent_query = transfer.get_latent_representation(query)
+    transfer.train(max_epochs=2, batch_size=query.n_obs, **train_kwargs)
+
+    reference_change = np.sum((latent_reference - transfer.get_latent_representation(ref)) ** 2)
+    query_change = np.sum((latent_query - transfer.get_latent_representation(query)) ** 2)
+    return reference_change, query_change, transfer
+
+
+@pytest.mark.parametrize("batch_representation", ["one-hot", "embedding"])
+def test_scvi_query_to_reference_mapping(batch_representation):
+    """scArches keeps the reference latent intact while updating the query, for both one-hot and
+    embedding batch representations. The embedding case relies on the freezable-embedding handling
+    in :class:`~scvi.model.base.ArchesMixin` / :class:`~scvi.nn.Embedding`."""
+    reference_change, query_change, transfer = _scvi_query_to_reference(
+        batch_representation=batch_representation
+    )
+    assert reference_change < 1e-4  # reference latent intact (frozen path)
+    assert query_change > 1e-3  # query latent updated by transfer training
+
+    if batch_representation == "embedding":
+        emb = transfer.module.get_embedding(scvi.REGISTRY_KEYS.BATCH_KEY)
+        assert emb.weight.requires_grad  # re-enabled so the new query row can train
+        assert emb.num_embeddings == 3  # grew by the new query batch
+
+
+def test_scvi_query_to_reference_freezes_reference_embedding_rows():
+    """With ``batch_representation="embedding"``, scArches freezes the reference embedding rows and
+    trains only the newly added (query) row."""
+    adata = synthetic_iid(n_batches=3)
+    ref = adata[adata.obs["batch"] != "batch_0"].copy()
+    query = adata[adata.obs["batch"] == "batch_0"].copy()
+    SCVI.setup_anndata(ref, batch_key="batch", labels_key="labels")
+    model = SCVI(ref, n_latent=8, encode_covariates=True, batch_representation="embedding")
+    model.train(max_epochs=2, batch_size=ref.n_obs)
+    n_old = model.summary_stats.n_batch
+
+    SCVI.prepare_query_anndata(query, model)
+    transfer = SCVI.load_query_data(query, model)
+    emb = transfer.module.get_embedding(scvi.REGISTRY_KEYS.BATCH_KEY)
+    assert emb.num_embeddings == n_old + 1
+    assert emb.weight.requires_grad
+
+    before = emb.weight.detach().clone()
+    transfer.train(
+        max_epochs=3, batch_size=query.n_obs, plan_kwargs={"lr": 0.1, "weight_decay": 0.0}
+    )
+    after = emb.weight.detach()
+    assert ((after[:n_old] - before[:n_old]) ** 2).sum().item() < 1e-8  # reference rows frozen
+    assert ((after[n_old:] - before[n_old:]) ** 2).sum().item() > 1e-3  # new query row updated
+
+
 def test_scvi_library_size_update(save_path):
     n_latent = 5
     adata1 = synthetic_iid()


### PR DESCRIPTION
# Summary
In scArches query-to-reference mapping (load_query_data), when the reference model was trained with batch_representation="embedding", the query latent never moved during surgery. One-hot batches were unaffected.

# New Tests

- test_scvi_query_to_reference_mapping: makes sure reference latent stays intact (<1e-4) while the query latent updates (>1e-3); the embedding case asserts the batch embedding grew and is trainable.

- test_scvi_query_to_reference_freezes_reference_embedding_rows: For models with batch embedding, this ensures the reference embedding rows (weights) remain frozen (<1e-8) and only the new query row updates (>1e-3). This test can be removed as it relies on too many implementation details.

# Fix
This fixes it with a one-line change to the online-update freezing logic.

# Details (Root Cause)
During surgery, _set_params_online_update freezes the whole network except a small allow-list of parameters (requires_grad=True only for first-layer FC weights, batchnorm under certain options, etc.). The batch embedding parameter (_embeddings_dict.batch.weight) wasn't on that allow-list, so it was frozen entirely — including the newly added row for the query batch. With that row frozen, the query batch had no learnable representation and the query latent stayed fixed.

# Important note
If a query dataset also contains reference batch categories, those reference embedding rows would receive a gradient. This can also be fixed with a few more lines of code.