### PR TITLE
fix(resolvi): reduce peak memory during RESOLVI.load()

### DIFF
--- a/src/scvi/external/resolvi/_model.py
+++ b/src/scvi/external/resolvi/_model.py
@@ -355,7 +355,13 @@ class RESOLVI(
         if prepare_data:
             if prepare_data_kwargs is None:
                 prepare_data_kwargs = {}
-            RESOLVI._prepare_data(adata, batch_key=batch_key, **prepare_data_kwargs)
+            neighbors_valid = (
+                "index_neighbor" in adata.obsm
+                and "distance_neighbor" in adata.obsm
+                and int(adata.obsm["index_neighbor"].max()) < adata.n_obs
+            )
+            if not neighbors_valid:
+                RESOLVI._prepare_data(adata, batch_key=batch_key, **prepare_data_kwargs)
 
         anndata_fields = [
             LayerField(REGISTRY_KEYS.X_KEY, layer, is_count_data=True),

--- a/src/scvi/external/resolvi/_module.py
+++ b/src/scvi/external/resolvi/_module.py
@@ -1322,3 +1322,16 @@ class RESOLVAE(PyroBaseModuleClass):
             "name": "obs_plate",
             "event_dim": 1,
         }
+
+    def on_load(self, model, **kwargs):
+        """Load Pyro param store directly without a training step.
+
+        RESOLVAE uses a manually-written guide with statically known parameter
+        names and shapes, so ``pyro.get_param_store().set_state()`` is
+        self-contained and does not require a prior forward pass to register
+        parameter shapes.  Skipping ``train(max_steps=1)`` avoids loading the
+        full dataset into memory during ``RESOLVI.load()``.
+        """
+        pyro.clear_param_store()
+        if kwargs.get("pyro_param_store") is not None:
+            pyro.get_param_store().set_state(kwargs["pyro_param_store"])


### PR DESCRIPTION
## Problem

Addresses  #3674

`RESOLVI.load()` consumed significantly more RAM than training, causing OOM on large datasets (e.g., 200k cells Xenium). Two sources of unnecessary memory allocation were identified:

## Root Causes & Fixes

### Fix 1: `setup_anndata()` re-ran `_prepare_data()` on every load

During `load()`, `setup_anndata()` is called with the original saved arguments (`prepare_data=True`). This re-ran `_prepare_data()` even when `index_neighbor` and `distance_neighbor` already existed in `adata.obsm`, causing:
- A full `adata.copy()` of all cells
- `sc.pp.neighbors()` recomputation on the full dataset

**Fix:** Skip `_prepare_data()` when neighbors are already valid (keys exist and indices are within bounds of the current adata).

### Fix 2: `on_load()` ran `train(max_steps=1)` unnecessarily

The generic `PyroBaseModuleClass.on_load()` runs `model.train(max_steps=1)` to initialize Pyro param shapes before restoring the saved param store. However, `RESOLVAE` uses a manually-written guide with statically known parameter names and shapes — `pyro.get_param_store().set_state()` is self-contained and does not require a prior forward pass.

**Fix:** Add a lightweight `on_load()` to `RESOLVAE` that directly restores the Pyro param store without a training step.

## Verification

Tested with synthetic data (20k cells × 2k genes):

| Version | tracemalloc peak |
|---|---:|
| Original | 0.109 GB |
| Patched | 0.036 GB |

- tracemalloc peak allocation reduced by **66%**
- Unnecessary `train(max_steps=1)` call eliminated during load
- All existing RESOLVI tests pass (14/14)
- Latent representations are identical before and after load

> **Note:** RSS-level difference requires 100k+ cells to be measurable. Full memory validation with the original reporter's Xenium dataset (200k cells) is recommended to confirm complete OOM resolution.