### PR TITLE
docs: render de_silent docstring placeholder in model methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ to [Semantic Versioning]. The full commit history is available in the [commit lo
     literally in several public model methods (e.g.
     {meth}`~scvi.model.SCVI.get_normalized_expression`,
     {meth}`~scvi.model.TOTALVI.get_protein_foreground_probability`) by applying the
-    missing `de_dsp` docstring processor, {pr}`XXXX`.
+    missing `de_dsp` docstring processor, {pr}`3921`.
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ to [Semantic Versioning]. The full commit history is available in the [commit lo
 
 #### Fixed
 
+- Fix unsubstituted `%(de_silent)s` docstring template placeholders being rendered
+    literally in several public model methods (e.g.
+    {meth}`~scvi.model.SCVI.get_normalized_expression`,
+    {meth}`~scvi.model.TOTALVI.get_protein_foreground_probability`) by applying the
+    missing `de_dsp` docstring processor, {pr}`XXXX`.
+
 #### Changed
 
 #### Removed

--- a/src/scvi/external/contrastivevi/_model.py
+++ b/src/scvi/external/contrastivevi/_model.py
@@ -33,7 +33,7 @@ from scvi.model.base._de_core import _de_core
 from scvi.train import TrainingPlan, TrainRunner
 from scvi.train._config import merge_kwargs
 from scvi.utils import setup_anndata_dsp, track
-from scvi.utils._docstrings import devices_dsp
+from scvi.utils._docstrings import de_dsp, devices_dsp
 
 from ._contrastive_data_splitting import ContrastiveDataSplitter
 from ._module import ContrastiveVAE
@@ -320,6 +320,7 @@ class ContrastiveVI(BaseModelClass):
             latent += [latent_sample.detach().cpu()]
         return torch.cat(latent).numpy()
 
+    @de_dsp.dedent
     @torch.inference_mode()
     def get_normalized_expression(
         self,

--- a/src/scvi/external/mrvi/_model.py
+++ b/src/scvi/external/mrvi/_model.py
@@ -1861,6 +1861,7 @@ class MRVI(
         obs_df = obs_df.loc[~obs_df._scvi_sample.duplicated("first")]
         self.sample_info = obs_df.set_index("_scvi_sample").sort_index()
 
+    @de_dsp.dedent
     @torch.inference_mode()
     def get_normalized_expression(
         self,

--- a/src/scvi/external/resolvi/_utils.py
+++ b/src/scvi/external/resolvi/_utils.py
@@ -11,7 +11,7 @@ from pyro import infer
 
 from scvi import settings
 from scvi.model._utils import _get_batch_code_from_category, parse_device_args
-from scvi.utils import track
+from scvi.utils import de_dsp, track
 
 logger = logging.getLogger(__name__)
 
@@ -95,6 +95,7 @@ class ResolVIPredictiveMixin:
             else torch.cat(latent).numpy()
         )
 
+    @de_dsp.dedent
     @torch.inference_mode()
     def get_normalized_expression_importance(
         self,
@@ -265,6 +266,7 @@ class ResolVIPredictiveMixin:
         else:
             return exprs
 
+    @de_dsp.dedent
     @torch.inference_mode()
     def get_normalized_expression(
         self,

--- a/src/scvi/model/_multivi.py
+++ b/src/scvi/model/_multivi.py
@@ -619,6 +619,7 @@ class MULTIVI(
                     else adata[adata.mod_names[1]].var_names[: self.n_regions][region_mask],
                 )
 
+    @de_dsp.dedent
     @torch.inference_mode()
     def get_normalized_expression(
         self,
@@ -950,6 +951,7 @@ class MULTIVI(
 
         return result
 
+    @de_dsp.dedent
     @torch.no_grad()
     def get_protein_foreground_probability(
         self,

--- a/src/scvi/model/_totalvi.py
+++ b/src/scvi/model/_totalvi.py
@@ -397,6 +397,7 @@ class TOTALVI(
             libraries += [library.cpu()]
         return torch.cat(libraries).numpy()
 
+    @de_dsp.dedent
     @torch.inference_mode()
     def get_normalized_expression(
         self,
@@ -590,6 +591,7 @@ class TOTALVI(
         else:
             return scale_list_gene, scale_list_pro
 
+    @de_dsp.dedent
     @torch.inference_mode()
     def get_protein_foreground_probability(
         self,
@@ -1036,6 +1038,7 @@ class TOTALVI(
 
         return np.concatenate(scdl_list, axis=0)
 
+    @de_dsp.dedent
     @torch.inference_mode()
     def get_feature_correlation_matrix(
         self,

--- a/src/scvi/model/base/_rnamixin.py
+++ b/src/scvi/model/base/_rnamixin.py
@@ -154,6 +154,7 @@ class RNASeqMixin:
         log_probs = importance_weight - torch.logsumexp(importance_weight, 0)
         return log_probs.exp().numpy()
 
+    @de_dsp.dedent
     @torch.inference_mode()
     def get_normalized_expression(
         self,
@@ -697,6 +698,7 @@ class RNASeqMixin:
 
         return np.concatenate(data_loader_list, axis=0)
 
+    @de_dsp.dedent
     @torch.inference_mode()
     def get_feature_correlation_matrix(
         self,

--- a/tests/model/test_docstrings.py
+++ b/tests/model/test_docstrings.py
@@ -1,0 +1,38 @@
+import inspect
+import re
+
+import pytest
+
+import scvi.model
+from scvi.external import MRVI, RESOLVI, ContrastiveVI
+
+# Public model classes whose method docstrings should be fully rendered, i.e.
+# contain no leftover ``%(...)s`` docstring-template placeholders. The external
+# models listed here define methods that share the ``de_dsp`` templated
+# parameter descriptions.
+_MODEL_CLASSES = [
+    getattr(scvi.model, name)
+    for name in scvi.model.__all__
+    if inspect.isclass(getattr(scvi.model, name))
+] + [ContrastiveVI, MRVI, RESOLVI]
+
+_PLACEHOLDER = re.compile(r"%\([A-Za-z0-9_]+\)s")
+
+
+@pytest.mark.parametrize("model_cls", _MODEL_CLASSES, ids=lambda c: c.__name__)
+def test_no_unsubstituted_docstring_placeholders(model_cls):
+    """Public methods must not expose raw ``%(...)s`` docstring placeholders.
+
+    A method whose docstring references a ``de_dsp`` placeholder (e.g.
+    ``%(de_silent)s``) but is missing the ``@de_dsp.dedent`` decorator renders
+    the literal placeholder to users. This guards against that regression.
+    """
+    offenders = []
+    for name, member in inspect.getmembers(model_cls, predicate=inspect.isfunction):
+        if name.startswith("_"):
+            continue
+        doc = member.__doc__ or ""
+        leftover = _PLACEHOLDER.findall(doc)
+        if leftover:
+            offenders.append(f"{model_cls.__name__}.{name}: {sorted(set(leftover))}")
+    assert not offenders, "Unsubstituted docstring placeholders found:\n" + "\n".join(offenders)


### PR DESCRIPTION
### Problem

Several public model methods use the `%(de_silent)s` docstring template
placeholder (defined in `scvi/utils/_docstrings.py` and registered in the
`de_dsp` processor) but are **not** decorated with `@de_dsp.dedent`. As a
result the placeholder is never substituted, and the literal string
`%(de_silent)s` is rendered in the docstrings and the online API reference
instead of the `silent` parameter description.

Reproducer:

```python
import scvi
print(scvi.model.SCVI.get_normalized_expression.__doc__)
# ...
#         return_numpy
#             ...
#         %(de_silent)s        <-- literal placeholder shown to users
#         dataloader
#             ...
```

### Fix

Apply the existing `@de_dsp.dedent` decorator (already used on the
`differential_expression` methods in the same files) to the affected methods:

| Model | Methods |
|-------|---------|
| `RNASeqMixin` (SCVI, LinearSCVI, …) | `get_normalized_expression`, `get_feature_correlation_matrix` |
| `TOTALVI` | `get_normalized_expression`, `get_protein_foreground_probability`, `get_feature_correlation_matrix` |
| `MULTIVI` | `get_normalized_expression`, `get_protein_foreground_probability` |
| `ContrastiveVI` | `get_normalized_expression` |
| `MRVI` | `get_normalized_expression` |
| `RESOLVI` | `get_normalized_expression`, `get_normalized_expression_importance` |

The change is documentation-only in effect: it adds the decorator (and the
`de_dsp` import where missing) so the placeholder is substituted. No runtime
behavior changes.

### Tests

Adds `tests/model/test_docstrings.py`, which parametrizes over the public
model classes and asserts that no public method exposes an unsubstituted
`%(...)s` placeholder. The test fails before this change (11 methods) and
passes after.

### Note / follow-up

`scvi.external.METHYLVI.differential_methylation` has the same missing-decorator
issue, but additionally references placeholders that are **not** defined in any
processor (`%(de_mdata)s`, `%(de_modality)s` — the latter with no matching
parameter in the signature). That case needs new placeholder definitions and a
small signature/docstring reconciliation, so I left it out of this PR to keep
the change focused. Happy to address it in a follow-up if desired.
