### PR TITLE
fix: emit warnings that were silently discarded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ to [Semantic Versioning]. The full commit history is available in the [commit lo
 - Fix unsubstituted `%(de_silent)s` docstring template placeholders being rendered literally in
     several public model methods by applying the missing `de_dsp` docstring processor, {pr}`3921`.
 - Fix how mudata object is saved with AutotuneExperiment, {pr}`3927`.
+- Fix bare `Warning(...)` statements that constructed a warning and silently
+    discarded it (instead of calling `warnings.warn(...)`) across several models
+    and training utilities, so the intended user-facing warnings are now emitted,
+    {pr}`3933`.
 
 #### Changed
 

--- a/src/scvi/external/gimvi/_utils.py
+++ b/src/scvi/external/gimvi/_utils.py
@@ -1,11 +1,13 @@
 import os
 import pickle
+import warnings
 from typing import Literal
 
 import numpy as np
 import torch
 from anndata import AnnData, read_h5ad
 
+from scvi import settings
 from scvi.data._download import _download
 
 
@@ -34,18 +36,22 @@ def _load_legacy_saved_gimvi_files(
         if os.path.exists(seq_data_path):
             adata_seq = read_h5ad(seq_data_path)
         elif not os.path.exists(seq_data_path):
-            Warning(
+            warnings.warn(
                 "Save path contains no saved anndata and no adata was passed. "
-                "Model will be loaded without anndata."
+                "Model will be loaded without anndata.",
+                UserWarning,
+                stacklevel=settings.warnings_stacklevel,
             )
     if load_spatial_adata:
         spatial_data_path = os.path.join(dir_path, f"{file_name_prefix}adata_spatial.h5ad")
         if os.path.exists(spatial_data_path):
             adata_spatial = read_h5ad(spatial_data_path)
         elif not os.path.exists(spatial_data_path):
-            Warning(
+            warnings.warn(
                 "Save path contains no saved anndata and no adata was passed. "
-                "Model will be loaded without anndata."
+                "Model will be loaded without anndata.",
+                UserWarning,
+                stacklevel=settings.warnings_stacklevel,
             )
 
     return (
@@ -91,18 +97,22 @@ def _load_saved_gimvi_files(
         if os.path.exists(seq_data_path):
             adata_seq = read_h5ad(seq_data_path)
         elif not os.path.exists(seq_data_path):
-            Warning(
+            warnings.warn(
                 "Save path contains no saved anndata and no adata was passed. "
-                "Model will be loaded without anndata."
+                "Model will be loaded without anndata.",
+                UserWarning,
+                stacklevel=settings.warnings_stacklevel,
             )
     if load_spatial_adata:
         spatial_data_path = os.path.join(dir_path, f"{file_name_prefix}adata_spatial.h5ad")
         if os.path.exists(spatial_data_path):
             adata_spatial = read_h5ad(spatial_data_path)
         elif not os.path.exists(spatial_data_path):
-            Warning(
+            warnings.warn(
                 "Save path contains no saved anndata and no adata was passed. "
-                "Model will be loaded without anndata."
+                "Model will be loaded without anndata.",
+                UserWarning,
+                stacklevel=settings.warnings_stacklevel,
             )
 
     return (

--- a/src/scvi/external/mrvi/_model.py
+++ b/src/scvi/external/mrvi/_model.py
@@ -399,9 +399,11 @@ class MRVI(
         else:
             for param in [indices, batch_size]:
                 if param is not None:
-                    Warning(
+                    warnings.warn(
                         f"Using {param} after custom Dataloader was initialize is redundant, "
                         f"please re-initialize with selected {param}",
+                        UserWarning,
+                        stacklevel=settings.warnings_stacklevel,
                     )
         us = []
         zs = []
@@ -1966,9 +1968,11 @@ class MRVI(
             scdl = dataloader
             for param in [indices, batch_size, n_samples]:
                 if param is not None:
-                    Warning(
+                    warnings.warn(
                         f"Using {param} after custom Dataloader was initialize is redundant, "
                         f"please re-initialize with selected {param}",
+                        UserWarning,
+                        stacklevel=settings.warnings_stacklevel,
                     )
             gene_mask = slice(None)
             transform_batch = [None]

--- a/src/scvi/model/base/_rnamixin.py
+++ b/src/scvi/model/base/_rnamixin.py
@@ -259,9 +259,11 @@ class RNASeqMixin:
             scdl = dataloader
             for param in [indices, batch_size, n_samples]:
                 if param is not None:
-                    Warning(
+                    warnings.warn(
                         f"Using {param} after custom Dataloader was initialize is redundant, "
                         f"please re-initialize with selected {param}",
+                        UserWarning,
+                        stacklevel=settings.warnings_stacklevel,
                     )
             gene_mask = slice(None)
             transform_batch = [None]
@@ -571,9 +573,11 @@ class RNASeqMixin:
         else:
             for param in [indices, batch_size, gene_list]:
                 if param is not None:
-                    Warning(
+                    warnings.warn(
                         f"Using {param} after custom Dataloader was initialize is redundant, "
                         f"please re-initialize with selected {param}",
+                        UserWarning,
+                        stacklevel=settings.warnings_stacklevel,
                     )
             gene_mask = slice(None)
             transform_batch = [None]
@@ -650,9 +654,11 @@ class RNASeqMixin:
             scdl = dataloader
             for param in [indices, batch_size, n_samples]:
                 if param is not None:
-                    Warning(
+                    warnings.warn(
                         f"Using {param} after custom Dataloader was initialize is redundant, "
                         f"please re-initialize with selected {param}",
+                        UserWarning,
+                        stacklevel=settings.warnings_stacklevel,
                     )
             transform_batch = None
 
@@ -825,9 +831,11 @@ class RNASeqMixin:
             scdl = dataloader
             for param in [indices, batch_size, n_samples]:
                 if param is not None:
-                    Warning(
+                    warnings.warn(
                         f"Using {param} after custom Dataloader was initialize is redundant, "
                         f"please re-initialize with selected {param}",
+                        UserWarning,
+                        stacklevel=settings.warnings_stacklevel,
                     )
 
         dropout_list = []
@@ -923,9 +931,11 @@ class RNASeqMixin:
             scdl = dataloader
             for param in [indices, batch_size]:
                 if param is not None:
-                    Warning(
+                    warnings.warn(
                         f"Using {param} after custom Dataloader was initialize is redundant, "
                         f"please re-initialize with selected {param}",
+                        UserWarning,
+                        stacklevel=settings.warnings_stacklevel,
                     )
 
         libraries = []

--- a/src/scvi/model/base/_training_mixin.py
+++ b/src/scvi/model/base/_training_mixin.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import logging
+import warnings
 from typing import TYPE_CHECKING
 
 import anndata
@@ -300,9 +301,11 @@ class SemisupervisedTrainingMixin:
             scdl = dataloader
             for param in [indices, batch_size]:
                 if param is not None:
-                    Warning(
+                    warnings.warn(
                         f"Using {param} after custom Dataloader was initialize is redundant, "
                         f"please re-initialize with selected {param}",
+                        UserWarning,
+                        stacklevel=settings.warnings_stacklevel,
                     )
 
         attributions = None
@@ -513,7 +516,11 @@ class SemisupervisedTrainingMixin:
                 batch_size=batch_size if batch_size != 128 else None,
             )
             self._datamodule = datamodule
-            Warning("Warning: SCANVI sampler is not available with custom dataloader")
+            warnings.warn(
+                "SCANVI sampler is not available with custom dataloader",
+                UserWarning,
+                stacklevel=settings.warnings_stacklevel,
+            )
             sampler_callback = []
 
         training_plan = self._training_plan_cls(self.module, self.n_labels, **plan_kwargs)
@@ -559,7 +566,11 @@ class SemisupervisedTrainingMixin:
         >>> attrs_df = model.get_ranked_features(attrs)
         """
         if attrs is None:
-            Warning("Missing Attributions matrix")
+            warnings.warn(
+                "Missing Attributions matrix",
+                UserWarning,
+                stacklevel=settings.warnings_stacklevel,
+            )
             return
 
         adata = self._validate_anndata(adata)

--- a/src/scvi/model/base/_vaemixin.py
+++ b/src/scvi/model/base/_vaemixin.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from typing import TYPE_CHECKING
 
 import torch
 
+from scvi import settings
 from scvi.data._utils import _validate_adata_dataloader_input
 from scvi.utils import unsupported_if_adata_minified
 
@@ -89,9 +91,11 @@ class VAEMixin:
         else:
             for param in [indices, batch_size]:
                 if param is not None:
-                    Warning(
+                    warnings.warn(
                         f"Using {param} after custom Dataloader was initialize is redundant, "
                         f"please re-initialize with selected {param}",
+                        UserWarning,
+                        stacklevel=settings.warnings_stacklevel,
                     )
 
         return -compute_elbo(self.module, dataloader, return_mean=return_mean, **kwargs)
@@ -168,9 +172,11 @@ class VAEMixin:
         else:
             for param in [indices, batch_size]:
                 if param is not None:
-                    Warning(
+                    warnings.warn(
                         f"Using {param} after custom Dataloader was initialize is redundant, "
                         f"please re-initialize with selected {param}",
+                        UserWarning,
+                        stacklevel=settings.warnings_stacklevel,
                     )
 
         log_likelihoods: list[float | Tensor] = [
@@ -249,9 +255,11 @@ class VAEMixin:
         else:
             for param in [indices, batch_size]:
                 if param is not None:
-                    Warning(
+                    warnings.warn(
                         f"Using {param} after custom Dataloader was initialize is redundant, "
                         f"please re-initialize with selected {param}",
+                        UserWarning,
+                        stacklevel=settings.warnings_stacklevel,
                     )
 
         return compute_reconstruction_error(
@@ -325,9 +333,11 @@ class VAEMixin:
         else:
             for param in [indices, batch_size]:
                 if param is not None:
-                    Warning(
+                    warnings.warn(
                         f"Using {param} after custom Dataloader was initialize is redundant, "
                         f"please re-initialize with selected {param}",
+                        UserWarning,
+                        stacklevel=settings.warnings_stacklevel,
                     )
 
         zs: list[Tensor] = []

--- a/src/scvi/train/_trainingplans.py
+++ b/src/scvi/train/_trainingplans.py
@@ -349,8 +349,11 @@ class TrainingPlan(pl.LightningModule):
             met = loss_output.extra_metrics[key]
             if isinstance(met, torch.Tensor):
                 if met.shape != torch.Size([]):
-                    Warning(
-                        f"Extra tracked metrics {key} should be 0-d tensors. It will not be logged"
+                    warnings.warn(
+                        f"Extra tracked metrics {key} should be 0-d tensors. "
+                        "It will not be logged",
+                        UserWarning,
+                        stacklevel=settings.warnings_stacklevel,
                     )
                 else:
                     met = met.detach()
@@ -1718,7 +1721,11 @@ if is_package_installed("mlx"):
             elif hasattr(self.module, "_training"):
                 self.module._training = is_training
             else:
-                Warning("Unable to set module training state, may affect training performance")
+                warnings.warn(
+                    "Unable to set module training state, may affect training performance",
+                    UserWarning,
+                    stacklevel=settings.warnings_stacklevel,
+                )
 
         def get_kl_weight(self) -> float:
             """Compute the KL weight for the current step or epoch.

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1,0 +1,46 @@
+import ast
+import pathlib
+
+import pytest
+
+import scvi
+
+_SRC = pathlib.Path(scvi.__file__).parent
+
+
+def _find_noop_warning_statements():
+    """Return ``file:lineno`` for every bare ``*Warning(...)`` statement in the source.
+
+    A statement such as ``Warning("msg")`` merely constructs a warning object and
+    immediately discards it, so the intended user-facing warning never fires. The
+    correct form is ``warnings.warn("msg", ...)``.
+    """
+    offenders = []
+    for path in _SRC.rglob("*.py"):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
+                func = node.value.func
+                name = getattr(func, "id", None) or getattr(func, "attr", None)
+                if name is not None and name.endswith("Warning"):
+                    offenders.append(f"{path.relative_to(_SRC)}:{node.lineno}")
+    return offenders
+
+
+def test_no_bare_warning_statements():
+    offenders = _find_noop_warning_statements()
+    assert not offenders, (
+        "Found `Warning(...)` used as a no-op statement (should be `warnings.warn(...)`):\n"
+        + "\n".join(offenders)
+    )
+
+
+def test_get_ranked_features_warns_on_missing_attrs():
+    adata = scvi.data.synthetic_iid()
+    scvi.model.SCANVI.setup_anndata(
+        adata, labels_key="labels", unlabeled_category="label_0", batch_key="batch"
+    )
+    model = scvi.model.SCANVI(adata)
+    with pytest.warns(UserWarning, match="Missing Attributions matrix"):
+        result = model.get_ranked_features()
+    assert result is None


### PR DESCRIPTION
### Problem

Several places in the codebase construct a `Warning(...)` object as a **bare
statement**:

```python
if param is not None:
    Warning(  # <-- constructs a Warning and throws it away; nothing is shown
        f"Using {param} after custom Dataloader was initialize is redundant, ..."
    )
```

Instantiating a `Warning` (or any subclass) does nothing on its own — the object
is immediately discarded, so the intended user-facing warning **never fires**.
The author clearly meant `warnings.warn(...)`. This affects, among others:

- redundant `indices`/`batch_size`/`n_samples` passed alongside a custom
  dataloader (`RNASeqMixin`, `VAEMixin`, `SemisupervisedTrainingMixin`, `MRVI`),
- `SemisupervisedTrainingMixin.get_ranked_features` called without an
  attributions matrix ("Missing Attributions matrix"),
- the SCANVI custom-dataloader sampler notice,
- legacy GIMVI loading when no saved AnnData is found,
- `TrainingPlan` extra-metric shape / module-training-state notices.

### Fix

Replace every bare `Warning(...)` statement (20 of them across 6 files) with a
proper `warnings.warn(msg, UserWarning, stacklevel=settings.warnings_stacklevel)`
call, matching the convention already used throughout the codebase. Behavior is
otherwise unchanged — the only difference is that the warnings are now actually
emitted. (I also dropped a redundant `"Warning: "` prefix from one message.)

### Tests

Adds `tests/test_warnings.py`:

1. `test_no_bare_warning_statements` — an AST scan asserting no `*Warning(...)`
   statement is used as a no-op anywhere in `scvi`. Fails before this change
   (20 offenders), passes after, and guards against reintroduction.
2. `test_get_ranked_features_warns_on_missing_attrs` — a behavioral test that
   `SCANVI.get_ranked_features()` (no attributions) now emits the warning.

Both tests fail on `main` and pass with this change. Existing model/train
suites (SCANVI, GIMVI, MRVI, SCVI) still pass locally.
