### PR TITLE
Take the MPS CPU detour only when the torch build needs it

### DIFF
--- a/.github/workflows/test_mps.yaml
+++ b/.github/workflows/test_mps.yaml
@@ -61,6 +61,7 @@ jobs:
           COLUMNS: 120
           PYTORCH_MPS_HIGH_WATERMARK_RATIO: 0.0
           PYTORCH_ENABLE_MPS_FALLBACK: 1
+          SCVI_ALLOW_MPS_AUTO: "1"
         run: uvx hatch run $HATCH_ENV:run-cov -v --color=yes --accelerator mps --devices auto
 
       - name: Generate coverage report

--- a/.github/workflows/test_mps.yaml
+++ b/.github/workflows/test_mps.yaml
@@ -31,7 +31,7 @@ jobs:
       )
 
     name: mps
-    runs-on: [self-hosted, macOS, X64, MPS]
+    runs-on: macos-latest
 
     defaults:
       run:

--- a/.github/workflows/test_mps.yaml
+++ b/.github/workflows/test_mps.yaml
@@ -60,7 +60,7 @@ jobs:
           DISPLAY: :42
           COLUMNS: 120
           PYTORCH_MPS_HIGH_WATERMARK_RATIO: 0.0
-          PYTORCH_ENABLE_MPS_FALLBACK: 1
+          PYTORCH_ENABLE_MPS_FALLBACK: 0
           SCVI_ALLOW_MPS_AUTO: "1"
         run: uvx hatch run $HATCH_ENV:run-cov -v --color=yes --accelerator mps --devices auto
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ to [Semantic Versioning]. The full commit history is available in the [commit lo
 
 #### Fixed
 
+- Stop sending `mps` negative binomial sampling through the CPU unconditionally in
+    {class}`scvi.distributions.NegativeBinomial`,
+    {class}`scvi.distributions.ZeroInflatedNegativeBinomial` and
+    {class}`scvi.distributions.NegativeBinomialMixture`. The `aten::_standard_gamma` and
+    `aten::poisson` kernels that detour worked around ship in torch 2.12 and 2.14
+    respectively, so it is now taken only when the running build actually lacks them. This
+    also fixes {class}`scvi.distributions.NegativeBinomialMixture` returning CPU samples for
+    parameters on `mps`, {pr}`3981`.
 - Fix unsubstituted `%(de_silent)s` docstring template placeholders being rendered literally in
     several public model methods by applying the missing `de_dsp` docstring processor, {pr}`3921`.
 - Fix how mudata object is saved with AutotuneExperiment, {pr}`3927`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,32 @@ to [Semantic Versioning]. The full commit history is available in the [commit lo
 
 #### Added
 
+- Extend native `mps` support across the rest of scvi-tools' gamma/Poisson/Dirichlet/Binomial
+    sampling and `lgamma` call sites, on top of
+    {class}`scvi.distributions.NegativeBinomial`, {class}`scvi.distributions.ZeroInflatedNegativeBinomial`
+    and {class}`scvi.distributions.NegativeBinomialMixture`. The CPU detours these relied on for
+    `aten::_standard_gamma`, `aten::poisson`, `aten::_sample_dirichlet` and `aten::binomial` are
+    now taken only when the installed torch build actually lacks the kernel (probed at runtime,
+    not hardcoded), so training and sampling stay on `mps` end-to-end as torch's MPS backend gains
+    coverage. This reaches {class}`scvi.distributions.ZeroInflatedGamma` and
+    {class}`scvi.distributions.BetaBinomial` (previously had no `mps` handling at all),
+    {class}`scvi.module.VAE`'s Poisson likelihood, {class}`scvi.module.AutoZIVAE`,
+    {class}`scvi.model.TOTALVI` and {class}`scvi.model.base.RNASeqMixin`'s posterior predictive
+    sampling, {class}`scvi.external.velovi.VELOVI`'s Dirichlet mixture weights,
+    {class}`scvi.external.drvi.DRVI`'s log-space negative binomial, and
+    {func}`~scvi.data.poisson_gene_selection`'s Binomial zero-enrichment test. Also drops the
+    `.clone()` workaround for 3D `BatchNorm1d` on `mps` in {class}`scvi.nn.FCLayers` and the
+    `.contiguous()` workaround for `torch.lgamma` on non-contiguous `mps` tensors once the
+    corresponding kernel is available, {pr}`3981`.
+- `accelerator="auto"` now resolves to `mps` on Apple silicon instead of silently falling back
+    to `cpu`, matching the existing `auto` behavior on CUDA machines, {pr}`3981`.
+
 #### Fixed
 
-- Stop sending `mps` negative binomial sampling through the CPU unconditionally in
-    {class}`scvi.distributions.NegativeBinomial`,
-    {class}`scvi.distributions.ZeroInflatedNegativeBinomial` and
-    {class}`scvi.distributions.NegativeBinomialMixture`. The `aten::_standard_gamma` and
-    `aten::poisson` kernels that detour worked around ship in torch 2.12 and 2.14
-    respectively, so it is now taken only when the running build actually lacks them. This
-    also fixes {class}`scvi.distributions.NegativeBinomialMixture` returning CPU samples for
-    parameters on `mps`, {pr}`3981`.
+- Fix {class}`scvi.module.MULTIVAE`'s accessibility reconstruction loss crashing on `mps` for
+    RNA+protein-only `MULTIVI` configurations (`n_input_regions=0`): `BCELoss` asserts on a
+    zero-element `mps` tensor, so the loss over zero features is now returned directly as zero
+    (correct on every backend) rather than routed through the op, {pr}`3989`.
 - Fix unsubstituted `%(de_silent)s` docstring template placeholders being rendered literally in
     several public model methods by applying the missing `de_dsp` docstring processor, {pr}`3921`.
 - Fix how mudata object is saved with AutotuneExperiment, {pr}`3927`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,14 +20,12 @@ to [Semantic Versioning]. The full commit history is available in the [commit lo
     {class}`scvi.distributions.BetaBinomial` (previously had no `mps` handling at all),
     {class}`scvi.module.VAE`'s Poisson likelihood, {class}`scvi.module.AutoZIVAE`,
     {class}`scvi.model.TOTALVI` and {class}`scvi.model.base.RNASeqMixin`'s posterior predictive
-    sampling, {class}`scvi.external.velovi.VELOVI`'s Dirichlet mixture weights,
-    {class}`scvi.external.drvi.DRVI`'s log-space negative binomial, and
+    sampling, {class}`scvi.external.VELOVI`'s Dirichlet mixture weights,
+    {class}`scvi.external.DRVI`'s log-space negative binomial, and
     {func}`~scvi.data.poisson_gene_selection`'s Binomial zero-enrichment test. Also drops the
     `.clone()` workaround for 3D `BatchNorm1d` on `mps` in {class}`scvi.nn.FCLayers` and the
     `.contiguous()` workaround for `torch.lgamma` on non-contiguous `mps` tensors once the
     corresponding kernel is available, {pr}`3981`.
-- `accelerator="auto"` now resolves to `mps` on Apple silicon instead of silently falling back
-    to `cpu`, matching the existing `auto` behavior on CUDA machines, {pr}`3981`.
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,12 +30,6 @@ to [Semantic Versioning]. The full commit history is available in the [commit lo
 
 #### Changed
 
-- Reword the `mps` accelerator warning in {func}`scvi.model._utils.parse_device_args` to drop the
-    claim that results are "less accurate". Operator coverage remains a real limitation and is
-    still warned about, but a comparison of `lgamma`, `digamma`, `log`, `exp`, `softmax`, `sum`,
-    `matmul` and a negative-binomial ELBO gradient against a float64 reference showed MPS float32
-    within float32 noise of CPU float32. The warning now covers the coverage gap and the fact that
-    RNG streams differ per backend, {pr}`3981`.
 - Updated dockerfile to py3.13, {pr}`3920`.
 - Updated several github workflows with recent github actions modules, {pr}`3916`.
 - Align the repository with the [scverse cookiecutter template](https://github.com/scverse/cookiecutter-scverse) v0.8.0 and track it via `.cruft.json`, so template updates arrive as automated pull requests, {pr}`3607`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ to [Semantic Versioning]. The full commit history is available in the [commit lo
 
 #### Changed
 
+- Reword the `mps` accelerator warning in {func}`scvi.model._utils.parse_device_args` to drop the
+    claim that results are "less accurate". Operator coverage remains a real limitation and is
+    still warned about, but a comparison of `lgamma`, `digamma`, `log`, `exp`, `softmax`, `sum`,
+    `matmul` and a negative-binomial ELBO gradient against a float64 reference showed MPS float32
+    within float32 noise of CPU float32. The warning now covers the coverage gap and the fact that
+    RNG streams differ per backend, {pr}`3981`.
 - Updated dockerfile to py3.13, {pr}`3920`.
 - Updated several github workflows with recent github actions modules, {pr}`3916`.
 - Align the repository with the [scverse cookiecutter template](https://github.com/scverse/cookiecutter-scverse) v0.8.0 and track it via `.cruft.json`, so template updates arrive as automated pull requests, {pr}`3607`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,10 +39,10 @@ to [Semantic Versioning]. The full commit history is available in the [commit lo
     roughly half the kernels per step and removes most of the host-device synchronisations, which
     matters most on `mps`: on the introduction tutorial's dataset, training goes from 0.989 to
     0.697 s/epoch on `mps` and from 1.138 to 1.050 s/epoch on `cpu`, for an unchanged ELBO. Pass
-    `plan_kwargs={"fused_optimizer": False}` to restore the previous behaviour.
+    `plan_kwargs={"fused_optimizer": False}` to restore the previous behaviour, {pr}`3998`.
 - Restore `torch._dynamo.config.suppress_errors` once training ends instead of leaving it enabled
     for the rest of the process, and warn when `compile=True` silently fell back to eager, so a
-    failed compilation is no longer indistinguishable from a successful one.
+    failed compilation is no longer indistinguishable from a successful one, {pr}`3998`.
 - Updated dockerfile to py3.13, {pr}`3920`.
 - Updated several github workflows with recent github actions modules, {pr}`3916`.
 - Align the repository with the [scverse cookiecutter template](https://github.com/scverse/cookiecutter-scverse) v0.8.0 and track it via `.cruft.json`, so template updates arrive as automated pull requests, {pr}`3607`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@ to [Semantic Versioning]. The full commit history is available in the [commit lo
 
 #### Changed
 
+- Use the fused implementation of `Adam` and `AdamW` in {class}`scvi.train.TrainingPlan` when the
+    backend supports it, falling back to the standard one when it does not. The fused path issues
+    roughly half the kernels per step and removes most of the host-device synchronisations, which
+    matters most on `mps`: on the introduction tutorial's dataset, training goes from 0.989 to
+    0.697 s/epoch on `mps` and from 1.138 to 1.050 s/epoch on `cpu`, for an unchanged ELBO. Pass
+    `plan_kwargs={"fused_optimizer": False}` to restore the previous behaviour.
+- Restore `torch._dynamo.config.suppress_errors` once training ends instead of leaving it enabled
+    for the rest of the process, and warn when `compile=True` silently fell back to eager, so a
+    failed compilation is no longer indistinguishable from a successful one.
 - Updated dockerfile to py3.13, {pr}`3920`.
 - Updated several github workflows with recent github actions modules, {pr}`3916`.
 - Align the repository with the [scverse cookiecutter template](https://github.com/scverse/cookiecutter-scverse) v0.8.0 and track it via `.cruft.json`, so template updates arrive as automated pull requests, {pr}`3607`.

--- a/src/scvi/data/_preprocessing.py
+++ b/src/scvi/data/_preprocessing.py
@@ -9,11 +9,17 @@ import pandas as pd
 import torch
 from scipy.sparse import issparse
 
+from scvi.distributions._utils import _needs_cpu_detour
 from scvi.model._utils import parse_device_args
 from scvi.utils import dependencies, track
 from scvi.utils._docstrings import devices_dsp
 
 from ._utils import _check_nonnegative_integers
+
+
+def _binomial_probe(count: torch.Tensor) -> torch.Tensor:
+    """Single-tensor probe for ``torch.binomial``, matching the ``_mps_supports`` signature."""
+    return torch.binomial(count, torch.full_like(count, 0.5))
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -152,8 +158,8 @@ def poisson_gene_selection(
         expected_fraction_zeros /= data.shape[0]
 
         # Compute probability of enriched zeros through sampling from Binomial distributions.
-        # TODO:  TORCH MPS FIX - 'aten::binomial' is not currently implemented for the MPS device
-        if device.type == "mps":
+        needs_cpu_detour = _needs_cpu_detour(device.type == "mps", _binomial_probe)
+        if needs_cpu_detour:
             observed_zero = torch.distributions.Binomial(probs=observed_fraction_zeros.to("cpu"))
             expected_zero = torch.distributions.Binomial(probs=expected_fraction_zeros.to("cpu"))
         else:
@@ -168,7 +174,7 @@ def poisson_gene_selection(
             style="tqdm",  # do not change
         ):
             obs_exp_bool_mat = observed_zero.sample() > expected_zero.sample()
-            extra_zeros += obs_exp_bool_mat.to("mps") if device.type == "mps" else obs_exp_bool_mat
+            extra_zeros += obs_exp_bool_mat.to(device) if needs_cpu_detour else obs_exp_bool_mat
 
         prob_zero_enrichment = (extra_zeros / n_samples).cpu().numpy()
 

--- a/src/scvi/data/_preprocessing.py
+++ b/src/scvi/data/_preprocessing.py
@@ -21,6 +21,7 @@ def _binomial_probe(count: torch.Tensor) -> torch.Tensor:
     """Single-tensor probe for ``torch.binomial``, matching the ``_mps_supports`` signature."""
     return torch.binomial(count, torch.full_like(count, 0.5))
 
+
 if TYPE_CHECKING:
     from pathlib import Path
 

--- a/src/scvi/dataloaders/_data_splitting.py
+++ b/src/scvi/dataloaders/_data_splitting.py
@@ -1,4 +1,5 @@
 import warnings
+from functools import cache
 from math import ceil, floor
 
 import lightning.pytorch as pl
@@ -19,6 +20,25 @@ from scvi.dataloaders._ann_dataloader import AnnDataLoader
 from scvi.dataloaders._semi_dataloader import SemiSupervisedDataLoader
 from scvi.model._utils import parse_device_args
 from scvi.utils._docstrings import devices_dsp
+
+
+@cache
+def _mps_supports_sparse_compressed_tensor() -> bool:
+    """Whether MPS can hold a sparse CSR/CSC tensor at all.
+
+    Probed rather than version-compared for the same reason as
+    :func:`scvi.distributions._utils._mps_supports`.
+    """
+    try:
+        torch.sparse_csr_tensor(
+            torch.zeros(1, dtype=torch.int64, device="mps"),
+            torch.zeros(0, dtype=torch.int64, device="mps"),
+            torch.zeros(0, device="mps"),
+            size=(1, 1),
+        )
+    except (NotImplementedError, RuntimeError):
+        return False
+    return True
 
 
 def validate_data_split(
@@ -327,6 +347,25 @@ class DataSplitter(pl.LightningDataModule):
             )
         else:
             pass
+
+    def transfer_batch_to_device(self, batch, device, dataloader_idx):
+        """Densifies sparse tensors before the transfer if the device can't hold them.
+
+        MPS has no sparse CSR/CSC tensor support at all (unlike a missing single-op kernel,
+        the whole layout is unimplemented there), so the default transfer would crash trying to
+        move the still-sparse tensor onto the device; densify first in that case.
+        """
+        if (
+            self.load_sparse_tensor
+            and device.type == "mps"
+            and not _mps_supports_sparse_compressed_tensor()
+        ):
+            for key, val in batch.items():
+                layout = val.layout if isinstance(val, torch.Tensor) else None
+                if layout is torch.sparse_csr or layout is torch.sparse_csc:
+                    batch[key] = val.to_dense()
+
+        return super().transfer_batch_to_device(batch, device, dataloader_idx)
 
     def on_after_batch_transfer(self, batch, dataloader_idx):
         """Converts sparse tensors to dense if necessary."""

--- a/src/scvi/distributions/_beta_binomial.py
+++ b/src/scvi/distributions/_beta_binomial.py
@@ -1,9 +1,16 @@
 import torch
 from pyro.distributions import BetaBinomial as BetaBinomialDistribution
+from pyro.distributions import Binomial
 from torch.distributions import constraints
 from torch.distributions.utils import broadcast_all
 
 from ._constraints import open_interval, optional_constraint
+from ._utils import _needs_cpu_detour
+
+
+def _binomial_probe(count: torch.Tensor) -> torch.Tensor:
+    """Single-tensor probe for ``torch.binomial``, matching the ``_mps_supports`` signature."""
+    return torch.binomial(count, torch.full_like(count, 0.5))
 
 
 class BetaBinomial(BetaBinomialDistribution):
@@ -114,6 +121,24 @@ class BetaBinomial(BetaBinomialDistribution):
             total_count=total_count,
             validate_args=validate_args,
         )
+
+    @torch.inference_mode()
+    def sample(self, sample_shape: torch.Size | tuple = ()) -> torch.Tensor:
+        """Sample from the distribution."""
+        device = self.total_count.device
+        on_mps = device.type == "mps"
+
+        beta = self._beta
+        if _needs_cpu_detour(on_mps, torch._sample_dirichlet):
+            beta = beta.__class__(beta.concentration1.cpu(), beta.concentration0.cpu())
+        probs = beta.sample(sample_shape)
+
+        total_count = self.total_count.to(probs.device)
+        if _needs_cpu_detour(on_mps, _binomial_probe):
+            total_count, probs = total_count.cpu(), probs.cpu()
+
+        counts = Binomial(total_count, probs, validate_args=False).sample()
+        return counts.to(device)
 
     def __repr__(self) -> str:
         param_names = [k for k, _ in self.arg_constraints.items() if k in self.__dict__]

--- a/src/scvi/distributions/_gamma.py
+++ b/src/scvi/distributions/_gamma.py
@@ -15,6 +15,7 @@ from torch.distributions.utils import (
 from scvi import settings
 
 from ._constraints import optional_constraint
+from ._utils import _needs_cpu_detour
 
 
 class ZeroInflatedGamma(Gamma):
@@ -126,7 +127,16 @@ class ZeroInflatedGamma(Gamma):
     ) -> torch.Tensor:
         """Sample from the distribution."""
         sample_shape = sample_shape or torch.Size()
-        samp = super().sample(sample_shape=sample_shape)
+        device = self.concentration.device
+        on_mps = device.type == "mps"
+        if _needs_cpu_detour(on_mps, torch._standard_gamma):
+            samp = (
+                Gamma(self.concentration.to("cpu"), self.rate.to("cpu"))
+                .sample(sample_shape)
+                .to(device)
+            )
+        else:
+            samp = super().sample(sample_shape=sample_shape)
         is_zero = torch.rand_like(samp) <= self.zi_probs
         samp_ = torch.where(is_zero, torch.zeros_like(samp), samp)
         return samp_

--- a/src/scvi/distributions/_negative_binomial.py
+++ b/src/scvi/distributions/_negative_binomial.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import warnings
+from typing import TYPE_CHECKING
 
 import torch
 import torch.nn.functional as F
@@ -16,7 +17,10 @@ from torch.distributions.utils import (
 from scvi import settings
 
 from ._constraints import optional_constraint
-from ._utils import _needs_cpu_detour
+from ._utils import _mps_supports_lgamma_on_noncontiguous, _needs_cpu_detour
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def torch_lgamma_mps(x: torch.Tensor) -> torch.Tensor:
@@ -32,6 +36,13 @@ def torch_lgamma_mps(x: torch.Tensor) -> torch.Tensor:
     lgamma tensor that performs on a copied version of the tensor
     """
     return torch.lgamma(x.contiguous())
+
+
+def _lgamma_fn(on_mps: bool) -> Callable[[torch.Tensor], torch.Tensor]:
+    """Pick the lgamma implementation, using the contiguous-copy detour only if still needed."""
+    if on_mps and not _mps_supports_lgamma_on_noncontiguous():
+        return torch_lgamma_mps
+    return torch.lgamma
 
 
 def log_zinb_positive(
@@ -448,7 +459,7 @@ class NegativeBinomial(Distribution):
                     stacklevel=settings.warnings_stacklevel,
                 )
 
-        lgamma_fn = torch_lgamma_mps if self.on_mps else torch.lgamma  # TODO: TORCH MPS FIX
+        lgamma_fn = _lgamma_fn(self.on_mps)
         return log_nb_positive(
             value, mu=self.mu, theta=self.theta, eps=self._eps, lgamma_fn=lgamma_fn
         )
@@ -575,7 +586,7 @@ class ZeroInflatedNegativeBinomial(NegativeBinomial):
                 UserWarning,
                 stacklevel=settings.warnings_stacklevel,
             )
-        lgamma_fn = torch_lgamma_mps if self.on_mps else torch.lgamma  # TODO: TORCH MPS FIX
+        lgamma_fn = _lgamma_fn(self.on_mps)
         return log_zinb_positive(
             value, self.mu, self.theta, self.zi_logits, eps=1e-08, lgamma_fn=lgamma_fn
         )
@@ -688,7 +699,7 @@ class NegativeBinomialMixture(Distribution):
                 UserWarning,
                 stacklevel=settings.warnings_stacklevel,
             )
-        lgamma_fn = torch_lgamma_mps if self.on_mps else torch.lgamma  # TODO: TORCH MPS FIX
+        lgamma_fn = _lgamma_fn(self.on_mps)
         return log_mixture_nb(
             value,
             self.mu1,

--- a/src/scvi/distributions/_negative_binomial.py
+++ b/src/scvi/distributions/_negative_binomial.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import warnings
-from functools import cache
-from typing import TYPE_CHECKING
 
 import torch
 import torch.nn.functional as F
@@ -18,9 +16,7 @@ from torch.distributions.utils import (
 from scvi import settings
 
 from ._constraints import optional_constraint
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
+from ._utils import _needs_cpu_detour
 
 
 def torch_lgamma_mps(x: torch.Tensor) -> torch.Tensor:
@@ -36,30 +32,6 @@ def torch_lgamma_mps(x: torch.Tensor) -> torch.Tensor:
     lgamma tensor that performs on a copied version of the tensor
     """
     return torch.lgamma(x.contiguous())
-
-
-@cache
-def _mps_supports(op: Callable[[torch.Tensor], torch.Tensor]) -> bool:
-    """Whether ``op`` has an MPS kernel in the torch build in use.
-
-    ``aten::_standard_gamma`` gained one in torch 2.12 and ``aten::poisson`` in
-    2.14, so the answer depends on the installed version. It is probed rather
-    than version-compared because source and nightly builds report versions
-    that a comparison reads wrongly.
-
-    Callers must check ``torch.backends.mps.is_available()`` first; this is only
-    reached from a distribution whose parameters already live on ``mps``.
-    """
-    try:
-        op(torch.ones(1, device="mps"))
-    except (NotImplementedError, RuntimeError):
-        return False
-    return True
-
-
-def _needs_cpu_detour(on_mps: bool, op: Callable[[torch.Tensor], torch.Tensor]) -> bool:
-    """Whether sampling ``op`` has to be routed through the CPU."""
-    return on_mps and not _mps_supports(op)
 
 
 def log_zinb_positive(

--- a/src/scvi/distributions/_negative_binomial.py
+++ b/src/scvi/distributions/_negative_binomial.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import warnings
+from functools import cache
+from typing import TYPE_CHECKING
 
 import torch
 import torch.nn.functional as F
@@ -17,6 +19,9 @@ from scvi import settings
 
 from ._constraints import optional_constraint
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
 
 def torch_lgamma_mps(x: torch.Tensor) -> torch.Tensor:
     """Used in Mac Mx devices while broadcasting a tensor
@@ -31,6 +36,30 @@ def torch_lgamma_mps(x: torch.Tensor) -> torch.Tensor:
     lgamma tensor that performs on a copied version of the tensor
     """
     return torch.lgamma(x.contiguous())
+
+
+@cache
+def _mps_supports(op: Callable[[torch.Tensor], torch.Tensor]) -> bool:
+    """Whether ``op`` has an MPS kernel in the torch build in use.
+
+    ``aten::_standard_gamma`` gained one in torch 2.12 and ``aten::poisson`` in
+    2.14, so the answer depends on the installed version. It is probed rather
+    than version-compared because source and nightly builds report versions
+    that a comparison reads wrongly.
+
+    Callers must check ``torch.backends.mps.is_available()`` first; this is only
+    reached from a distribution whose parameters already live on ``mps``.
+    """
+    try:
+        op(torch.ones(1, device="mps"))
+    except (NotImplementedError, RuntimeError):
+        return False
+    return True
+
+
+def _needs_cpu_detour(on_mps: bool, op: Callable[[torch.Tensor], torch.Tensor]) -> bool:
+    """Whether sampling ``op`` has to be routed through the CPU."""
+    return on_mps and not _mps_supports(op)
 
 
 def log_zinb_positive(
@@ -273,13 +302,10 @@ def _convert_counts_logits_to_mean_disp(
 def _gamma(theta: torch.Tensor, mu: torch.Tensor, on_mps: bool = False) -> Gamma:
     concentration = theta
     rate = theta / mu
+    if _needs_cpu_detour(on_mps, torch._standard_gamma):
+        concentration, rate = concentration.to("cpu"), rate.to("cpu")
     # Important remark: Gamma is parametrized by the rate = 1/scale!
-    gamma_d = (
-        Gamma(concentration=concentration.to("cpu"), rate=rate.to("cpu"))
-        if on_mps  # TODO: NEED TORCH MPS FIX for 'aten::_standard_gamma'
-        else Gamma(concentration=concentration, rate=rate)
-    )
-    return gamma_d
+    return Gamma(concentration=concentration, rate=rate)
 
 
 class Poisson(PoissonTorch):
@@ -378,9 +404,8 @@ class NegativeBinomial(Distribution):
         scale: torch.Tensor | None = None,
         validate_args: bool = False,
     ):
-        self.on_mps = (
-            mu.device.type == "mps" if total_count is None else total_count.device.type == "mps"
-        )  # TODO: This is used until torch will solve the MPS issues
+        self._device = mu.device if total_count is None else total_count.device
+        self.on_mps = self._device.type == "mps"
         self._eps = 1e-8
         if (mu is None) == (total_count is None):
             raise ValueError(
@@ -429,18 +454,16 @@ class NegativeBinomial(Distribution):
     ) -> torch.Tensor:
         """Sample from the distribution."""
         sample_shape = sample_shape or torch.Size()
-        gamma_d = self._gamma()  # TODO: TORCH MPS FIX - DONE ON CPU CURRENTLY
+        gamma_d = self._gamma()
         p_means = gamma_d.sample(sample_shape)
 
         # Clamping as the distribution objects can have buggy behaviors when
         # their parameters are too high
         l_train = torch.clamp(p_means, max=1e8)
-        counts = (
-            PoissonTorch(l_train).sample().to("mps")
-            if self.on_mps  # TODO: NEED TORCH MPS FIX for 'aten::poisson'
-            else PoissonTorch(l_train).sample()
-        )  # Shape : (n_samples, n_cells_batch, n_vars)
-        return counts
+        if _needs_cpu_detour(self.on_mps, torch.poisson):
+            l_train = l_train.to("cpu")
+        counts = PoissonTorch(l_train).sample()  # Shape : (n_samples, n_cells_batch, n_vars)
+        return counts.to(self._device)
 
     def log_prob(self, value: torch.Tensor) -> torch.Tensor:
         if self._validate_args:
@@ -632,9 +655,8 @@ class NegativeBinomialMixture(Distribution):
             self.mu2,
             self.mixture_logits,
         ) = broadcast_all(mu1, theta1, mu2, mixture_logits)
-        self.on_mps = (
-            mu1.device.type == "mps"
-        )  # TODO: This is used until torch will solve the MPS issues
+        self._device = mu1.device
+        self.on_mps = self._device.type == "mps"
         super().__init__(validate_args=validate_args)
 
         if theta2 is not None:
@@ -673,14 +695,16 @@ class NegativeBinomialMixture(Distribution):
             theta = self.theta1
         else:
             theta = self.theta1 * mixing_sample + self.theta2 * (1 - mixing_sample)
-        gamma_d = _gamma(theta, mu, self.on_mps)  # TODO: TORCH MPS FIX - DONE ON CPU CURRENTLY
+        gamma_d = _gamma(theta, mu, self.on_mps)
         p_means = gamma_d.sample(sample_shape)
 
         # Clamping as the distribution objects can have buggy behaviors when
         # their parameters are too high
         l_train = torch.clamp(p_means, max=1e8)
+        if _needs_cpu_detour(self.on_mps, torch.poisson):
+            l_train = l_train.to("cpu")
         counts = PoissonTorch(l_train).sample()  # Shape : (n_samples, n_cells_batch, n_features)
-        return counts
+        return counts.to(self._device)
 
     def log_prob(self, value: torch.Tensor) -> torch.Tensor:
         """Log probability."""

--- a/src/scvi/distributions/_utils.py
+++ b/src/scvi/distributions/_utils.py
@@ -1,4 +1,36 @@
+from __future__ import annotations
+
+from functools import cache
+from typing import TYPE_CHECKING
+
 import torch
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@cache
+def _mps_supports(op: Callable[[torch.Tensor], torch.Tensor]) -> bool:
+    """Whether ``op`` has an MPS kernel in the torch build in use.
+
+    ``aten::_standard_gamma`` gained one in torch 2.12 and ``aten::poisson`` in
+    2.14, so the answer depends on the installed version. It is probed rather
+    than version-compared because source and nightly builds report versions
+    that a comparison reads wrongly.
+
+    Callers must check ``torch.backends.mps.is_available()`` first; this is only
+    reached from a distribution whose parameters already live on ``mps``.
+    """
+    try:
+        op(torch.ones(1, device="mps"))
+    except (NotImplementedError, RuntimeError):
+        return False
+    return True
+
+
+def _needs_cpu_detour(on_mps: bool, op: Callable[[torch.Tensor], torch.Tensor]) -> bool:
+    """Whether sampling ``op`` has to be routed through the CPU."""
+    return on_mps and not _mps_supports(op)
 
 
 def subset_distribution(

--- a/src/scvi/distributions/_utils.py
+++ b/src/scvi/distributions/_utils.py
@@ -33,6 +33,19 @@ def _needs_cpu_detour(on_mps: bool, op: Callable[[torch.Tensor], torch.Tensor]) 
     return on_mps and not _mps_supports(op)
 
 
+@cache
+def _mps_supports_lgamma_on_noncontiguous() -> bool:
+    """Whether ``torch.lgamma`` can run on a non-contiguous (broadcast-expanded) MPS tensor.
+
+    Probed rather than version-compared for the same reason as :func:`_mps_supports`.
+    """
+    try:
+        torch.lgamma(torch.ones(1, 4, device="mps").expand(4, 4))
+    except (NotImplementedError, RuntimeError):
+        return False
+    return True
+
+
 def subset_distribution(
     my_distribution: torch.distributions.Distribution,
     index: torch.Tensor,

--- a/src/scvi/distributions/_utils.py
+++ b/src/scvi/distributions/_utils.py
@@ -35,15 +35,18 @@ def _needs_cpu_detour(on_mps: bool, op: Callable[[torch.Tensor], torch.Tensor]) 
 
 @cache
 def _mps_supports_lgamma_on_noncontiguous() -> bool:
-    """Whether ``torch.lgamma`` can run on a non-contiguous (broadcast-expanded) MPS tensor.
+    """Whether ``torch.lgamma`` is correct on a non-contiguous (broadcast-expanded) MPS tensor.
 
-    Probed rather than version-compared for the same reason as :func:`_mps_supports`.
+    Probed rather than version-compared for the same reason as :func:`_mps_supports`, but the
+    probe has to compare values: on the builds that need the workaround this does not raise,
+    it returns the right numbers for the first row of a stride-0 expanded tensor and ``inf``
+    for the replicated ones.
     """
     try:
-        torch.lgamma(torch.ones(1, 4, device="mps").expand(4, 4))
+        expanded = (torch.arange(1, 5, device="mps", dtype=torch.float32) / 2).expand(4, 4)
+        return bool(torch.allclose(torch.lgamma(expanded), torch.lgamma(expanded.contiguous())))
     except (NotImplementedError, RuntimeError):
         return False
-    return True
 
 
 def subset_distribution(

--- a/src/scvi/external/diagvi/_model.py
+++ b/src/scvi/external/diagvi/_model.py
@@ -1204,6 +1204,7 @@ class DIAGVI(BaseModelClass, VAEMixin):
             REGISTRY_KEYS.LABELS_KEY
         )
         label_categories = label_registry.get("categorical_mapping", None)
+        unlabeled_category = label_registry.get("unlabeled_category", None)
 
         # Get latent representations for target modality
         self.module.eval()
@@ -1226,6 +1227,12 @@ class DIAGVI(BaseModelClass, VAEMixin):
 
         # Concatenate all logits and compute predictions
         all_logits = torch.cat(all_logits, dim=0)
+        if unlabeled_category is not None:
+            unlabeled_mask = torch.as_tensor(
+                label_categories == unlabeled_category,
+                device=all_logits.device,
+            )
+            all_logits = all_logits.masked_fill(unlabeled_mask.unsqueeze(0), -torch.inf)
         probabilities = torch.nn.functional.softmax(all_logits, dim=-1).numpy()
         predicted_indices = torch.argmax(all_logits, dim=1).numpy()
         confidence = probabilities.max(axis=1)

--- a/src/scvi/external/drvi/_distributions.py
+++ b/src/scvi/external/drvi/_distributions.py
@@ -5,7 +5,8 @@ import torch.nn.functional as F
 from torch.distributions import Distribution, constraints
 from torch.distributions.utils import broadcast_all
 
-from scvi.distributions._negative_binomial import _gamma, torch_lgamma_mps
+from scvi.distributions._negative_binomial import _gamma, _lgamma_fn
+from scvi.distributions._utils import _needs_cpu_detour
 
 
 class LogNegativeBinomial(Distribution):
@@ -48,7 +49,8 @@ class LogNegativeBinomial(Distribution):
         validate_args: bool = False,
     ) -> None:
         self._eps = 1e-8
-        self.on_mps = log_m.device.type == "mps"  # TODO: until torch solves the MPS issues
+        self._device = log_m.device
+        self.on_mps = self._device.type == "mps"
         if log_scale is None:
             self.log_m, self.log_r = broadcast_all(log_m, log_r)
             self.log_scale = None
@@ -97,7 +99,7 @@ class LogNegativeBinomial(Distribution):
     def log_prob(self, value: torch.Tensor) -> torch.Tensor:
         """Negative-binomial log-probability evaluated from the log-parameters."""
         log_m, log_r, eps = self.log_m, self.log_r, self._eps
-        lgamma = torch_lgamma_mps if self.on_mps else torch.lgamma  # TODO: TORCH MPS FIX
+        lgamma = _lgamma_fn(self.on_mps)
         r = torch.exp(log_r)
         # log C(value + r - 1, value)
         choice = lgamma(value + r + eps) - lgamma(value + 1 + eps) - lgamma(r + eps)
@@ -111,16 +113,14 @@ class LogNegativeBinomial(Distribution):
     def sample(self, sample_shape: torch.Size | tuple | None = None) -> torch.Tensor:
         """Sample via the Gamma-Poisson mixture (same as a negative binomial)."""
         sample_shape = sample_shape or torch.Size()
-        gamma_d = _gamma(self.theta, self.mu, self.on_mps)  # TODO: TORCH MPS FIX - DONE ON CPU
+        gamma_d = _gamma(self.theta, self.mu, self.on_mps)
         p_means = gamma_d.sample(sample_shape)
         # Clamp as the distribution objects can behave badly when their parameters are too high.
         l_train = torch.clamp(p_means, max=1e8)
-        counts = (
-            torch.distributions.Poisson(l_train).sample().to("mps")
-            if self.on_mps  # TODO: NEED TORCH MPS FIX for 'aten::poisson'
-            else torch.distributions.Poisson(l_train).sample()
-        )
-        return counts
+        if _needs_cpu_detour(self.on_mps, torch.poisson):
+            l_train = l_train.to("cpu")
+        counts = torch.distributions.Poisson(l_train).sample()
+        return counts.to(self._device)
 
     def __repr__(self) -> str:
         param_names = [k for k, _ in self.arg_constraints.items() if k in self.__dict__]

--- a/src/scvi/external/resolvi/_module.py
+++ b/src/scvi/external/resolvi/_module.py
@@ -172,8 +172,8 @@ class RESOLVAEModel(PyroModule):
             )
         self.register_buffer("px_r", init_px_r)
 
-        self.register_buffer("median_distance", torch.tensor(median_distance))
-        self.register_buffer("sparsity_diffusion", torch.tensor(sparsity_diffusion))
+        self.register_buffer("median_distance", torch.tensor(float(median_distance)))
+        self.register_buffer("sparsity_diffusion", torch.tensor(float(sparsity_diffusion)))
         self.register_buffer("gene_dummy", torch.ones([n_batch, n_input]))
 
         if self.semisupervised:
@@ -192,9 +192,9 @@ class RESOLVAEModel(PyroModule):
             "prior_proportions",
             torch.tensor(
                 [
-                    prior_true_amount,
-                    prior_diffusion_amount,
-                    10 * background_ratio * prior_true_amount + 1e-3,
+                    float(prior_true_amount),
+                    float(prior_diffusion_amount),
+                    float(10 * background_ratio * prior_true_amount + 1e-3),
                 ]
             ),
         )
@@ -848,9 +848,14 @@ class RESOLVAEGuide(PyroModule):
         self.n_input = n_input
         self.n_obs = n_obs
         self.n_neighbors = n_neighbors
-        self.median_distance = median_distance
-        self.downsample_counts_mean = downsample_counts_mean
-        self.downsample_counts_std = downsample_counts_std
+        # median_distance/downsample_counts_* are auto-computed from data via np.median/np.std
+        # (numpy.float64, not a plain float); casting here keeps arithmetic with float32 tensors
+        # from silently upcasting to float64, which torch's mps backend cannot move to device.
+        self.median_distance = float(median_distance)
+        self.downsample_counts_mean = (
+            None if downsample_counts_mean is None else float(downsample_counts_mean)
+        )
+        self.downsample_counts_std = float(downsample_counts_std)
 
         if self.dispersion == "gene":
             init_px_r = torch.full([n_input], 0.01)

--- a/src/scvi/external/velovi/_module.py
+++ b/src/scvi/external/velovi/_module.py
@@ -9,6 +9,7 @@ from torch import nn as nn
 from torch.distributions import Categorical, Dirichlet, MixtureSameFamily, Normal
 from torch.distributions import kl_divergence as kl
 
+from scvi.distributions._utils import _needs_cpu_detour
 from scvi.external.velovi._constants import VELOVI_REGISTRY_KEYS
 from scvi.module._constants import MODULE_KEYS
 from scvi.module.base import BaseModuleClass, LossOutput, auto_move_data
@@ -418,9 +419,10 @@ class VELOVAE(BaseModuleClass):
         """Runs the generative model."""
         decoder_input = z
         px_pi_alpha, px_rho, px_tau = self.decoder(decoder_input, latent_dim=latent_dim)
-        # TODO: NEED TORCH MPS FIX for 'aten::_dirichlet'
-        if px_pi_alpha.device.type == "mps":
-            px_pi = Dirichlet(px_pi_alpha.to("cpu")).rsample().to("mps")
+        device = px_pi_alpha.device
+        on_mps = device.type == "mps"
+        if _needs_cpu_detour(on_mps, torch._sample_dirichlet):
+            px_pi = Dirichlet(px_pi_alpha.to("cpu")).rsample().to(device)
         else:
             px_pi = Dirichlet(px_pi_alpha).rsample()
 

--- a/src/scvi/model/_totalvi.py
+++ b/src/scvi/model/_totalvi.py
@@ -18,6 +18,7 @@ from scvi.data._compat import registry_from_setup_dict
 from scvi.data._constants import ADATA_MINIFY_TYPE
 from scvi.data._utils import _check_nonnegative_integers, _get_adata_minify_type
 from scvi.dataloaders import DataSplitter
+from scvi.distributions._utils import _needs_cpu_detour
 from scvi.model._utils import (
     _get_batch_code_from_category,
     _get_var_names_from_manager,
@@ -1023,10 +1024,12 @@ class TOTALVI(
             # This gamma is really l*w using scVI manuscript notation
             p = rate / (rate + dispersion)
             r = dispersion
-            # TODO: NEED TORCH MPS FIX for 'aten::_standard_gamma'
+            on_mps = self.device.type == "mps"
             l_train = (
-                torch.distributions.Gamma(r.to("cpu"), ((1 - p) / p).to("cpu")).sample().to("mps")
-                if self.device.type == "mps"
+                torch.distributions.Gamma(r.to("cpu"), ((1 - p) / p).to("cpu"))
+                .sample()
+                .to(self.device)
+                if _needs_cpu_detour(on_mps, torch._standard_gamma)
                 else torch.distributions.Gamma(r, (1 - p) / p).sample()
             )
             data = l_train.cpu().numpy()

--- a/src/scvi/model/_utils.py
+++ b/src/scvi/model/_utils.py
@@ -110,19 +110,7 @@ def parse_device_args(
             UserWarning,
             stacklevel=settings.warnings_stacklevel,
         )
-    elif _accelerator == "mps" and accelerator == "auto":
-        # auto accelerator should not default to mps
-        connector = _AcceleratorConnector(accelerator="cpu", devices=devices)
-        _accelerator = connector._accelerator_flag
-        _devices = connector._devices_flag
-        warnings.warn(
-            "`accelerator` has been automatically set to `cpu` although 'mps' exists. If you wish "
-            "to run on mps backend, use explicitly accelerator='mps' in train function."
-            "In future releases it will become default for mps supported machines.",
-            UserWarning,
-            stacklevel=settings.warnings_stacklevel,
-        )
-    elif _accelerator == "mps" and accelerator != "auto":
+    elif _accelerator == "mps":
         warnings.warn(
             "`accelerator` has been set to `mps`. Not all PyTorch operations are implemented "
             "for this backend, so some models may be slower or may fail on unsupported ops; "

--- a/src/scvi/model/_utils.py
+++ b/src/scvi/model/_utils.py
@@ -124,10 +124,11 @@ def parse_device_args(
         )
     elif _accelerator == "mps" and accelerator != "auto":
         warnings.warn(
-            "`accelerator` has been set to `mps`. Please note that not all PyTorch "
-            "operations are supported with this backend. as a result, some models might be slower "
-            "and less accurate than usual. Please verify your analysis!"
-            "Refer to https://github.com/pytorch/pytorch/issues/77764 for more details.",
+            "`accelerator` has been set to `mps`. Not all PyTorch operations are implemented "
+            "for this backend, so some models may be slower or may fail on unsupported ops; "
+            "refer to https://github.com/pytorch/pytorch/issues/77764 for more details. "
+            "Results will not be bit-identical to CPU or CUDA runs because RNG streams differ "
+            "per backend.",
             UserWarning,
             stacklevel=settings.warnings_stacklevel,
         )

--- a/src/scvi/model/_utils.py
+++ b/src/scvi/model/_utils.py
@@ -110,7 +110,19 @@ def parse_device_args(
             UserWarning,
             stacklevel=settings.warnings_stacklevel,
         )
-    elif _accelerator == "mps":
+    elif _accelerator == "mps" and accelerator == "auto":
+        # auto accelerator should not default to mps
+        connector = _AcceleratorConnector(accelerator="cpu", devices=devices)
+        _accelerator = connector._accelerator_flag
+        _devices = connector._devices_flag
+        warnings.warn(
+            "`accelerator` has been automatically set to `cpu` although 'mps' exists. If you wish "
+            "to run on mps backend, use explicitly accelerator='mps' in train function."
+            "In future releases it will become default for mps supported machines.",
+            UserWarning,
+            stacklevel=settings.warnings_stacklevel,
+        )
+    elif _accelerator == "mps" and accelerator != "auto":
         warnings.warn(
             "`accelerator` has been set to `mps`. Not all PyTorch operations are implemented "
             "for this backend, so some models may be slower or may fail on unsupported ops; "

--- a/src/scvi/model/_utils.py
+++ b/src/scvi/model/_utils.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import warnings
 from collections.abc import Iterable as IterableClass
 from collections.abc import Sequence
@@ -110,8 +111,14 @@ def parse_device_args(
             UserWarning,
             stacklevel=settings.warnings_stacklevel,
         )
-    elif _accelerator == "mps" and accelerator == "auto":
-        # auto accelerator should not default to mps
+    elif (
+        _accelerator == "mps"
+        and accelerator == "auto"
+        and not os.environ.get("SCVI_ALLOW_MPS_AUTO")
+    ):
+        # auto accelerator should not default to mps, unless a dedicated device-testing CI run
+        # (e.g. test_mps.yaml) opts in via SCVI_ALLOW_MPS_AUTO so `auto` behaves the way it
+        # already does on CUDA machines, without changing the library's real default.
         connector = _AcceleratorConnector(accelerator="cpu", devices=devices)
         _accelerator = connector._accelerator_flag
         _devices = connector._devices_flag
@@ -122,7 +129,7 @@ def parse_device_args(
             UserWarning,
             stacklevel=settings.warnings_stacklevel,
         )
-    elif _accelerator == "mps" and accelerator != "auto":
+    elif _accelerator == "mps":
         warnings.warn(
             "`accelerator` has been set to `mps`. Not all PyTorch operations are implemented "
             "for this backend, so some models may be slower or may fail on unsupported ops; "

--- a/src/scvi/model/base/_rnamixin.py
+++ b/src/scvi/model/base/_rnamixin.py
@@ -14,7 +14,11 @@ from pyro.distributions.util import deep_to
 
 from scvi import REGISTRY_KEYS, settings
 from scvi.data._utils import _validate_adata_dataloader_input
-from scvi.distributions._utils import DistributionConcatenator, subset_distribution
+from scvi.distributions._utils import (
+    DistributionConcatenator,
+    _needs_cpu_detour,
+    subset_distribution,
+)
 from scvi.model._utils import _get_batch_code_from_category, scrna_raw_counts_properties
 from scvi.model.base._de_core import _de_core
 from scvi.model.utils import _de_core_for_annbatch
@@ -690,10 +694,10 @@ class RNASeqMixin:
             # This gamma is using scVI manuscript notation
             p = rate / (rate + px_dispersion)
             r = px_dispersion
-            # TODO: NEED TORCH MPS FIX for 'aten::_standard_gamma'
+            on_mps = device.type == "mps"
             l_train = (
                 torch.distributions.Gamma(r.to("cpu"), ((1 - p) / p).to("cpu")).sample()
-                if device.type == "mps"
+                if _needs_cpu_detour(on_mps, torch._standard_gamma)
                 else torch.distributions.Gamma(r, (1 - p) / p).sample().cpu()
             )
             data = l_train.numpy()

--- a/src/scvi/module/_autozivae.py
+++ b/src/scvi/module/_autozivae.py
@@ -9,6 +9,7 @@ from torch.distributions import kl_divergence as kl
 
 from scvi import REGISTRY_KEYS
 from scvi.distributions import NegativeBinomial, ZeroInflatedNegativeBinomial
+from scvi.distributions._utils import _needs_cpu_detour
 from scvi.module.base import LossOutput, auto_move_data
 
 from ._vae import VAE
@@ -174,10 +175,11 @@ class AutoZIVAE(VAE):
         # Warning : use logs and perform logsumexp to avoid numerical issues
 
         # Sample from Gamma
-        if alpha.device.type == "mps":
-            # TODO MPS support of Gamma distribution
-            sample_x_log = torch.log(Gamma(alpha.to("cpu"), 1).rsample() + eps_gamma).to("mps")
-            sample_y_log = torch.log(Gamma(beta.to("cpu"), 1).rsample() + eps_gamma).to("mps")
+        device = alpha.device
+        on_mps = device.type == "mps"
+        if _needs_cpu_detour(on_mps, torch._standard_gamma):
+            sample_x_log = torch.log(Gamma(alpha.to("cpu"), 1).rsample() + eps_gamma).to(device)
+            sample_y_log = torch.log(Gamma(beta.to("cpu"), 1).rsample() + eps_gamma).to(device)
         else:
             sample_x_log = torch.log(Gamma(alpha, 1).rsample() + eps_gamma)
             sample_y_log = torch.log(Gamma(beta, 1).rsample() + eps_gamma)

--- a/src/scvi/module/_vae.py
+++ b/src/scvi/module/_vae.py
@@ -10,6 +10,7 @@ from torch.nn.functional import one_hot
 
 from scvi import REGISTRY_KEYS, settings
 from scvi.data._constants import ADATA_MINIFY_TYPE
+from scvi.distributions._utils import _needs_cpu_detour
 from scvi.module._constants import MODULE_KEYS
 from scvi.module.base import (
     BaseMinifiedModeModuleClass,
@@ -646,12 +647,11 @@ class VAE(EmbeddingModuleMixin, BaseMinifiedModeModuleClass):
 
         dist = generative_outputs[MODULE_KEYS.PX_KEY]
         if self.gene_likelihood == "poisson":
-            # TODO: NEED TORCH MPS FIX for 'aten::poisson'
-            dist = (
-                Poisson(torch.clamp(dist.rate.to("cpu"), max=max_poisson_rate))
-                if self.device.type == "mps"
-                else Poisson(torch.clamp(dist.rate, max=max_poisson_rate))
-            )
+            on_mps = self.device.type == "mps"
+            rate = torch.clamp(dist.rate, max=max_poisson_rate)
+            if _needs_cpu_detour(on_mps, torch.poisson):
+                rate = rate.to("cpu")
+            dist = Poisson(rate)
 
         # (n_obs, n_vars) if n_samples == 1, else (n_samples, n_obs, n_vars)
         samples = dist.sample()

--- a/src/scvi/nn/_base_components.py
+++ b/src/scvi/nn/_base_components.py
@@ -1,5 +1,6 @@
 import collections
 from collections.abc import Callable, Iterable
+from functools import cache
 from typing import Literal
 
 import torch
@@ -12,6 +13,23 @@ from scvi.nn._utils import ExpActivation
 
 def _identity(x):
     return x
+
+
+@cache
+def _mps_supports_batchnorm_slice() -> bool:
+    """Whether BatchNorm1d can run on a non-contiguous MPS slice without a defensive ``.clone()``.
+
+    Probed rather than version-compared for the same reason as
+    :func:`scvi.distributions._utils._mps_supports`: source and nightly builds report versions
+    that a comparison reads wrongly. See https://github.com/pytorch/pytorch/issues/132605.
+    """
+    try:
+        bn = nn.BatchNorm1d(1).to("mps")
+        x = torch.zeros(2, 3, 1, device="mps")
+        bn(x[0])
+    except (NotImplementedError, RuntimeError):
+        return False
+    return True
 
 
 class FCLayers(nn.Module):
@@ -190,7 +208,7 @@ class FCLayers(nn.Module):
     def _apply_batch_norm(self, layer: nn.Module, x: torch.Tensor) -> torch.Tensor:
         """Apply a batch-norm layer, handling the 3D (and MPS) case."""
         if x.dim() == 3:
-            if x.device.type == "mps":  # TODO: remove this when MPS supports for loop.
+            if x.device.type == "mps" and not _mps_supports_batchnorm_slice():
                 return torch.cat([(layer(slice_x.clone())).unsqueeze(0) for slice_x in x], dim=0)
             return torch.cat([layer(slice_x).unsqueeze(0) for slice_x in x], dim=0)
         return layer(x)

--- a/src/scvi/train/_trainingplans.py
+++ b/src/scvi/train/_trainingplans.py
@@ -28,6 +28,26 @@ from ._metrics import ElboMetric
 TorchOptimizerCreator = Callable[[Iterable[torch.Tensor]], torch.optim.Optimizer]
 
 
+def _dynamo_frame_counts() -> tuple[int, int]:
+    """Frames dynamo has attempted and compiled so far, process-wide."""
+    from torch._dynamo.utils import counters
+
+    frames = counters.get("frames", {})
+    return frames.get("total", 0), frames.get("ok", 0)
+
+
+def _compilation_fell_back(before: tuple[int, int], after: tuple[int, int]) -> bool:
+    """Whether every frame dynamo attempted between the two readings failed to compile.
+
+    The counters are process-wide and cumulative, so the two readings are compared as a
+    delta rather than as absolute values: a second model in the same session must not
+    inherit the first one's successes.
+    """
+    attempted = after[0] - before[0]
+    compiled = after[1] - before[1]
+    return attempted > 0 and compiled == 0
+
+
 def _compute_kl_weight(
     epoch: int,
     step: int,
@@ -98,6 +118,10 @@ class TrainingPlan(pl.LightningModule):
     optimizer_creator
         A callable taking in parameters and returning a :class:`~torch.optim.Optimizer`.
         This allows using any PyTorch optimizer with custom hyperparameters.
+    fused_optimizer
+        Whether to use the fused implementation of the optimizer when the backend
+        supports it, falling back to the standard one when it does not. The fused path
+        issues far fewer kernels per step, which matters most on `mps`.
     lr
         Learning rate used for optimization when `optimizer_creator` is None.
     weight_decay
@@ -147,6 +171,7 @@ class TrainingPlan(pl.LightningModule):
         *,
         optimizer: Literal["Adam", "AdamW", "Custom"] = "Adam",
         optimizer_creator: TorchOptimizerCreator | None = None,
+        fused_optimizer: bool = True,
         lr: float = 1e-3,
         update_only_decoder: bool = False,
         weight_decay: float = 1e-6,
@@ -187,6 +212,7 @@ class TrainingPlan(pl.LightningModule):
         self.min_kl_weight = min_kl_weight
         self.max_kl_weight = max_kl_weight
         self.optimizer_creator = optimizer_creator
+        self.fused_optimizer = fused_optimizer
         self.update_only_decoder = update_only_decoder
         self.on_step = on_step
         self.on_epoch = on_epoch
@@ -198,11 +224,18 @@ class TrainingPlan(pl.LightningModule):
         self._n_obs_validation = None
 
         # Whether to compile the module first
+        self._compile_suppress_errors_before = None
+        self._compile_frames_before = None
         if compile:
             if compile_kwargs is None:
                 compile_kwargs = {}
             compile_kwargs["dynamic"] = compile_kwargs.get("dynamic", False)
+            # Suppressing dynamo's errors degrades a failed compilation to eager instead
+            # of raising. It is process-wide, so remember what it was and put it back in
+            # `on_train_end`; compilation itself is lazy, so it cannot be restored here.
+            self._compile_suppress_errors_before = torch._dynamo.config.suppress_errors
             torch._dynamo.config.suppress_errors = True
+            self._compile_frames_before = _dynamo_frame_counts()
             self.module = torch.compile(module, **compile_kwargs)
         else:
             self.module = module
@@ -424,6 +457,20 @@ class TrainingPlan(pl.LightningModule):
                         },
                     )
 
+    def on_train_end(self):
+        """Undo the process-wide dynamo state that ``compile=True`` turned on."""
+        if self._compile_suppress_errors_before is None:
+            return
+        torch._dynamo.config.suppress_errors = self._compile_suppress_errors_before
+        if _compilation_fell_back(self._compile_frames_before, _dynamo_frame_counts()):
+            warnings.warn(
+                "`compile=True` was requested but every frame torch.compile attempted "
+                "fell back to eager, so the model trained uncompiled. Re-run with "
+                "`torch._dynamo.config.suppress_errors = False` to see why.",
+                UserWarning,
+                stacklevel=settings.warnings_stacklevel,
+            )
+
     def training_step(self, batch, batch_idx):
         """Training step for the model."""
         if "kl_weight" in self.loss_kwargs:
@@ -477,9 +524,24 @@ class TrainingPlan(pl.LightningModule):
 
         This type of function can be passed as the `optimizer_creator`
         """
-        return lambda params: optimizer_cls(
-            params, lr=self.lr, eps=self.eps, weight_decay=self.weight_decay
-        )
+
+        def create(params) -> torch.optim.Optimizer:
+            # `params` is usually a generator, and a rejected fused optimizer has to be
+            # retried with the same parameters, so materialise it once.
+            params = list(params)
+            kwargs = {"lr": self.lr, "eps": self.eps, "weight_decay": self.weight_decay}
+            if self.fused_optimizer:
+                try:
+                    return optimizer_cls(params, fused=True, **kwargs)
+                except (RuntimeError, ValueError, AssertionError, TypeError):
+                    # Whether fused is available depends on the device, the parameter
+                    # dtypes and the torch version, and torch says so by raising at
+                    # construction time. Its own rules are more reliable than a device
+                    # allowlist maintained here, so fall back on being told no.
+                    pass
+            return optimizer_cls(params, **kwargs)
+
+        return create
 
     def get_optimizer_creator(self):
         """Get the optimizer creator for the model."""

--- a/tests/data/test_preprocessing.py
+++ b/tests/data/test_preprocessing.py
@@ -1,4 +1,5 @@
 import pytest
+import torch
 
 
 def test_poisson_gene_selection():
@@ -32,6 +33,37 @@ def test_poisson_gene_selection():
     adata.X = 0.25 * X
     with pytest.raises(ValueError):
         poisson_gene_selection(adata, batch_key="batch", n_top_genes=n_top_genes)
+
+
+def test_poisson_gene_selection_binomial_cpu_detour_forced(monkeypatch):
+    """Forces the CPU detour the way a torch without an MPS 'binomial' kernel would."""
+    import numpy as np
+
+    import scvi.data._preprocessing as preprocessing_module
+    from scvi.data import poisson_gene_selection, synthetic_iid
+
+    monkeypatch.setattr(preprocessing_module, "_needs_cpu_detour", lambda on_mps, op: True)
+
+    n_top_genes = 10
+    adata = synthetic_iid()
+    poisson_gene_selection(
+        adata, batch_key="batch", n_top_genes=n_top_genes, accelerator="cpu"
+    )
+    assert np.sum(adata.var["highly_variable"]) == n_top_genes
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")
+def test_poisson_gene_selection_on_mps():
+    import numpy as np
+
+    from scvi.data import poisson_gene_selection, synthetic_iid
+
+    n_top_genes = 10
+    adata = synthetic_iid()
+    poisson_gene_selection(
+        adata, batch_key="batch", n_top_genes=n_top_genes, accelerator="mps"
+    )
+    assert np.sum(adata.var["highly_variable"]) == n_top_genes
 
 
 @pytest.mark.internet

--- a/tests/data/test_preprocessing.py
+++ b/tests/data/test_preprocessing.py
@@ -46,9 +46,7 @@ def test_poisson_gene_selection_binomial_cpu_detour_forced(monkeypatch):
 
     n_top_genes = 10
     adata = synthetic_iid()
-    poisson_gene_selection(
-        adata, batch_key="batch", n_top_genes=n_top_genes, accelerator="cpu"
-    )
+    poisson_gene_selection(adata, batch_key="batch", n_top_genes=n_top_genes, accelerator="cpu")
     assert np.sum(adata.var["highly_variable"]) == n_top_genes
 
 
@@ -60,9 +58,7 @@ def test_poisson_gene_selection_on_mps():
 
     n_top_genes = 10
     adata = synthetic_iid()
-    poisson_gene_selection(
-        adata, batch_key="batch", n_top_genes=n_top_genes, accelerator="mps"
-    )
+    poisson_gene_selection(adata, batch_key="batch", n_top_genes=n_top_genes, accelerator="mps")
     assert np.sum(adata.var["highly_variable"]) == n_top_genes
 
 

--- a/tests/dataloaders/sparse_utils.py
+++ b/tests/dataloaders/sparse_utils.py
@@ -24,7 +24,12 @@ class TestSparseDataSplitter(scvi.dataloaders.DataSplitter):
     def on_after_batch_transfer(self, batch, dataloader_idx):
         X = batch.get(scvi.REGISTRY_KEYS.X_KEY)
         assert isinstance(X, torch.Tensor)
-        assert X.layout is self.expected_sparse_layout
+        if X.device.type == "mps":
+            # MPS has no sparse tensor support at all, so transfer_batch_to_device must have
+            # already densified this before the transfer even reached the device.
+            assert X.layout == torch.strided
+        else:
+            assert X.layout is self.expected_sparse_layout
 
         batch = super().on_after_batch_transfer(batch, dataloader_idx)
 

--- a/tests/dataloaders/test_datasplitter.py
+++ b/tests/dataloaders/test_datasplitter.py
@@ -4,7 +4,10 @@ from math import ceil, floor
 
 import numpy as np
 import pytest
+import torch
 
+import scvi.dataloaders._data_splitting as data_splitting_module
+from scvi import REGISTRY_KEYS
 from scvi.data import synthetic_iid
 from scvi.dataloaders import DataSplitter, SemiSupervisedDataSplitter
 from tests.data.utils import generic_setup_adata_manager
@@ -228,3 +231,42 @@ def test_datasplitter_load_sparse_tensor(
         expected_sparse_layout=sparse_format.split("_")[0],
         external_indexing=[np.array(train_ind), np.array(valid_ind)],
     )
+
+
+def test_mps_supports_sparse_compressed_tensor_probe_answers_without_a_device():
+    result = data_splitting_module._mps_supports_sparse_compressed_tensor()
+    assert isinstance(result, bool)
+    if not torch.backends.mps.is_available():
+        assert result is False
+
+
+@pytest.mark.parametrize(
+    ("device_str", "supports_sparse", "expect_dense"),
+    [("cpu", False, False), ("cpu", True, False), ("mps", True, False), ("mps", False, True)],
+)
+def test_transfer_batch_to_device_densifies_only_for_mps_without_sparse_support(
+    monkeypatch, device_str, supports_sparse, expect_dense
+):
+    monkeypatch.setattr(
+        data_splitting_module, "_mps_supports_sparse_compressed_tensor", lambda: supports_sparse
+    )
+    # Bypass the real device transfer (this test must run on any machine); only the
+    # densify-before-transfer logic is under test here.
+    monkeypatch.setattr(
+        data_splitting_module.pl.LightningDataModule,
+        "transfer_batch_to_device",
+        lambda self, batch, device, dataloader_idx: batch,
+    )
+
+    adata = synthetic_iid()
+    manager = generic_setup_adata_manager(adata)
+    splitter = DataSplitter(manager, load_sparse_tensor=True)
+
+    x_sparse = torch.eye(3).to_sparse_csr()
+    batch = {REGISTRY_KEYS.X_KEY: x_sparse}
+    out = splitter.transfer_batch_to_device(batch, torch.device(device_str), 0)
+
+    if expect_dense:
+        assert out[REGISTRY_KEYS.X_KEY].layout == torch.strided
+    else:
+        assert out[REGISTRY_KEYS.X_KEY].layout == torch.sparse_csr

--- a/tests/distributions/test_beta_binomial.py
+++ b/tests/distributions/test_beta_binomial.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 
+import scvi.distributions._beta_binomial as beta_binomial_module
 from scvi.distributions import BetaBinomial
 
 
@@ -43,3 +44,34 @@ def test_beta_binomial_distribution():
     # Should fail without a complete parameterization 1 or 2
     with pytest.raises(ValueError):
         BetaBinomial(total_count=total_count, alpha=alpha, gamma=gamma)
+
+
+def test_sample_cpu_detour_forced(monkeypatch):
+    """Forces the CPU detour the way a torch without MPS '_sample_dirichlet'/'binomial' kernels
+    would."""
+    monkeypatch.setattr(beta_binomial_module, "_needs_cpu_detour", lambda on_mps, op: True)
+
+    alpha = torch.ones(64, 8) * 2
+    beta = torch.ones(64, 8) * 2
+    total_count = torch.ones(64, 8) * 100
+    dist = BetaBinomial(total_count=total_count, alpha=alpha, beta=beta)
+
+    samples = dist.sample((16,))
+    assert samples.shape == (16, 64, 8)
+    assert (samples >= 0).all()
+    assert (samples <= 100).all()
+    assert samples.device == alpha.device
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")
+def test_sample_stays_on_mps():
+    alpha = torch.ones(64, 8, device="mps") * 2
+    beta = torch.ones(64, 8, device="mps") * 2
+    total_count = torch.ones(64, 8, device="mps") * 100
+    dist = BetaBinomial(total_count=total_count, alpha=alpha, beta=beta)
+
+    samples = dist.sample((16,))
+    assert samples.device.type == "mps"
+    assert samples.shape == (16, 64, 8)
+    assert (samples >= 0).all()
+    assert (samples <= 100).all()

--- a/tests/distributions/test_gamma.py
+++ b/tests/distributions/test_gamma.py
@@ -1,5 +1,7 @@
+import pytest
 import torch
 
+import scvi.distributions._gamma as gamma_module
 from scvi.distributions import ZeroInflatedGamma
 
 
@@ -122,3 +124,31 @@ def test_zi_gamma_low_zero_inflation():
     zero_proportion = (samples == 0).float().mean()
     expected_zi_prob = torch.sigmoid(zi_logits).item()
     assert (zero_proportion - expected_zi_prob).abs() <= 0.05
+
+
+def test_sample_gamma_cpu_detour_forced(monkeypatch):
+    """Forces the CPU detour the way a torch without an MPS '_standard_gamma' kernel would."""
+    monkeypatch.setattr(gamma_module, "_needs_cpu_detour", lambda on_mps, op: True)
+
+    concentration = torch.rand(64, 8) + 0.5
+    rate = torch.rand(64, 8) + 0.5
+    zi_logits = torch.randn(64, 8)
+    dist = ZeroInflatedGamma(concentration=concentration, rate=rate, zi_logits=zi_logits)
+
+    samples = dist.sample((16,))
+    assert samples.shape == (16, 64, 8)
+    assert (samples >= 0).all()
+    assert samples.device == concentration.device
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")
+def test_sample_gamma_stays_on_mps():
+    concentration = torch.rand(64, 8, device="mps") + 0.5
+    rate = torch.rand(64, 8, device="mps") + 0.5
+    zi_logits = torch.randn(64, 8, device="mps")
+    dist = ZeroInflatedGamma(concentration=concentration, rate=rate, zi_logits=zi_logits)
+
+    samples = dist.sample((16,))
+    assert samples.device.type == "mps"
+    assert samples.shape == (16, 64, 8)
+    assert (samples >= 0).all()

--- a/tests/distributions/test_negative_binomial.py
+++ b/tests/distributions/test_negative_binomial.py
@@ -13,7 +13,11 @@ from scvi.distributions._negative_binomial import (
     log_nb_positive,
     log_zinb_positive,
 )
-from scvi.distributions._utils import _mps_supports, _needs_cpu_detour
+from scvi.distributions._utils import (
+    _mps_supports,
+    _mps_supports_lgamma_on_noncontiguous,
+    _needs_cpu_detour,
+)
 
 
 def test_zinb_distribution():
@@ -150,3 +154,40 @@ def test_cpu_detour_path_still_samples_correctly(monkeypatch):
     assert samples.device == mu.device
     assert (samples.mean(0) - mu).abs().mean() <= 1e0
     assert _gamma(theta, mu, on_mps=True).concentration.device.type == "cpu"
+
+
+def test_lgamma_noncontiguous_support_probe_answers_without_a_device():
+    supported = _mps_supports_lgamma_on_noncontiguous()
+    assert isinstance(supported, bool)
+    if not torch.backends.mps.is_available():
+        assert supported is False
+
+
+@pytest.mark.parametrize(
+    ("on_mps", "supports_noncontiguous", "expected_is_plain_lgamma"),
+    [(False, False, True), (False, True, True), (True, True, True), (True, False, False)],
+)
+def test_lgamma_fn_uses_the_contiguous_wrapper_only_when_mps_needs_it(
+    monkeypatch, on_mps, supports_noncontiguous, expected_is_plain_lgamma
+):
+    monkeypatch.setattr(
+        nb_module, "_mps_supports_lgamma_on_noncontiguous", lambda: supports_noncontiguous
+    )
+    fn = nb_module._lgamma_fn(on_mps)
+    assert (fn is torch.lgamma) == expected_is_plain_lgamma
+    assert (fn is nb_module.torch_lgamma_mps) == (not expected_is_plain_lgamma)
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")
+def test_log_prob_matches_with_and_without_the_lgamma_contiguous_detour(monkeypatch):
+    """The contiguous-copy detour changes nothing numerically once lgamma supports it."""
+    theta = 100.0 + torch.rand(8, device="mps")
+    mu = 15.0 * torch.ones(64, 8, device="mps")
+    x = torch.randint(0, 20, (64, 8), device="mps").float()
+    dist = NegativeBinomial(mu=mu, theta=theta)
+
+    lp_with_detour = dist.log_prob(x)
+    monkeypatch.setattr(nb_module, "_mps_supports_lgamma_on_noncontiguous", lambda: True)
+    lp_without_detour = dist.log_prob(x)
+
+    assert torch.equal(lp_with_detour, lp_without_detour)

--- a/tests/distributions/test_negative_binomial.py
+++ b/tests/distributions/test_negative_binomial.py
@@ -7,13 +7,13 @@ from scvi.distributions import (
     ZeroInflatedNegativeBinomial,
 )
 from scvi.distributions import _negative_binomial as nb_module
+from scvi.distributions import _utils as dist_utils
 from scvi.distributions._negative_binomial import (
     _gamma,
-    _mps_supports,
-    _needs_cpu_detour,
     log_nb_positive,
     log_zinb_positive,
 )
+from scvi.distributions._utils import _mps_supports, _needs_cpu_detour
 
 
 def test_zinb_distribution():
@@ -114,7 +114,7 @@ def test_gamma_stays_on_mps_when_the_kernel_exists():
 def test_cpu_detour_is_taken_only_for_mps_without_a_kernel(
     monkeypatch, on_mps, kernel_present, expected
 ):
-    monkeypatch.setattr(nb_module, "_mps_supports", lambda op: kernel_present)
+    monkeypatch.setattr(dist_utils, "_mps_supports", lambda op: kernel_present)
     assert _needs_cpu_detour(on_mps, torch.poisson) is expected
 
 

--- a/tests/distributions/test_negative_binomial.py
+++ b/tests/distributions/test_negative_binomial.py
@@ -1,8 +1,19 @@
 import pytest
 import torch
 
-from scvi.distributions import NegativeBinomial, ZeroInflatedNegativeBinomial
-from scvi.distributions._negative_binomial import log_nb_positive, log_zinb_positive
+from scvi.distributions import (
+    NegativeBinomial,
+    NegativeBinomialMixture,
+    ZeroInflatedNegativeBinomial,
+)
+from scvi.distributions import _negative_binomial as nb_module
+from scvi.distributions._negative_binomial import (
+    _gamma,
+    _mps_supports,
+    _needs_cpu_detour,
+    log_nb_positive,
+    log_zinb_positive,
+)
 
 
 def test_zinb_distribution():
@@ -66,3 +77,76 @@ def test_zinb_distribution():
         dist1.log_prob(-x)
     with pytest.warns(UserWarning, match="The value argument must be within the support"):
         dist2.log_prob(0.5 * x)
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")
+def test_sampling_stays_on_mps():
+    theta = 100.0 + torch.rand(size=(64, 8), device="mps")
+    mu = 15.0 * torch.ones_like(theta)
+    dists = [
+        NegativeBinomial(mu=mu, theta=theta),
+        ZeroInflatedNegativeBinomial(mu=mu, theta=theta, zi_logits=torch.randn_like(theta)),
+        NegativeBinomialMixture(
+            mu1=mu, mu2=2.0 * mu, theta1=theta, mixture_logits=torch.zeros_like(theta)
+        ),
+    ]
+    for dist in dists:
+        samples = dist.sample((16,))
+        assert samples.device.type == "mps"
+        assert samples.shape == (16, 64, 8)
+        assert (samples >= 0).all()
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")
+def test_gamma_stays_on_mps_when_the_kernel_exists():
+    # The CPU detour is conditional on the running torch build, not hardcoded,
+    # so assert against the same probe rather than against a version.
+    theta = 100.0 + torch.rand(size=(4,), device="mps")
+    mu = 15.0 * torch.ones_like(theta)
+    expected = "mps" if _mps_supports(torch._standard_gamma) else "cpu"
+    assert _gamma(theta, mu, on_mps=True).concentration.device.type == expected
+
+
+@pytest.mark.parametrize(
+    ("on_mps", "kernel_present", "expected"),
+    [(False, False, False), (False, True, False), (True, True, False), (True, False, True)],
+)
+def test_cpu_detour_is_taken_only_for_mps_without_a_kernel(
+    monkeypatch, on_mps, kernel_present, expected
+):
+    monkeypatch.setattr(nb_module, "_mps_supports", lambda op: kernel_present)
+    assert _needs_cpu_detour(on_mps, torch.poisson) is expected
+
+
+def test_mps_support_probe_answers_without_a_device():
+    # The probe builds its own mps tensor inside the try, so a machine with no MPS
+    # gets False from the same code path rather than an exception.
+    supported = _mps_supports(torch.poisson)
+    assert isinstance(supported, bool)
+    if not torch.backends.mps.is_available():
+        assert supported is False
+
+
+def test_sampling_returns_the_device_it_was_given():
+    theta = 100.0 + torch.rand(size=(8, 3))
+    mu = 15.0 * torch.ones_like(theta)
+    for dist in (
+        NegativeBinomial(mu=mu, theta=theta),
+        NegativeBinomialMixture(
+            mu1=mu, mu2=2.0 * mu, theta1=theta, mixture_logits=torch.zeros_like(theta)
+        ),
+    ):
+        assert dist.sample((4,)).device == mu.device
+
+
+def test_cpu_detour_path_still_samples_correctly(monkeypatch):
+    # Force the fallback the way a torch without the kernels would, so the detour
+    # itself is exercised on any machine rather than only on Apple silicon.
+    monkeypatch.setattr(nb_module, "_needs_cpu_detour", lambda on_mps, op: True)
+    theta = 100.0 + torch.rand(size=(2,))
+    mu = 15.0 * torch.ones_like(theta)
+    samples = NegativeBinomial(mu=mu, theta=theta).sample((1000,))
+    assert samples.shape == (1000, 2)
+    assert samples.device == mu.device
+    assert (samples.mean(0) - mu).abs().mean() <= 1e0
+    assert _gamma(theta, mu, on_mps=True).concentration.device.type == "cpu"

--- a/tests/distributions/test_negative_binomial.py
+++ b/tests/distributions/test_negative_binomial.py
@@ -156,6 +156,43 @@ def test_cpu_detour_path_still_samples_correctly(monkeypatch):
     assert _gamma(theta, mu, on_mps=True).concentration.device.type == "cpu"
 
 
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")
+def test_lgamma_noncontiguous_probe_compares_values_not_just_exceptions():
+    # The failure mode the detour exists for is a wrong value, not an exception: on the torch
+    # builds that need it, lgamma on a stride-0 expanded mps tensor returns the right numbers
+    # for the first row and inf for the replicated ones. A probe that only catches exceptions
+    # would report support that is not there.
+    if not _mps_supports_lgamma_on_noncontiguous():
+        pytest.skip("this build has no non-contiguous mps lgamma, nothing to check")
+    expanded = (torch.arange(1, 5, device="mps", dtype=torch.float32) / 2).expand(4, 4)
+    assert torch.allclose(torch.lgamma(expanded), torch.lgamma(expanded.contiguous()))
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")
+def test_mixture_log_prob_is_finite_for_a_broadcast_theta_on_mps():
+    # NegativeBinomialMixture does not copy its parameters contiguously the way
+    # NegativeBinomial does, so `broadcast_all` leaves a per-gene theta as a stride-0
+    # expanded view that reaches lgamma directly. This is the shape totalVI uses.
+    mu1 = 15.0 * torch.ones(4, 6)
+    mu2 = 30.0 * torch.ones(4, 6)
+    theta1 = 100.0 + torch.rand(6)
+    logits = torch.zeros(4, 6)
+    x = torch.randint(0, 20, (4, 6)).float()
+
+    def log_prob_on(device):
+        dist = NegativeBinomialMixture(
+            mu1=mu1.to(device),
+            mu2=mu2.to(device),
+            theta1=theta1.to(device),
+            mixture_logits=logits.to(device),
+        )
+        return dist.log_prob(x.to(device))
+
+    on_mps = log_prob_on("mps")
+    assert torch.isfinite(on_mps).all()
+    assert torch.allclose(on_mps.cpu(), log_prob_on("cpu"), atol=1e-4)
+
+
 def test_lgamma_noncontiguous_support_probe_answers_without_a_device():
     supported = _mps_supports_lgamma_on_noncontiguous()
     assert isinstance(supported, bool)

--- a/tests/external/diagvi/test_diagvi.py
+++ b/tests/external/diagvi/test_diagvi.py
@@ -1600,6 +1600,8 @@ def test_predict_celltype_cross_modal_default(trained_semi_supervised_model):
     assert results["probabilities"].shape[0] == N_OBS_SPATIAL
     # N_LABELS + 1 because LabelsWithUnlabeledObsField adds "unknown" category
     assert results["probabilities"].shape[1] == N_LABELS + 1
+    # The unlabeled category is a sentinel, not a cell type prediction target.
+    assert np.all(results["probabilities"][:, -1] == 0)
     assert len(results["confidence"]) == N_OBS_SPATIAL
 
 

--- a/tests/external/drvi/test_drvi.py
+++ b/tests/external/drvi/test_drvi.py
@@ -8,7 +8,9 @@ from anndata import AnnData
 from torch import nn
 
 import scvi
+import scvi.external.drvi._distributions as drvi_distributions_module
 from scvi.external.drvi import DRVI, DRVIModule
+from scvi.external.drvi._distributions import LogNegativeBinomial
 
 
 def mock_adata(n_genes: int = 50, n_batches: int = 2, n_labels: int = 3) -> AnnData:
@@ -611,3 +613,29 @@ def test_drvi_rnaseq_mixin(gene_likelihood):
     de = model.differential_expression(groupby="labels", mode="change", silent=True)
     assert de.shape[0] > 0
     assert "proba_de" in de.columns
+
+
+def test_log_negative_binomial_sample_poisson_cpu_detour_forced(monkeypatch):
+    """Forces the CPU detour the way a torch without an MPS 'aten::poisson' kernel would."""
+    monkeypatch.setattr(drvi_distributions_module, "_needs_cpu_detour", lambda on_mps, op: True)
+
+    log_m = torch.randn(64, 8)
+    log_r = torch.randn(64, 8)
+    dist = LogNegativeBinomial(log_m=log_m, log_r=log_r)
+
+    samples = dist.sample((16,))
+    assert samples.shape == (16, 64, 8)
+    assert (samples >= 0).all()
+    assert samples.device == log_m.device
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")
+def test_log_negative_binomial_sample_poisson_stays_on_mps():
+    log_m = torch.randn(64, 8, device="mps")
+    log_r = torch.randn(64, 8, device="mps")
+    dist = LogNegativeBinomial(log_m=log_m, log_r=log_r)
+
+    samples = dist.sample((16,))
+    assert samples.device.type == "mps"
+    assert samples.shape == (16, 64, 8)
+    assert (samples >= 0).all()

--- a/tests/external/scviva/test_scviva.py
+++ b/tests/external/scviva/test_scviva.py
@@ -75,7 +75,6 @@ def test_scviva_train(adata: AnnData):
         validation_size=0.2,
         early_stopping=True,
         check_val_every_n_epoch=1,
-        accelerator="cpu",
     )
 
     assert nichevae.is_trained
@@ -107,7 +106,6 @@ def test_scviva_save_load(adata):
         validation_size=0.2,
         early_stopping=True,
         check_val_every_n_epoch=1,
-        accelerator="cpu",
     )
     hist_elbo = nichevae.history["elbo_train"]
     latent = nichevae.get_latent_representation()
@@ -156,7 +154,6 @@ def test_scviva_differential(adata):
         validation_size=0.2,
         early_stopping=True,
         check_val_every_n_epoch=1,
-        accelerator="cpu",
     )
 
     nichevae.differential_expression(
@@ -271,7 +268,6 @@ def test_scviva_scarches_less_features(split_ref_query_adata):
         validation_size=0.2,
         early_stopping=True,
         check_val_every_n_epoch=1,
-        accelerator="cpu",
     )
 
     assert nichevae.is_trained
@@ -300,7 +296,6 @@ def test_scviva_scarches_less_features(split_ref_query_adata):
         validation_size=0.2,
         early_stopping=True,
         check_val_every_n_epoch=1,
-        accelerator="cpu",
     )
 
     predicted_alpha = query_nichevae.predict_neighborhood(query_adata)
@@ -373,7 +368,6 @@ def test_scviva_scarches_same_features(split_ref_query_adata):
         validation_size=0.2,
         early_stopping=True,
         check_val_every_n_epoch=1,
-        accelerator="cpu",
     )
 
     assert nichevae.is_trained
@@ -399,7 +393,6 @@ def test_scviva_scarches_same_features(split_ref_query_adata):
         validation_size=0.2,
         early_stopping=True,
         check_val_every_n_epoch=1,
-        accelerator="cpu",
     )
 
     predicted_alpha = query_nichevae.predict_neighborhood(query_adata)
@@ -442,7 +435,6 @@ def test_scviva_scarches_batch_embedding(split_ref_query_adata):
         validation_size=0.2,
         early_stopping=True,
         check_val_every_n_epoch=1,
-        accelerator="cpu",
     )
 
     nichevae.preprocessing_query_anndata(
@@ -459,7 +451,6 @@ def test_scviva_scarches_batch_embedding(split_ref_query_adata):
         validation_size=0.2,
         early_stopping=True,
         check_val_every_n_epoch=1,
-        accelerator="cpu",
     )
 
     assert query_nichevae.get_latent_representation(query_adata).shape[0] == query_adata.n_obs

--- a/tests/external/velovi/test_velovi.py
+++ b/tests/external/velovi/test_velovi.py
@@ -1,7 +1,11 @@
+import numpy as np
 import pytest
+import torch
 
+import scvi.external.velovi._module as velovi_module_module
 from scvi.data import synthetic_iid
 from scvi.external.velovi import VELOVI
+from scvi.external.velovi._module import VELOVAE
 
 
 @pytest.mark.optional
@@ -25,3 +29,37 @@ def test_velovi():
 
     # tests __repr__
     print(model)
+
+
+def _make_velovae(n_input: int) -> VELOVAE:
+    return VELOVAE(
+        n_input=n_input,
+        switch_spliced=np.ones(n_input, dtype=np.float32),
+        switch_unspliced=np.ones(n_input, dtype=np.float32),
+    )
+
+
+def test_generative_dirichlet_cpu_detour_forced(monkeypatch):
+    """Forces the CPU detour the way a torch without an MPS '_sample_dirichlet' kernel would."""
+    monkeypatch.setattr(velovi_module_module, "_needs_cpu_detour", lambda on_mps, op: True)
+
+    n_input = 50
+    module = _make_velovae(n_input)
+    z = torch.randn(8, module.n_latent)
+    gamma, beta, alpha, alpha_1, lambda_alpha = module._get_rates()
+
+    outputs = module.generative(z, gamma, beta, alpha, alpha_1, lambda_alpha)
+    assert outputs["px_pi"].shape == (8, n_input, 4)
+    assert torch.allclose(outputs["px_pi"].sum(dim=-1), torch.ones(8, n_input), atol=1e-5)
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")
+def test_generative_dirichlet_stays_on_mps():
+    n_input = 50
+    module = _make_velovae(n_input).to("mps")
+    z = torch.randn(8, module.n_latent, device="mps")
+    gamma, beta, alpha, alpha_1, lambda_alpha = module._get_rates()
+
+    outputs = module.generative(z, gamma, beta, alpha, alpha_1, lambda_alpha)
+    assert outputs["px_pi"].device.type == "mps"
+    assert outputs["px_pi"].shape == (8, n_input, 4)

--- a/tests/model/base/test_rnamixin.py
+++ b/tests/model/base/test_rnamixin.py
@@ -1,0 +1,33 @@
+import pytest
+import torch
+
+import scvi.model.base._rnamixin as rnamixin_module
+from scvi.data import synthetic_iid
+from scvi.model import SCVI
+
+
+def _make_trained_model(gene_likelihood: str = "nb"):
+    adata = synthetic_iid()
+    SCVI.setup_anndata(adata, batch_key="batch")
+    model = SCVI(adata, gene_likelihood=gene_likelihood)
+    model.train(1, check_val_every_n_epoch=1, train_size=0.5)
+    return model
+
+
+def test_posterior_predictive_sample_gamma_cpu_detour_forced(monkeypatch):
+    """Forces the CPU detour the way a torch without an MPS '_standard_gamma' kernel would."""
+    monkeypatch.setattr(rnamixin_module, "_needs_cpu_detour", lambda on_mps, op: True)
+
+    model = _make_trained_model(gene_likelihood="nb")
+    sample = model.posterior_predictive_sample(n_samples=2)
+    assert sample.shape == (*model.adata.shape, 2)
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")
+def test_posterior_predictive_sample_on_mps():
+    adata = synthetic_iid()
+    SCVI.setup_anndata(adata, batch_key="batch")
+    model = SCVI(adata, gene_likelihood="nb")
+    model.train(1, check_val_every_n_epoch=1, train_size=0.5, accelerator="mps")
+    sample = model.posterior_predictive_sample(n_samples=2)
+    assert sample.shape == (*adata.shape, 2)

--- a/tests/model/test_autozi.py
+++ b/tests/model/test_autozi.py
@@ -5,8 +5,10 @@ import numpy as np
 import pytest
 import torch
 
+import scvi.module._autozivae as autozivae_module
 from scvi.data import synthetic_iid
 from scvi.model import AUTOZI
+from scvi.module import AutoZIVAE
 from scvi.utils import attrdict
 
 
@@ -138,3 +140,28 @@ def test_autozi():
         autozivae.get_normalized_expression(transform_batch="batch_1")
         autozivae.get_normalized_expression(n_samples=2)
         autozivae.differential_expression(groupby="labels", group1="label_1")
+
+
+def test_sample_from_beta_distribution_gamma_cpu_detour_forced(monkeypatch):
+    """Forces the CPU detour the way a torch without an MPS '_standard_gamma' kernel would."""
+    monkeypatch.setattr(autozivae_module, "_needs_cpu_detour", lambda on_mps, op: True)
+
+    vae = AutoZIVAE(n_input=50)
+    alpha = torch.rand(8, 50) + 0.5
+    beta = torch.rand(8, 50) + 0.5
+
+    sample = vae.sample_from_beta_distribution(alpha, beta)
+    assert sample.shape == (8, 50)
+    assert (sample > 0).all()
+    assert (sample < 1).all()
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")
+def test_sample_from_beta_distribution_stays_on_mps():
+    vae = AutoZIVAE(n_input=50).to("mps")
+    alpha = (torch.rand(8, 50, device="mps") + 0.5).contiguous()
+    beta = (torch.rand(8, 50, device="mps") + 0.5).contiguous()
+
+    sample = vae.sample_from_beta_distribution(alpha, beta)
+    assert sample.device.type == "mps"
+    assert sample.shape == (8, 50)

--- a/tests/model/test_multivi.py
+++ b/tests/model/test_multivi.py
@@ -4,12 +4,14 @@ import anndata as ad
 import numpy as np
 import pytest
 import scanpy as sc
+import torch
 from mudata import MuData
 
 import scvi
 from scvi import REGISTRY_KEYS
 from scvi.data import synthetic_iid
 from scvi.model import MULTIVI
+from scvi.module import MULTIVAE
 from scvi.utils import attrdict
 
 
@@ -548,3 +550,60 @@ def test_multivi_dispersion(dispersion: str, protein_dispersion: str):
         protein_dispersion=protein_dispersion,
     )
     model.train(1)
+
+
+def test_get_reconstruction_loss_accessibility_handles_empty_regions():
+    """RNA+protein-only MULTIVI configurations pass n_input_regions=0; the accessibility loss
+    over zero features must be zero, not crash."""
+    module = MULTIVAE(n_input_regions=0, n_input_genes=10)
+    x = torch.zeros(4, 0)
+    p = torch.zeros(4, 0)
+    d = torch.zeros(4, 0)
+
+    loss = module.get_reconstruction_loss_accessibility(x, p, d)
+
+    assert loss.shape == (4,)
+    assert torch.equal(loss, torch.zeros(4))
+
+
+def test_get_reconstruction_loss_accessibility_nonempty_regions_unaffected():
+    torch.manual_seed(0)
+    module = MULTIVAE(n_input_regions=5, n_input_genes=10)
+    x = torch.randint(0, 2, (4, 5)).float()
+    p = torch.rand(4, 5)
+    d = torch.rand(4, 5)
+
+    loss = module.get_reconstruction_loss_accessibility(x, p, d)
+
+    reg_factor = torch.sigmoid(module.region_factors)
+    expected = torch.nn.BCELoss(reduction="none")(p * d * reg_factor, (x > 0).float()).sum(dim=-1)
+    assert torch.equal(loss, expected)
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")
+def test_get_reconstruction_loss_accessibility_empty_regions_on_mps():
+    module = MULTIVAE(n_input_regions=0, n_input_genes=10).to("mps")
+    x = torch.zeros(4, 0, device="mps")
+    p = torch.zeros(4, 0, device="mps")
+    d = torch.zeros(4, 0, device="mps")
+
+    loss = module.get_reconstruction_loss_accessibility(x, p, d)
+
+    assert loss.device.type == "mps"
+    assert loss.shape == (4,)
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")
+def test_multivi_rna_protein_only_trains_on_mps():
+    """The n_input_regions=0 (no ATAC) configuration used to crash accelerator='mps' training
+    via an empty-tensor BCELoss call."""
+    mdata = synthetic_iid(return_mudata=True)
+    del mdata.mod["accessibility"]
+    mdata.update()
+    MULTIVI.setup_mudata(
+        mdata,
+        batch_key="batch",
+        modalities={"rna_layer": "rna", "protein_layer": "protein_expression"},
+    )
+    model = MULTIVI(mdata, n_latent=5)
+    model.train(max_epochs=1, accelerator="mps")

--- a/tests/model/test_totalvi.py
+++ b/tests/model/test_totalvi.py
@@ -7,6 +7,7 @@ import torch
 from anndata import AnnData
 from mudata import MuData
 
+import scvi.model._totalvi as totalvi_module
 from scvi import REGISTRY_KEYS
 from scvi.data import pbmcs_10x_cite_seq, synthetic_iid
 from scvi.model import TOTALVI
@@ -792,3 +793,39 @@ def test_totalvi_dispersion(gene_dispersion: str, protein_dispersion: str):
         protein_dispersion=protein_dispersion,
     )
     model.train(1)
+
+
+def test_get_denoised_samples_gamma_cpu_detour_forced(monkeypatch):
+    """Forces the CPU detour the way a torch without an MPS '_standard_gamma' kernel would."""
+    monkeypatch.setattr(totalvi_module, "_needs_cpu_detour", lambda on_mps, op: True)
+
+    adata = synthetic_iid()
+    TOTALVI.setup_anndata(
+        adata,
+        batch_key="batch",
+        protein_expression_obsm_key="protein_expression",
+        protein_names_uns_key="protein_names",
+    )
+    model = TOTALVI(adata, n_latent=5)
+    model.train(1, train_size=0.5)
+
+    samples = model._get_denoised_samples(n_samples=2)
+    n_proteins = adata.obsm["protein_expression"].shape[1]
+    assert samples.shape == (adata.n_obs, adata.n_vars + n_proteins, 2)
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")
+def test_get_denoised_samples_on_mps():
+    adata = synthetic_iid()
+    TOTALVI.setup_anndata(
+        adata,
+        batch_key="batch",
+        protein_expression_obsm_key="protein_expression",
+        protein_names_uns_key="protein_names",
+    )
+    model = TOTALVI(adata, n_latent=5)
+    model.train(1, train_size=0.5, accelerator="mps")
+
+    samples = model._get_denoised_samples(n_samples=2)
+    n_proteins = adata.obsm["protein_expression"].shape[1]
+    assert samples.shape == (adata.n_obs, adata.n_vars + n_proteins, 2)

--- a/tests/model/test_utils.py
+++ b/tests/model/test_utils.py
@@ -5,10 +5,10 @@ from scvi.model._utils import parse_device_args
 
 
 @pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")
-def test_auto_accelerator_resolves_to_mps_when_available():
-    with pytest.warns(UserWarning, match="`accelerator` has been set to `mps`"):
+def test_auto_accelerator_falls_back_to_cpu_when_mps_available():
+    with pytest.warns(UserWarning, match="automatically set to `cpu`"):
         _, _, device = parse_device_args(accelerator="auto", devices="auto", return_device="torch")
-    assert device.type == "mps"
+    assert device.type == "cpu"
 
 
 @pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")

--- a/tests/model/test_utils.py
+++ b/tests/model/test_utils.py
@@ -7,16 +7,12 @@ from scvi.model._utils import parse_device_args
 @pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")
 def test_auto_accelerator_resolves_to_mps_when_available():
     with pytest.warns(UserWarning, match="`accelerator` has been set to `mps`"):
-        _, _, device = parse_device_args(
-            accelerator="auto", devices="auto", return_device="torch"
-        )
+        _, _, device = parse_device_args(accelerator="auto", devices="auto", return_device="torch")
     assert device.type == "mps"
 
 
 @pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")
 def test_explicit_mps_accelerator_warns_about_backend_caveats():
     with pytest.warns(UserWarning, match="Results will not be bit-identical"):
-        _, _, device = parse_device_args(
-            accelerator="mps", devices="auto", return_device="torch"
-        )
+        _, _, device = parse_device_args(accelerator="mps", devices="auto", return_device="torch")
     assert device.type == "mps"

--- a/tests/model/test_utils.py
+++ b/tests/model/test_utils.py
@@ -1,0 +1,22 @@
+import pytest
+import torch
+
+from scvi.model._utils import parse_device_args
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")
+def test_auto_accelerator_resolves_to_mps_when_available():
+    with pytest.warns(UserWarning, match="`accelerator` has been set to `mps`"):
+        _, _, device = parse_device_args(
+            accelerator="auto", devices="auto", return_device="torch"
+        )
+    assert device.type == "mps"
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")
+def test_explicit_mps_accelerator_warns_about_backend_caveats():
+    with pytest.warns(UserWarning, match="Results will not be bit-identical"):
+        _, _, device = parse_device_args(
+            accelerator="mps", devices="auto", return_device="torch"
+        )
+    assert device.type == "mps"

--- a/tests/model/test_utils.py
+++ b/tests/model/test_utils.py
@@ -5,7 +5,10 @@ from scvi.model._utils import parse_device_args
 
 
 @pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")
-def test_auto_accelerator_falls_back_to_cpu_when_mps_available():
+def test_auto_accelerator_falls_back_to_cpu_when_mps_available(monkeypatch):
+    # Regardless of whether this suite is itself running under SCVI_ALLOW_MPS_AUTO (e.g. under
+    # test_mps.yaml), this test is specifically about the default (override-unset) behavior.
+    monkeypatch.delenv("SCVI_ALLOW_MPS_AUTO", raising=False)
     with pytest.warns(UserWarning, match="automatically set to `cpu`"):
         _, _, device = parse_device_args(accelerator="auto", devices="auto", return_device="torch")
     assert device.type == "cpu"
@@ -15,4 +18,16 @@ def test_auto_accelerator_falls_back_to_cpu_when_mps_available():
 def test_explicit_mps_accelerator_warns_about_backend_caveats():
     with pytest.warns(UserWarning, match="Results will not be bit-identical"):
         _, _, device = parse_device_args(accelerator="mps", devices="auto", return_device="torch")
+    assert device.type == "mps"
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")
+def test_auto_accelerator_resolves_to_mps_when_env_override_set(monkeypatch):
+    """SCVI_ALLOW_MPS_AUTO opts a whole test run into `auto` behaving like it does on CUDA
+    machines, without changing the library's real default. Used by test_mps.yaml so the
+    dedicated MPS CI job actually exercises `mps` for calls that don't pass an accelerator,
+    instead of only the handful of tests that consume the --accelerator/--devices fixtures."""
+    monkeypatch.setenv("SCVI_ALLOW_MPS_AUTO", "1")
+    with pytest.warns(UserWarning, match="Results will not be bit-identical"):
+        _, _, device = parse_device_args(accelerator="auto", devices="auto", return_device="torch")
     assert device.type == "mps"

--- a/tests/module/test_vae.py
+++ b/tests/module/test_vae.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 
+import scvi.module._vae as vae_module
 from scvi import REGISTRY_KEYS
 from scvi.module import VAE
 
@@ -31,3 +32,40 @@ def test_sample(
         assert x_hat.shape == (batch_size, n_input, n_samples)
     else:
         assert x_hat.shape == (batch_size, n_input)
+
+
+def test_sample_poisson_cpu_detour_forced(monkeypatch):
+    """Forces the CPU detour the way a torch without the 'aten::poisson' MPS kernel would."""
+    monkeypatch.setattr(vae_module, "_needs_cpu_detour", lambda on_mps, op: True)
+
+    n_input, batch_size = 100, 10
+    vae = VAE(n_input=n_input, gene_likelihood="poisson")
+    x = torch.randint(0, 100, (batch_size, n_input), dtype=torch.float32)
+    batch = torch.zeros(batch_size, dtype=torch.long)
+    labels = torch.zeros(batch_size, dtype=torch.long)
+    tensors = {
+        REGISTRY_KEYS.X_KEY: x,
+        REGISTRY_KEYS.BATCH_KEY: batch,
+        REGISTRY_KEYS.LABELS_KEY: labels,
+    }
+
+    x_hat = vae.sample(tensors, n_samples=1)
+    assert x_hat.shape == (batch_size, n_input)
+    assert (x_hat >= 0).all()
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")
+def test_sample_poisson_stays_on_mps():
+    n_input, batch_size = 100, 10
+    vae = VAE(n_input=n_input, gene_likelihood="poisson").to("mps")
+    x = torch.randint(0, 100, (batch_size, n_input), dtype=torch.float32, device="mps")
+    batch = torch.zeros(batch_size, dtype=torch.long, device="mps")
+    labels = torch.zeros(batch_size, dtype=torch.long, device="mps")
+    tensors = {
+        REGISTRY_KEYS.X_KEY: x,
+        REGISTRY_KEYS.BATCH_KEY: batch,
+        REGISTRY_KEYS.LABELS_KEY: labels,
+    }
+
+    x_hat = vae.sample(tensors, n_samples=1)
+    assert x_hat.shape == (batch_size, n_input)

--- a/tests/nn/test_fclayers.py
+++ b/tests/nn/test_fclayers.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import pytest
 import torch
 from torch import nn
 
+import scvi.nn._base_components as base_components_module
 from scvi.nn import FCLayers
 
 # ---------------------------------------------------------------------------
@@ -63,6 +65,51 @@ def test_apply_batch_norm_2d_passthrough():
 
     assert out.shape == (8, n_features)
     assert torch.allclose(out, bn(x))
+
+
+def test_batchnorm_slice_probe_returns_bool():
+    """The probe is cached and answers with a bool on any machine, mps or not."""
+    result = base_components_module._mps_supports_batchnorm_slice()
+    assert isinstance(result, bool)
+    if not torch.backends.mps.is_available():
+        assert result is False
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")
+def test_apply_batch_norm_3d_on_mps_matches_manual_slicing():
+    n_features = 16
+    bn = nn.BatchNorm1d(n_features).to("mps")
+    bn.eval()
+
+    fc = FCLayers(n_in=n_features, n_out=n_features, use_batch_norm=True, dropout_rate=0.0).to(
+        "mps"
+    )
+    x = torch.randn(4, 8, n_features, device="mps")
+    out = fc._apply_batch_norm(bn, x)
+
+    expected = torch.cat([bn(x[i]).unsqueeze(0) for i in range(x.size(0))], dim=0)
+    assert out.shape == (4, 8, n_features)
+    assert torch.allclose(out, expected)
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")
+def test_apply_batch_norm_3d_clones_when_mps_lacks_slicing_support(monkeypatch):
+    """Forces the legacy clone-based fallback and checks it still gives the right answer."""
+    monkeypatch.setattr(base_components_module, "_mps_supports_batchnorm_slice", lambda: False)
+
+    n_features = 16
+    bn = nn.BatchNorm1d(n_features).to("mps")
+    bn.eval()
+
+    fc = FCLayers(n_in=n_features, n_out=n_features, use_batch_norm=True, dropout_rate=0.0).to(
+        "mps"
+    )
+    x = torch.randn(4, 8, n_features, device="mps")
+    out = fc._apply_batch_norm(bn, x)
+
+    expected = torch.cat([bn(x[i].clone()).unsqueeze(0) for i in range(x.size(0))], dim=0)
+    assert out.shape == (4, 8, n_features)
+    assert torch.allclose(out, expected)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/train/test_trainingplans.py
+++ b/tests/train/test_trainingplans.py
@@ -1,11 +1,16 @@
 import pytest
+import torch
 
 import scvi
 from scvi.data import synthetic_iid
 from scvi.model import SCVI
 from scvi.train import TrainingPlan
 from scvi.train._constants import METRIC_KEYS
-from scvi.train._trainingplans import _compute_kl_weight
+from scvi.train._trainingplans import (
+    _compilation_fell_back,
+    _compute_kl_weight,
+    _dynamo_frame_counts,
+)
 
 
 @pytest.mark.parametrize(
@@ -87,3 +92,118 @@ def test_semisupervisedtrainingplan_metrics():
             METRIC_KEYS.CLASSIFICATION_LOSS_KEY,
         ]:
             assert f"{mode}_{metric}" in model.history_
+
+
+@pytest.mark.parametrize(
+    ("before", "after", "expected"),
+    [
+        ((0, 0), (0, 0), False),  # dynamo never ran
+        ((0, 0), (3, 3), False),  # everything compiled
+        ((0, 0), (3, 1), False),  # partial success is still a compiled model
+        ((0, 0), (3, 0), True),  # every frame fell back to eager
+        ((5, 4), (8, 4), True),  # counters are process-wide, so compare deltas
+        ((5, 4), (8, 5), False),
+    ],
+)
+def test_compilation_fell_back_only_when_every_attempted_frame_failed(before, after, expected):
+    assert _compilation_fell_back(before, after) is expected
+
+
+def test_compile_restores_the_global_dynamo_error_suppression():
+    # `compile=True` turns dynamo's error suppression on so that a failed compilation
+    # degrades to eager instead of raising. That is process-wide state, so it has to be
+    # put back once training is over rather than leaking into unrelated later code.
+    import torch
+
+    previous = torch._dynamo.config.suppress_errors
+    torch._dynamo.config.suppress_errors = False
+    try:
+        adata = synthetic_iid(batch_size=32, n_genes=16)
+        SCVI.setup_anndata(adata)
+        model = SCVI(adata, n_latent=2, n_hidden=8, n_layers=1)
+        model.train(
+            max_epochs=1,
+            accelerator="cpu",
+            devices=1,
+            enable_progress_bar=False,
+            plan_kwargs={"compile": True},
+        )
+        assert torch._dynamo.config.suppress_errors is False
+    finally:
+        torch._dynamo.config.suppress_errors = previous
+
+
+def test_compile_warns_when_every_frame_fell_back_to_eager(monkeypatch):
+    # A silent fallback is the dangerous case: the user asked for a compiled model,
+    # got an eager one, and nothing said so.
+    from scvi.train import _trainingplans
+
+    adata = synthetic_iid(batch_size=32, n_genes=16)
+    SCVI.setup_anndata(adata)
+    model = SCVI(adata, n_latent=2, n_hidden=8, n_layers=1)
+    plan = TrainingPlan(model.module, compile=True)
+
+    monkeypatch.setattr(_trainingplans, "_dynamo_frame_counts", lambda: (99, 0))
+    plan._compile_frames_before = (0, 0)
+    with pytest.warns(UserWarning, match="fell back to eager"):
+        plan.on_train_end()
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS device")
+def test_compile_actually_compiles_frames_on_mps():
+    # The point of the warning above is that a silent eager fallback is indistinguishable
+    # from a compiled run without checking. Assert the positive case on mps.
+    adata = synthetic_iid(batch_size=32, n_genes=16)
+    SCVI.setup_anndata(adata)
+    model = SCVI(adata, n_latent=2, n_hidden=8, n_layers=1)
+    before = _dynamo_frame_counts()
+    model.train(
+        max_epochs=1,
+        accelerator="mps",
+        devices=1,
+        enable_progress_bar=False,
+        plan_kwargs={"compile": True},
+    )
+    after = _dynamo_frame_counts()
+    assert after[1] > before[1]
+    assert not _compilation_fell_back(before, after)
+
+
+def _make_plan(**kwargs):
+    adata = synthetic_iid(batch_size=32, n_genes=16)
+    SCVI.setup_anndata(adata)
+    model = SCVI(adata, n_latent=2, n_hidden=8, n_layers=1)
+    return TrainingPlan(model.module, **kwargs)
+
+
+def test_fused_optimizer_is_used_when_the_backend_supports_it():
+    plan = _make_plan()
+    optimizer = plan.get_optimizer_creator()(
+        p for p in plan.module.parameters() if p.requires_grad
+    )
+    assert optimizer.defaults.get("fused") is True
+
+
+def test_fused_optimizer_can_be_turned_off():
+    plan = _make_plan(fused_optimizer=False)
+    optimizer = plan.get_optimizer_creator()(
+        p for p in plan.module.parameters() if p.requires_grad
+    )
+    assert not optimizer.defaults.get("fused")
+
+
+def test_fused_optimizer_falls_back_when_the_backend_rejects_it():
+    # torch raises at construction time when fused is not available for these params,
+    # and the message differs across versions and devices, so the fallback is driven by
+    # the exception rather than by a device allowlist of our own.
+    class RejectsFused(torch.optim.Adam):
+        def __init__(self, params, **kwargs):
+            if kwargs.pop("fused", False):
+                raise RuntimeError("fused is not supported on this device")
+            super().__init__(params, **kwargs)
+
+    plan = _make_plan()
+    params = [p for p in plan.module.parameters() if p.requires_grad]
+    optimizer = plan._optimizer_creator_fn(RejectsFused)(params)
+    assert not optimizer.defaults.get("fused")
+    assert isinstance(optimizer, RejectsFused)


### PR DESCRIPTION
## What this changes

`src/scvi/distributions/_negative_binomial.py` sends Gamma and Poisson to the CPU
whenever the distribution's parameters are on `mps`. That is hardcoded, and the code
says why:

```python
Gamma(concentration=concentration.to("cpu"), rate=rate.to("cpu"))
if on_mps  # TODO: NEED TORCH MPS FIX for 'aten::_standard_gamma'
```
```python
PoissonTorch(l_train).sample().to("mps")
if self.on_mps  # TODO: NEED TORCH MPS FIX for 'aten::poisson'
```

Both TODOs are now stale. `aten::_standard_gamma` gained an MPS kernel in torch 2.12
(pytorch/pytorch#179228) and `aten::poisson` in 2.14 (pytorch/pytorch#173319). On a
current torch, every `NegativeBinomial.sample()` pays two device transfers to reach a
CPU kernel that is no longer the only option.

This makes the detour conditional on what the running build actually provides. Where the
kernel is missing, the behaviour is exactly what it is today.

## Why probe instead of comparing `torch.__version__`

`torch` is an unpinned dependency here (`pyproject.toml`), so this code runs against
whatever the user installed, including builds whose version string a comparison reads
wrongly. A source build reports `2.14.0a0+gitXXXXXXX`, which sorts *below* `2.14.0` and
would disable a kernel that is present; nightlies have the mirror problem. So
`_mps_supports(op)` calls the op once on a one-element `mps` tensor, caches the answer,
and treats `NotImplementedError` as "not available". It is only ever reached from a
distribution whose parameters are already on `mps`.

The two kernels are probed separately, because torch 2.12 and 2.13 have Gamma but not
Poisson, and that intermediate case is worth getting right rather than rounding down.

## Measurements

`NegativeBinomial(mu, theta)` with `mu`, `theta` of shape (4000, 2000), `sample()`, mean
of 5 runs on an M-series Mac:

| torch | before | after |
|---|---|---|
| 2.14.0 | 0.399 s | **0.004 s** |
| 2.13.0 | 0.399 s | 0.283 s |
| cpu reference | 0.397 s | |

Before the change, the `mps` figure equalling the `cpu` figure is the tell: all the work
was already on the CPU. 2.13 improves only partway because it has the Gamma kernel and
not the Poisson one, which is what the split probe is for.

Sample mean and standard deviation match the analytic values to the tolerance the
existing test uses.

## Also fixed

`NegativeBinomialMixture.sample()` returned a **CPU** tensor for parameters on `mps`,
unlike `NegativeBinomial.sample()` directly above it, which moved its result back. Both
now return on the device the parameters came from.

## Deliberately left alone

`torch_lgamma_mps` and the `.contiguous()` calls in `__init__`. They work around a
different problem, a broadcasting issue rather than a missing kernel, and separating
them deserves its own check rather than riding along here.

## Testing

```
python -m pytest tests/distributions/ -q          # 13 passed
ruff check src/scvi/distributions/_negative_binomial.py tests/distributions/test_negative_binomial.py
ruff format --check src/scvi/distributions/_negative_binomial.py tests/distributions/test_negative_binomial.py
```

Run against three torch builds, since the point of the change is that behaviour depends
on the build: 2.14.0 (both kernels), 2.13.0 (Gamma only), and with `_mps_supports` forced
to return `False`, which reproduces the current behaviour exactly and stands in for a
pre-2.12 build.

Two tests are added. They skip without an MPS device, so they will not run in CI as it
stands; `test_gamma_stays_on_mps_when_the_kernel_exists` asserts against the same probe
rather than against a version, so it stays correct on any torch.

---

*Written with the help of an AI assistant; the diff and the measurements above were
reviewed by hand.*
