### PR TITLE
fix(model): BaseModelClass.view_registry() raises AttributeError on '_registry'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ to [Semantic Versioning]. The full commit history is available in the [commit lo
     contains missing values, {pr}`3962`.
 - Fix {func}`~scvi.data.purified_pbmc_dataset` returning a duplicated `cd4_t_helper` batch {pr}`3985`.
 - Fix builtin datasets downloads failing outright on a single transient, {pr}`3987`.
+- Fix {class}`scvi.model.base.BaseModelClass`'s `view_registry` and `update_setup_method_args`
+    raising `AttributeError: '...' object has no attribute '_registry'`: these methods were
+    adapted from {class}`~scvi.data.AnnDataManager` but kept reaching for the manager's
+    `_registry`/`fields` attributes instead of the model's `registry_`/`adata_manager`, {pr}`3991`.
 
 #### Changed
 

--- a/src/scvi/model/base/_base_model.py
+++ b/src/scvi/model/base/_base_model.py
@@ -1587,13 +1587,7 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
         adata_manager.view_registry(hide_state_registries=hide_state_registries)
 
     def view_setup_method_args(self) -> None:
-        """Prints setup kwargs used to produce a given registry.
-
-        Parameters
-        ----------
-        registry
-            Registry produced by an AnnDataManager.
-        """
+        """Prints setup kwargs used to produce this model's registry."""
         model_name = self.registry_[_MODEL_NAME_KEY]
         setup_args = self.registry_[_SETUP_ARGS_KEY]
         if model_name is not None and setup_args is not None:
@@ -1612,19 +1606,19 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
         version = self.registry_[_SCVI_VERSION_KEY]
         rich.print(f"Anndata setup with scvi-tools version {version}.")
         rich.print()
-        self.view_setup_method_args(self._registry)
+        self.view_setup_method_args()
 
         in_colab = "google.colab" in sys.modules
         force_jupyter = None if not in_colab else True
         console = rich.console.Console(force_jupyter=force_jupyter)
 
-        ss = AnnDataManager._get_summary_stats_from_registry(self._registry)
-        dr = self._get_data_registry_from_registry(self._registry)
+        ss = AnnDataManager._get_summary_stats_from_registry(self.registry_)
+        dr = AnnDataManager._get_data_registry_from_registry(self.registry_)
         console.print(self._view_summary_stats(ss))
         console.print(self._view_data_registry(dr))
 
-        if not hide_state_registries:
-            for field in self.fields:
+        if not hide_state_registries and self.adata_manager is not None:
+            for field in self.adata_manager.fields:
                 state_registry = self.get_state_registry(field.registry_key)
                 t = field.view_state_registry(state_registry)
                 if t is not None:
@@ -1727,7 +1721,7 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
             of the setup method that will be used to update the existing values
             in the registry of this instance.
         """
-        self._registry[_SETUP_ARGS_KEY].update(setup_method_args)
+        self.registry_[_SETUP_ARGS_KEY].update(setup_method_args)
 
     def get_normalized_expression(self, *args, **kwargs):
         """Not implemented for this model class.

--- a/tests/model/test_scvi.py
+++ b/tests/model/test_scvi.py
@@ -221,6 +221,9 @@ def test_scvi(gene_likelihood: str, n_latent: int):
     # test view_anndata_setup
     model.view_anndata_setup()
     model.view_anndata_setup(hide_state_registries=True)
+    # test view_registry
+    model.view_registry()
+    model.view_registry(hide_state_registries=True)
 
     assert model.is_trained is True
     z = model.get_latent_representation()


### PR DESCRIPTION
## Problem

`BaseModelClass.view_registry()` cannot run — it raises before printing anything past the version line:

```
AttributeError: 'SCVI' object has no attribute '_registry'
```

`view_registry()`, `view_setup_method_args()` and `update_setup_method_args()` on `BaseModelClass` are adapted copies of the `AnnDataManager` methods of the same names, but the adaptation was only partial. `AnnDataManager` keeps the registry in `self._registry` and its fields in `self.fields`; `BaseModelClass.__init__` stores the registry as `self.registry_` (`_base_model.py:154`/`160`) and has no `fields` attribute at all. Four call sites were left pointing at the manager's names:

| line | current | problem |
|---|---|---|
| `_base_model.py:1615` | `self.view_setup_method_args(self._registry)` | `self._registry` doesn't exist — **and** `view_setup_method_args(self)` takes no argument any more (its docstring still documents the removed `registry` parameter) |
| `_base_model.py:1621` | `AnnDataManager._get_summary_stats_from_registry(self._registry)` | `self._registry` doesn't exist |
| `_base_model.py:1622` | `self._get_data_registry_from_registry(self._registry)` | neither the attribute nor the method exists on the model |
| `_base_model.py:1627` | `for field in self.fields:` | `fields` is an `AnnDataManager` attribute |
| `_base_model.py:1730` | `self._registry[_SETUP_ARGS_KEY].update(...)` | same slip in `update_setup_method_args()` |

Every other method in the same block already uses `self.registry_` correctly — `view_registry()` itself does on its first line (`version = self.registry_[_SCVI_VERSION_KEY]`), as do `get_state_registry()` and `get_setup_arg()`. `AnnDataManager.view_registry()` is covered by `tests/data/test_anndata.py::test_view_registry`, but nothing exercised the model-level copy, so this went unnoticed.

## Fix

- `self._registry` → `self.registry_` (4 places).
- `self.view_setup_method_args(self._registry)` → `self.view_setup_method_args()`, and drop the stale `registry` parameter from that method's docstring.
- `self._get_data_registry_from_registry(...)` → `AnnDataManager._get_data_registry_from_registry(...)`, matching how the summary-stats helper is already called on the line above.
- `self.fields` → `self.adata_manager.fields`, guarded by `self.adata_manager is not None`: state registries are rendered by the `AnnDataField` objects themselves, which only exist when a manager is attached. A registry-only model (built via `registry=`, e.g. after `load_registry()`) still prints the version, setup args, summary stats and data registry, and simply skips the per-field state registries instead of crashing.

Added `model.view_registry()` / `model.view_registry(hide_state_registries=True)` to `tests/model/test_scvi.py`, right next to the existing `model.view_anndata_setup()` smoke checks.

## Verification

No scvi-tools install needed: `view_registry`, `view_setup_method_args`, `get_state_registry`, `_view_summary_stats` and `_view_data_registry` were sliced verbatim out of `_base_model.py` by AST line range and attached to a stand-in class carrying exactly what `BaseModelClass.__init__` sets (`registry_`, `_adata_manager`), together with the two `AnnDataManager` staticmethods they reach for, then run against a synthetic registry.

```
--- UNPATCHED (upstream main) ---
Anndata setup with scvi-tools version 1.4.0.
  >> view_registry(hide_state_registries=True)  -> AttributeError: no attribute '_registry'
  >> view_registry(hide_state_registries=False) -> AttributeError: no attribute '_registry'

--- PATCHED ---
Anndata setup with scvi-tools version 1.4.0.

Setup via `SCVI.setup_anndata` with arguments:
{'layer': None, 'batch_key': 'batch'}

     Summary Statistics
┌──────────────────┬───────┐
│ Summary Stat Key │ Value │
├──────────────────┼───────┤
│      n_vars      │   2   │
│     n_batch      │   2   │
└──────────────────┴───────┘
               Data Registry
┌──────────────┬──────────────────────────┐
│ Registry Key │   scvi-tools Location    │
├──────────────┼──────────────────────────┤
│      X       │         adata.X          │
│    batch     │ adata.obs['_scvi_batch'] │
└──────────────┴──────────────────────────┘
  >> view_registry(hide_state_registries=True)  -> OK
  >> view_registry(hide_state_registries=False) -> OK
```

`ruff==0.16.5` (the pinned pre-commit rev) `format --check` reports both files already formatted; `ruff check` output is unchanged relative to the pristine upstream files.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
