### PR TITLE
fix(totalvae): validate library_log_vars instead of library_log_means twice

### DIFF
--- a/src/scvi/module/_totalvae.py
+++ b/src/scvi/module/_totalvae.py
@@ -170,7 +170,7 @@ class TOTALVAE(BaseMinifiedModeModuleClass):
         self.extra_payload_autotune = extra_payload_autotune
         self.use_observed_lib_size = use_size_factor_key or use_observed_lib_size
         if not self.use_observed_lib_size:
-            if library_log_means is None or library_log_means is None:
+            if library_log_means is None or library_log_vars is None:
                 raise ValueError(
                     "If not using observed_lib_size, "
                     "must provide library_log_means and library_log_vars."


### PR DESCRIPTION
### What

The `TOTALVAE` argument check ORs `library_log_means is None` with itself:

```python
if not self.use_observed_lib_size:
    if library_log_means is None or library_log_means is None:   # <- library_log_vars
        raise ValueError(
            "If not using observed_lib_size, "
            "must provide library_log_means and library_log_vars."
        )

    self.register_buffer("library_log_means", torch.from_numpy(library_log_means).float())
    self.register_buffer("library_log_vars", torch.from_numpy(library_log_vars).float())
```

The error message names both parameters, and the two lines right below dereference both.

### Why it matters

Constructing `TOTALVAE(..., use_observed_lib_size=False, library_log_means=arr, library_log_vars=None)` passes the guard, then fails four lines later inside `register_buffer` with

```
TypeError: expected np.ndarray (got NoneType)
```

instead of the intended, actionable `ValueError`. Only the mirror case (`library_log_means=None`) is currently caught.

### Prior art in this repo

The same guard is spelled correctly elsewhere, with the identical error message:

* `src/scvi/module/_vae.py:196` — `if library_log_means is None or library_log_vars is None:`
* `src/scvi/external/contrastivevi/_module.py:81` — same

`_totalvae.py` is the only copy that checks one parameter twice.

### Not affected

* `use_observed_lib_size=True` — block is not entered.
* Both provided — guard was false, stays false.
* `library_log_means=None` — guard was already true, stays true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
